### PR TITLE
Fix French ordinal suffix parsing

### DIFF
--- a/ovos_number_parser/numbers_fr.py
+++ b/ovos_number_parser/numbers_fr.py
@@ -47,7 +47,7 @@ _NUMBERS_FR = {
     "milliard": 1000000000,
     "milliards": 1000000000}
 
-_ORDINAL_ENDINGS_FR = ("er", "re", "ère", "nd", "nde" "ième", "ème", "e")
+_ORDINAL_ENDINGS_FR = ("er", "re", "ère", "nd", "nde", "ième", "ème", "e")
 
 _NUM_STRING_FR = {
     0: 'zéro',

--- a/tests/test_number_parser_fr.py
+++ b/tests/test_number_parser_fr.py
@@ -1,0 +1,17 @@
+import unittest
+
+from ovos_number_parser.numbers_fr import _get_ordinal_fr, extract_number_fr
+
+
+class TestNumberParserFr(unittest.TestCase):
+    def test_extract_numeric_ordinals(self):
+        self.assertEqual(_get_ordinal_fr("2nde"), 2)
+        self.assertEqual(_get_ordinal_fr("5ième"), 5)
+        self.assertEqual(_get_ordinal_fr("21ème"), 21)
+
+    def test_extract_number_from_ordinal_phrase(self):
+        self.assertEqual(extract_number_fr("la 2nde place", ordinals=True), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- fix the French ordinal suffix tuple so  and  are handled as separate endings
- add a focused regression test for numeric French ordinals

## Testing
- 
-  *(fails in this environment: missing  dependency)*