### PR TITLE
fix: use is_fractional_nl for Dutch in is_fractional

### DIFF
--- a/ovos_number_parser/__init__.py
+++ b/ovos_number_parser/__init__.py
@@ -329,7 +329,7 @@ def is_fractional(input_str: str, lang: str, short_scale: bool = True) -> Union[
     if lang.startswith("it"):
         return is_fractional_it(input_str, short_scale)
     if lang.startswith("nl"):
-        return is_fractional_pl(input_str, short_scale)
+        return is_fractional_nl(input_str, short_scale)
     if lang.startswith("pl"):
         return is_fractional_pl(input_str, short_scale)
     if lang.startswith("pt"):


### PR DESCRIPTION
Closes #48.

The `nl` (Dutch) branch of `is_fractional` returned `is_fractional_pl` (Polish) instead of the already-imported `is_fractional_nl`, so Dutch fraction parsing ran Polish logic.

```diff
     if lang.startswith("nl"):
-        return is_fractional_pl(input_str, short_scale)
+        return is_fractional_nl(input_str, short_scale)
```

Found during a source-validation pass of the OVOS Technical Manual.