### PR TITLE
ci: install setuptools for the release workflow

### DIFF
--- a/.github/workflows/release_workflow.yml
+++ b/.github/workflows/release_workflow.yml
@@ -49,7 +49,7 @@ jobs:
           python-version: "3.14"
       - name: Install Build Tools
         run: |
-          python -m pip install build wheel
+          python -m pip install build wheel setuptools
       - name: version
         run: echo "::set-output name=version::$(python setup.py --version)"
         id: version
@@ -80,6 +80,7 @@ jobs:
       - name: Get version from setup.py
         id: get_version
         run: |
+          python -m pip install setuptools
           VERSION=$(python setup.py --version)
           echo "VERSION=$VERSION" >> $GITHUB_ENV
 


### PR DESCRIPTION
The release workflow's publish and propose jobs run `setup.py` on Python 3.14, which no longer ships setuptools — both jobs failed with `ModuleNotFoundError: No module named 'setuptools'` and no alpha was published. Install it explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)