### PR TITLE
fix: language dispatch and return-contract bugs

### DIFF
--- a/ovos_number_parser/__init__.py
+++ b/ovos_number_parser/__init__.py
@@ -361,7 +361,7 @@ def is_fractional(input_str: str, lang: str,
     if lang.startswith("it"):
         return is_fractional_it(input_str, short_scale)
     if lang.startswith("nl"):
-        return is_fractional_pl(input_str, short_scale)
+        return is_fractional_nl(input_str, short_scale)
     if lang.startswith("pl"):
         return is_fractional_pl(input_str, short_scale)
     if lang.startswith("pt"):
@@ -400,7 +400,10 @@ def is_ordinal(input_str: str, lang: str) -> Union[bool, float]:
     if lang.startswith("en"):
         return is_ordinal_en(input_str)
     if lang.startswith("de"):
-        return is_ordinal_de(input_str)
+        val = is_ordinal_de(input_str)
+        if isinstance(val, str) and val.endswith("."):
+            return int(val[:-1])
+        return val
     if lang.startswith("da"):
         return is_ordinal_da(input_str)
     raise NotImplementedError(f"Unsupported language: '{lang}'")

--- a/ovos_number_parser/numbers_da.py
+++ b/ovos_number_parser/numbers_da.py
@@ -873,11 +873,9 @@ def extract_number_da(text, short_scale=False, ordinals=False):
                                         and x.value.endswith("."),
                               numbers))
 
-    number = numbers[0].value if numbers else None
-
-    if number:
-        number = float(number)
-        if number.is_integer():
-            number = int(number)
-
+    if not numbers:
+        return False
+    number = float(numbers[0].value)
+    if number.is_integer():
+        number = int(number)
     return number

--- a/ovos_number_parser/numbers_de.py
+++ b/ovos_number_parser/numbers_de.py
@@ -437,6 +437,7 @@ def numbers_to_digits_de(text, short_scale=False,
         str
         The original text, with numbers subbed in where appropriate.
     """
+    text = _expand_compound_numbers_de(text)
     tokens = tokenize(text)
     numbers_to_replace = \
         _extract_numbers_with_text_de(tokens, short_scale, ordinals, fractions)

--- a/ovos_number_parser/numbers_es.py
+++ b/ovos_number_parser/numbers_es.py
@@ -638,9 +638,8 @@ def nice_number_es(number, speech=True, denominators=range(1, 21)):
         else:
             # else return "2 y 3 cuarto", for example
             strNumber = '{} y {} {}'.format(whole, num, den_str)
-        if num > 1 and den != 3:
-            # if the numerator is greater than 1 and the denominator
-            # is not 3 ("tercio"), add an s for plural
+        if num > 1:
+            # pluralize the denominator ("dos tercios", "tres cuartos")
             strNumber += 's'
 
     return strNumber

--- a/tests/test_dispatch_fixes.py
+++ b/tests/test_dispatch_fixes.py
@@ -1,0 +1,37 @@
+"""Regression tests for language dispatch and return-contract fixes."""
+import unittest
+
+from ovos_number_parser import extract_number, is_fractional, is_ordinal, numbers_to_digits
+from ovos_number_parser.numbers_es import nice_number_es
+
+
+class TestDispatchFixes(unittest.TestCase):
+    def test_nl_is_fractional_uses_dutch(self):
+        # "derde" is Dutch for third; the Polish table does not know it
+        self.assertAlmostEqual(is_fractional("derde", "nl"), 1 / 3)
+        self.assertEqual(is_fractional("kwart", "nl"), 0.25)
+        # Polish words must not leak into Dutch
+        self.assertFalse(is_fractional("trzecie", "nl"))
+
+    def test_da_extract_returns_false_not_none(self):
+        self.assertIs(extract_number("hej med dig", "da"), False)
+
+    def test_de_is_ordinal_returns_value(self):
+        self.assertEqual(is_ordinal("dritte", "de"), 3)
+        self.assertEqual(is_ordinal("einundzwanzigste", "de"), 21)
+        self.assertFalse(is_ordinal("hund", "de"))
+
+    def test_de_numbers_to_digits_compounds(self):
+        self.assertEqual(numbers_to_digits("einundzwanzig katzen", "de"),
+                         "21 katzen")
+        self.assertEqual(
+            numbers_to_digits("zweitausendfünfhundert euro", "de"),
+            "2500 euro")
+
+    def test_es_nice_number_pluralizes_tercios(self):
+        self.assertEqual(nice_number_es(2 / 3), "2 tercios")
+        self.assertEqual(nice_number_es(0.75), "3 cuartos")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Five small bug fixes, each with a regression test in `tests/test_dispatch_fixes.py`:

- **nl**: `is_fractional` dispatched to the Polish implementation, so Dutch fraction words were never recognized
- **da**: `extract_number` returned `None` instead of the documented `False` when no number is found
- **de**: `is_ordinal` returned strings like `"3."` instead of the ordinal value; it now returns `3`
- **de**: `numbers_to_digits` left compound numbers (`einundzwanzig`, `zweitausendfünfhundert`) unconverted; it now expands them first
- **es**: `nice_number` never pluralized `tercios` ("2 tercio"), the denominator now pluralizes whenever the numerator is above one

🤖 Generated with [Claude Code](https://claude.com/claude-code)