### PR TITLE
fix: digit extraction and ordinal values in RomanceNumberExtractor, wire galician helpers

### DIFF
--- a/ovos_number_parser/__init__.py
+++ b/ovos_number_parser/__init__.py
@@ -17,7 +17,8 @@ from ovos_number_parser.numbers_es import numbers_to_digits_es, pronounce_number
 from ovos_number_parser.numbers_eu import pronounce_number_eu, extract_number_eu, is_fractional_eu
 from ovos_number_parser.numbers_fa import pronounce_number_fa, extract_number_fa
 from ovos_number_parser.numbers_fr import (pronounce_number_fr, extract_number_fr, is_fractional_fr)
-from ovos_number_parser.numbers_gl import pronounce_number_gl, extract_number_gl, is_fractional_gl, numbers_to_digits_gl
+from ovos_number_parser.numbers_gl import pronounce_number_gl, extract_number_gl, is_fractional_gl, \
+    numbers_to_digits_gl, pronounce_ordinal_gl, is_ordinal_gl, pronounce_fraction_gl
 from ovos_number_parser.numbers_hu import pronounce_number_hu, pronounce_ordinal_hu
 from ovos_number_parser.numbers_it import (extract_number_it, pronounce_number_it, is_fractional_it)
 from ovos_number_parser.numbers_mwl import MWL
@@ -191,6 +192,8 @@ def pronounce_fraction(fraction_word: str, lang: str, scale: Optional[Scale] = N
         return AST.pronounce_fraction(fraction_word, scale=scale)
     elif lang.startswith("mwl"):
         return MWL.pronounce_fraction(fraction_word, scale=scale)
+    elif lang.startswith("gl"):
+        return pronounce_fraction_gl(fraction_word, scale=scale)
     else:
         raise NotImplementedError(f"unsupported language: {lang}")
 
@@ -236,6 +239,8 @@ def pronounce_ordinal(number: Union[int, float], lang: str,
         return pronounce_ordinal_nl(number)
     if lang.startswith("sv"):
         return pronounce_ordinal_sv(number)
+    if lang.startswith("gl"):
+        return pronounce_ordinal_gl(number, gender=gender, scale=scale)
     # fallback to unicode RBNF
     try:
         engine = RbnfEngine.for_language(lang.split("-")[0])
@@ -353,7 +358,7 @@ def is_fractional(input_str: str, lang: str,
     if lang.startswith("es"):
         return is_fractional_es(input_str, short_scale)
     if lang.startswith("gl"):
-        return is_fractional_gl(input_str, short_scale)
+        return is_fractional_gl(input_str)
     if lang.startswith("eu"):
         return is_fractional_eu(input_str)
     if lang.startswith("fr"):
@@ -406,4 +411,6 @@ def is_ordinal(input_str: str, lang: str) -> Union[bool, float]:
         return val
     if lang.startswith("da"):
         return is_ordinal_da(input_str)
+    if lang.startswith("gl"):
+        return is_ordinal_gl(input_str)
     raise NotImplementedError(f"Unsupported language: '{lang}'")

--- a/ovos_number_parser/util.py
+++ b/ovos_number_parser/util.py
@@ -376,16 +376,19 @@ class RomanceNumberExtractor:
     def __init__(self, vocab: NumberVocabulary):
         self.vocab = vocab
 
-    def is_ordinal(self, input_str: str, scale: Optional[Scale] = None) -> bool:
+    def is_ordinal(self, input_str: str, scale: Optional[Scale] = None) -> Union[int, bool]:
         """
-        Determine if a string is a Portuguese ordinal word.
+        Determine if a string is an ordinal word.
 
         Returns:
-            bool: True if the input string is recognized as a Portuguese ordinal, otherwise False.
+            (int or bool): the value of the ordinal if the input string is
+            recognized as an ordinal, otherwise False.
         """
         scale = scale or self.vocab.DEFAULT_SCALE
         ordinals_map = self.vocab.get_ordinal_strings(scale)
-        return input_str in ordinals_map
+        if input_str in ordinals_map:
+            return ordinals_map[input_str]
+        return False
 
     def is_fractional(self, input_str: str) -> Union[float, bool]:
         """
@@ -428,6 +431,15 @@ class RomanceNumberExtractor:
         # normalize and tokenize
         clean_text = text.lower().replace('-', ' ')
         tokens = [t for t in clean_text.split() if t not in self.vocab.JOIN_WORD]
+
+        # a digit token wins if it appears before any spoken number word
+        for tok in tokens:
+            t = tok.strip(".,!?;:").replace(",", ".")
+            if t and t.lstrip("-").replace(".", "", 1).isdigit():
+                val = float(t)
+                return int(val) if val.is_integer() else val
+            if tok in numbers_map or tok in ordinals_map or tok in scales_map:
+                break
 
         # plural fraction words ("cuartos", "terzos") multiply by the preceding
         # cardinal ("tres cuartos" = 3/4), singular ones add ("dois e meio" = 2.5)

--- a/tests/test_romance_extractor_contracts.py
+++ b/tests/test_romance_extractor_contracts.py
@@ -1,0 +1,49 @@
+"""Contract tests for RomanceNumberExtractor and the Galician wiring."""
+import unittest
+
+from ovos_number_parser import (extract_number, is_fractional, is_ordinal,
+                                pronounce_fraction, pronounce_ordinal)
+
+
+class TestDigitTokens(unittest.TestCase):
+    def test_digits_extract(self):
+        for lang in ("pt", "gl", "mwl", "ast"):
+            self.assertEqual(extract_number("7", lang), 7, lang)
+            self.assertEqual(extract_number("tengo 7 gatos", lang), 7, lang)
+            self.assertEqual(extract_number("3,5", lang), 3.5, lang)
+
+    def test_spoken_word_before_digit_wins(self):
+        self.assertEqual(extract_number("dous gatos e 7 cans", "gl"), 2)
+
+
+class TestIsOrdinalReturnsValue(unittest.TestCase):
+    def test_value_not_bool(self):
+        cases = [("pt", "terceiro", 3), ("gl", "segundo", 2),
+                 ("mwl", "segundo", 2), ("ast", "terceru", 3)]
+        for lang, word, expected in cases:
+            val = is_ordinal(word, lang)
+            self.assertEqual(val, expected, f"{lang} {word}")
+            self.assertNotIsInstance(val, bool, f"{lang} {word}")
+
+    def test_not_ordinal(self):
+        self.assertFalse(is_ordinal("gato", "gl"))
+        self.assertFalse(is_ordinal("gato", "pt"))
+
+
+class TestGalicianWiring(unittest.TestCase):
+    def test_pronounce_fraction(self):
+        self.assertEqual(pronounce_fraction("2/3", "gl"), "dous terzos")
+        self.assertEqual(pronounce_fraction("1/2", "gl"), "un medio")
+
+    def test_pronounce_ordinal(self):
+        self.assertEqual(pronounce_ordinal(1, "gl"), "primeiro")
+        self.assertEqual(pronounce_ordinal(2, "gl"), "segundo")
+        self.assertEqual(pronounce_ordinal(3, "gl"), "terceiro")
+
+    def test_is_fractional(self):
+        self.assertEqual(is_fractional("medio", "gl"), 0.5)
+        self.assertFalse(is_fractional("can", "gl"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Three related fixes on the shared Romance engine (pt/gl/mwl/ast), with contract tests in `tests/test_romance_extractor_contracts.py`:

- `extract_number` ignored digit tokens entirely — `extract_number("7", "ast")` returned `False`. Digit tokens now win when they appear before any spoken number word.
- `is_ordinal` returned a bare boolean; the module dispatcher documents that it returns the ordinal's value. It now returns the value.
- Galician already implemented `pronounce_fraction_gl`, `pronounce_ordinal_gl` and `is_ordinal_gl` but none were dispatched, and the `is_fractional_gl` call passed a parameter the function no longer accepts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)