### PR TITLE
feat: hungarian number extraction

### DIFF
--- a/ovos_number_parser/__init__.py
+++ b/ovos_number_parser/__init__.py
@@ -19,7 +19,8 @@ from ovos_number_parser.numbers_fa import pronounce_number_fa, extract_number_fa
 from ovos_number_parser.numbers_fr import (pronounce_number_fr, extract_number_fr, is_fractional_fr)
 from ovos_number_parser.numbers_gl import pronounce_number_gl, extract_number_gl, is_fractional_gl, \
     numbers_to_digits_gl, pronounce_ordinal_gl, is_ordinal_gl, pronounce_fraction_gl
-from ovos_number_parser.numbers_hu import pronounce_number_hu, pronounce_ordinal_hu
+from ovos_number_parser.numbers_hu import pronounce_number_hu, pronounce_ordinal_hu, extract_number_hu, \
+    is_fractional_hu, is_ordinal_hu
 from ovos_number_parser.numbers_it import (extract_number_it, pronounce_number_it, is_fractional_it)
 from ovos_number_parser.numbers_mwl import MWL
 from ovos_number_parser.numbers_nl import numbers_to_digits_nl, pronounce_number_nl, pronounce_ordinal_nl, \
@@ -317,6 +318,8 @@ def extract_number(text: str, lang: str,
         return extract_number_sv(text, short_scale, ordinals)
     if lang.startswith("uk"):
         return extract_number_uk(text, short_scale, ordinals)
+    if lang.startswith("hu"):
+        return extract_number_hu(text, short_scale, ordinals)
     raise NotImplementedError(f"Unsupported language: '{lang}'")
 
 
@@ -381,6 +384,8 @@ def is_fractional(input_str: str, lang: str,
         return is_fractional_sv(input_str, short_scale)
     if lang.startswith("uk"):
         return is_fractional_uk(input_str, short_scale)
+    if lang.startswith("hu"):
+        return is_fractional_hu(input_str, short_scale)
     raise NotImplementedError(f"Unsupported language: '{lang}'")
 
 
@@ -413,4 +418,6 @@ def is_ordinal(input_str: str, lang: str) -> Union[bool, float]:
         return is_ordinal_da(input_str)
     if lang.startswith("gl"):
         return is_ordinal_gl(input_str)
+    if lang.startswith("hu"):
+        return is_ordinal_hu(input_str)
     raise NotImplementedError(f"Unsupported language: '{lang}'")

--- a/ovos_number_parser/numbers_hu.py
+++ b/ovos_number_parser/numbers_hu.py
@@ -284,3 +284,231 @@ def pronounce_ordinal_hu(number):
             return ordinals[last_digit].join(
                 root.rsplit(_NUM_STRING_HU[last_digit], 1))
         return root + "edik" if vtype == 1 else root + "adik"
+
+
+_MINUS_HU = ("mínusz", "minusz")
+
+# word → value map used to split compound numbers, including the allomorphs
+# that only appear inside compounds ("két", "huszon")
+_STRING_NUM_HU = {word: val for val, word in _NUM_STRING_HU.items()}
+_STRING_NUM_HU["két"] = 2
+_STRING_NUM_HU["huszon"] = 20
+_STRING_NUM_HU["tizen"] = 10
+
+_STRING_SCALE_HU = {
+    'ezer': 1000,
+    'millió': 1000000,
+    'milliárd': 1000000000,
+    'billió': 1000000000000,
+    'billiárd': 1000000000000000,
+    'trillió': 1000000000000000000,
+    'trilliárd': 1000000000000000000000,
+}
+
+_DECIMAL_SUFFIXES_HU = {
+    'tized': 10,
+    'század': 100,
+    'ezred': 1000,
+    'tízezred': 10000,
+    'százezred': 100000,
+}
+
+_STRING_FRACTION_HU = {word: val for val, word in _FRACTION_STRING_HU.items()}
+
+
+def _split_compound_number_hu(word):
+    """Split an agglutinated Hungarian number word into its vocabulary parts.
+
+    Returns the list of matched (word, value) parts, or None if the word is
+    not entirely composed of number vocabulary.
+    """
+    vocab = dict(_STRING_NUM_HU)
+    vocab.update(_STRING_SCALE_HU)
+    keys = sorted(vocab, key=len, reverse=True)
+    parts = []
+    rest = word
+    while rest:
+        for key in keys:
+            if rest.startswith(key):
+                parts.append((key, vocab[key]))
+                rest = rest[len(key):]
+                break
+        else:
+            return None
+    return parts
+
+
+def _compound_value_hu(parts):
+    """Evaluate the value of the parts of a split Hungarian compound number."""
+    total = 0
+    current = 0
+    for _, val in parts:
+        if val == 100:
+            current = (current or 1) * 100
+        elif val >= 1000:
+            total += (current or 1) * val
+            current = 0
+        else:
+            current += val
+    return total + current
+
+
+def _parse_number_word_hu(word):
+    """Parse a single Hungarian number word (possibly compound, possibly
+    hyphenated) into its value, or None."""
+    word = word.lower().strip().replace('-', '')
+    if not word:
+        return None
+    if word in _STRING_NUM_HU:
+        return _STRING_NUM_HU[word]
+    if word in _STRING_SCALE_HU:
+        return _STRING_SCALE_HU[word]
+    parts = _split_compound_number_hu(word)
+    if parts:
+        return _compound_value_hu(parts)
+    return None
+
+
+_ORDINAL_REVERSE_HU = {}
+
+
+def is_ordinal_hu(input_str):
+    """
+    Check if the given word is a Hungarian ordinal number.
+
+    Args:
+        input_str (str): the string to check if ordinal
+    Returns:
+        (bool) or (int): False if not an ordinal, otherwise the number
+    """
+    if not _ORDINAL_REVERSE_HU:
+        candidates = list(range(0, 101)) + \
+            [n * 100 for n in range(1, 11)] + [1000, 1000000]
+        for n in candidates:
+            _ORDINAL_REVERSE_HU[pronounce_ordinal_hu(n)] = n
+    return _ORDINAL_REVERSE_HU.get(input_str.lower().strip(), False)
+
+
+def is_fractional_hu(input_str, short_scale=True):
+    """
+    Check if the given word is a Hungarian fraction.
+
+    Args:
+        input_str (str): the string to check if fractional
+        short_scale (bool): ignored, present for API compatibility
+    Returns:
+        (bool) or (float): False if not a fraction, otherwise the fraction
+    """
+    word = input_str.lower().strip()
+    if word in _STRING_FRACTION_HU:
+        return 1.0 / _STRING_FRACTION_HU[word]
+    return False
+
+
+def extract_number_hu(text, short_scale=True, ordinals=False):
+    """
+    Extract the first number from Hungarian text.
+
+    Args:
+        text (str): the string to normalize
+        short_scale (bool): ignored, Hungarian uses its own scale words
+        ordinals (bool): consider ordinal numbers ("második" → 2)
+    Returns:
+        (int, float or False): the extracted number or False if no number
+                               was found
+    """
+    tokens = [t.strip('.,!?;:').lower() for t in text.split()]
+    tokens = [t for t in tokens if t]
+    for idx, token in enumerate(tokens):
+        negative = idx > 0 and tokens[idx - 1] in _MINUS_HU
+
+        # digits, including comma decimals
+        cleaned = token.replace(',', '.')
+        try:
+            val = float(cleaned)
+            if val == int(val) and '.' not in cleaned:
+                val = int(val)
+            return -val if negative else val
+        except ValueError:
+            pass
+
+        if ordinals:
+            val = is_ordinal_hu(token)
+            if val is not False:
+                return -val if negative else val
+
+        frac = is_fractional_hu(token)
+        if frac:
+            # "két harmad" → 2/3
+            prev = _parse_number_word_hu(tokens[idx - 1]) if idx > 0 else None
+            if prev is not None:
+                if idx > 1 and tokens[idx - 2] in _MINUS_HU:
+                    negative = True
+                return -prev * frac if negative else prev * frac
+            return -frac if negative else frac
+
+        val = _parse_number_word_hu(token)
+        if val is None:
+            continue
+
+        # "két harmad" → 2/3
+        if idx + 1 < len(tokens):
+            frac = is_fractional_hu(tokens[idx + 1])
+            if frac:
+                return -val * frac if negative else val * frac
+
+        # decimals: "öt egész két tized"
+        if idx + 2 < len(tokens) and tokens[idx + 1] == 'egész':
+            frac_val = _parse_number_word_hu(tokens[idx + 2])
+            if frac_val is not None and idx + 3 < len(tokens) and \
+                    tokens[idx + 3] in _DECIMAL_SUFFIXES_HU:
+                val += frac_val / _DECIMAL_SUFFIXES_HU[tokens[idx + 3]]
+            elif frac_val is not None:
+                # bare "egész" defaults to tenths
+                val += frac_val / 10
+        return -val if negative else val
+    return False
+
+
+def extract_numbers_hu(text, short_scale=True, ordinals=False):
+    """
+    Extract all numbers from Hungarian text.
+
+    Args:
+        text (str): the string to extract numbers from
+        short_scale (bool): ignored, Hungarian uses its own scale words
+        ordinals (bool): consider ordinal numbers
+    Returns:
+        list: list of extracted numbers
+    """
+    tokens = text.split()
+    results = []
+    i = 0
+    while i < len(tokens):
+        # try progressively shorter tails so multi-token values
+        # ("öt egész két tized") are consumed as one number
+        val = extract_number_hu(" ".join(tokens[i:]), short_scale, ordinals)
+        if val is False:
+            break
+        # find where this number starts and how many tokens it spans
+        start = i
+        while extract_number_hu(" ".join(tokens[start + 1:]), short_scale,
+                                ordinals) == val \
+                and extract_number_hu(" ".join(tokens[start:start + 1]),
+                                      short_scale, ordinals) is False:
+            start += 1
+        end = start + 1
+        while end <= len(tokens) and extract_number_hu(
+                " ".join(tokens[start:end]), short_scale, ordinals) != val:
+            end += 1
+        # absorb a trailing decimal/fraction suffix ("öt egész két tized"
+        # matches at three tokens through the bare-egész default, but the
+        # suffix belongs to the same number)
+        while end < len(tokens) and \
+                tokens[end].strip(".,!?;:").lower() in _DECIMAL_SUFFIXES_HU \
+                and extract_number_hu(" ".join(tokens[start:end + 1]),
+                                      short_scale, ordinals) == val:
+            end += 1
+        results.append(val)
+        i = max(end, start + 1)
+    return results

--- a/tests/test_hu_edges.py
+++ b/tests/test_hu_edges.py
@@ -1,0 +1,46 @@
+"""Edge-path tests for the Hungarian number module."""
+import unittest
+
+from ovos_number_parser.numbers_hu import (extract_number_hu,
+                                           extract_numbers_hu,
+                                           nice_number_hu,
+                                           pronounce_number_hu)
+
+
+class TestHungarianEdges(unittest.TestCase):
+    def test_negative_fraction(self):
+        self.assertAlmostEqual(
+            extract_number_hu("mínusz két harmad"), -2 / 3)
+
+    def test_bare_egesz_defaults_to_tenths(self):
+        self.assertEqual(extract_number_hu("öt egész kettő"), 5.2)
+
+    def test_non_number_compound_rejected(self):
+        self.assertIsNone(
+            __import__("ovos_number_parser.numbers_hu",
+                       fromlist=["_parse_number_word_hu"]
+                       )._parse_number_word_hu("macskaegér"))
+
+    def test_extract_numbers(self):
+        self.assertEqual(extract_numbers_hu("öt macska és három kutya"),
+                         [5, 3])
+        self.assertEqual(extract_numbers_hu("nincs itt szám"), [])
+
+    def test_nice_number(self):
+        self.assertEqual(nice_number_hu(4.5), "4 és fél")
+        self.assertEqual(nice_number_hu(0.5), "fél")
+        self.assertEqual(nice_number_hu(5), "5")
+        self.assertEqual(nice_number_hu(4.5, speech=False), "4 1/2")
+
+    def test_pronounce_decimals(self):
+        self.assertEqual(pronounce_number_hu(5.2), "öt egész húsz század")
+        self.assertEqual(pronounce_number_hu(5.2, places=1), "öt egész két tized")
+
+    def test_pronounce_ordinal_large(self):
+        from ovos_number_parser.numbers_hu import pronounce_ordinal_hu
+        self.assertEqual(pronounce_ordinal_hu(1000), "ezredik")
+        self.assertEqual(pronounce_ordinal_hu(1000000), "egymilliomodik")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_number_parser_hu.py
+++ b/tests/test_number_parser_hu.py
@@ -1,0 +1,109 @@
+import unittest
+
+from ovos_number_parser import (extract_number, is_fractional, is_ordinal,
+                                pronounce_number, pronounce_ordinal)
+
+
+class TestPronounceNumberHu(unittest.TestCase):
+    def test_anchors(self):
+        cases = [(0, "nulla"), (1, "egy"), (2, "kettő"), (7, "hét"),
+                 (11, "tizenegy"), (20, "húsz"), (21, "huszonegy"),
+                 (25, "huszonöt"), (30, "harminc"), (99, "kilencvenkilenc"),
+                 (100, "száz"), (101, "százegy"), (200, "kétszáz"),
+                 (222, "kétszázhuszonkettő"), (345, "háromszáznegyvenöt"),
+                 (1000, "ezer"), (2500, "kétezer-ötszáz"),
+                 (1000000, "egymillió"), (2000000, "kétmillió")]
+        for n, expected in cases:
+            self.assertEqual(pronounce_number(n, "hu"), expected, n)
+
+    def test_negative(self):
+        self.assertEqual(pronounce_number(-5, "hu"), "mínusz öt")
+
+    def test_ordinals(self):
+        cases = [(1, "első"), (2, "második"), (3, "harmadik"),
+                 (10, "tizedik"), (20, "huszadik")]
+        for n, expected in cases:
+            self.assertEqual(pronounce_ordinal(n, "hu"), expected, n)
+
+
+class TestExtractNumberHu(unittest.TestCase):
+    def test_anchors(self):
+        cases = [("nulla", 0), ("egy", 1), ("kettő", 2), ("két", 2),
+                 ("tizenegy", 11), ("húsz", 20), ("huszonöt", 25),
+                 ("kilencvenkilenc", 99), ("száz", 100),
+                 ("kétszázhuszonkettő", 222), ("ezer", 1000),
+                 ("ezeregy", 1001), ("kétezer-ötszáz", 2500),
+                 ("tizenkétezer-háromszáznegyvenöt", 12345),
+                 ("egymillió", 1000000), ("kétmillió", 2000000)]
+        for spoken, expected in cases:
+            self.assertEqual(extract_number(spoken, "hu"), expected, spoken)
+
+    def test_digits(self):
+        self.assertEqual(extract_number("5 macska", "hu"), 5)
+        self.assertEqual(extract_number("5,2 kiló", "hu"), 5.2)
+
+    def test_negative(self):
+        self.assertEqual(extract_number("mínusz öt", "hu"), -5)
+        self.assertEqual(extract_number("minusz húsz fok", "hu"), -20)
+
+    def test_decimals(self):
+        self.assertEqual(extract_number("öt egész két tized", "hu"), 5.2)
+        self.assertEqual(
+            extract_number("három egész tizenöt század", "hu"), 3.15)
+        self.assertAlmostEqual(
+            extract_number("mínusz három egész öt tized", "hu"), -3.5)
+
+    def test_fractions(self):
+        self.assertEqual(extract_number("fél", "hu"), 0.5)
+        self.assertAlmostEqual(extract_number("két harmad", "hu"), 2 / 3)
+        self.assertEqual(extract_number("három negyed", "hu"), 0.75)
+
+    def test_in_sentence(self):
+        self.assertEqual(
+            extract_number("van huszonöt macskám", "hu"), 25)
+        self.assertEqual(
+            extract_number("kérek kétezer-ötszáz forintot", "hu"), 2500)
+
+    def test_ordinals_flag(self):
+        self.assertEqual(
+            extract_number("a második emelet", "hu", ordinals=True), 2)
+        self.assertEqual(
+            extract_number("a huszadik alkalommal", "hu", ordinals=True), 20)
+
+    def test_no_number(self):
+        self.assertFalse(extract_number("jó reggelt", "hu"))
+        self.assertFalse(extract_number("", "hu"))
+
+    def test_round_trip_sweep(self):
+        values = list(range(0, 121)) + [150, 222, 345, 999, 1000, 1001,
+                                        2500, 9999, 12345, 100000, 123456,
+                                        1000000, 2000000]
+        for n in values:
+            spoken = pronounce_number(n, "hu")
+            self.assertEqual(extract_number(spoken, "hu"), n,
+                             f"{n} -> {spoken!r}")
+
+    def test_negative_round_trip(self):
+        for n in (-1, -21, -100, -2500):
+            spoken = pronounce_number(n, "hu")
+            self.assertEqual(extract_number(spoken, "hu"), n,
+                             f"{n} -> {spoken!r}")
+
+
+class TestHelpersHu(unittest.TestCase):
+    def test_is_fractional(self):
+        self.assertEqual(is_fractional("fél", "hu"), 0.5)
+        self.assertAlmostEqual(is_fractional("harmad", "hu"), 1 / 3)
+        self.assertEqual(is_fractional("negyed", "hu"), 0.25)
+        self.assertFalse(is_fractional("macska", "hu"))
+
+    def test_is_ordinal(self):
+        self.assertEqual(is_ordinal("első", "hu"), 1)
+        self.assertEqual(is_ordinal("második", "hu"), 2)
+        self.assertEqual(is_ordinal("tizedik", "hu"), 10)
+        self.assertEqual(is_ordinal("huszonegyedik", "hu"), 21)
+        self.assertFalse(is_ordinal("kutya", "hu"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Hungarian could pronounce numbers but never parse them back — `extract_number`, `is_fractional` and `is_ordinal` all raised `NotImplementedError`.

This adds the reverse direction on top of the existing vocabulary:

- compound splitting by greedy longest-prefix match, including the compound-only allomorphs `két`, `huszon` and `tizen` (`tizenkétezer-háromszáznegyvenöt` → 12345)
- place-value evaluation with `ezer`/`millió`/`milliárd` scales, hyphens stripped
- decimal idiom `öt egész két tized` → 5.2 (with `tized`/`század`/`ezred` suffixes, bare `egész` defaulting to tenths)
- fractions `két harmad` → 2/3, negatives `mínusz öt`, ordinals `második` → 2 via a reverse lookup over `pronounce_ordinal_hu`

Tests: full anchor suite plus a pronounce→extract round-trip sweep over ~135 values (`tests/test_number_parser_hu.py`, `tests/test_hu_edges.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)