### PR TITLE
feat: slovenian number extraction

### DIFF
--- a/ovos_number_parser/__init__.py
+++ b/ovos_number_parser/__init__.py
@@ -28,7 +28,8 @@ from ovos_number_parser.numbers_nl import numbers_to_digits_nl, pronounce_number
 from ovos_number_parser.numbers_pl import numbers_to_digits_pl, pronounce_number_pl, extract_number_pl, is_fractional_pl
 from ovos_number_parser.numbers_pt import PortugueseVariant, PT_PT, PT_BR
 from ovos_number_parser.numbers_ru import numbers_to_digits_ru, pronounce_number_ru, extract_number_ru, is_fractional_ru
-from ovos_number_parser.numbers_sl import pronounce_number_sl
+from ovos_number_parser.numbers_sl import pronounce_number_sl, extract_number_sl, is_fractional_sl, \
+    is_ordinal_sl
 from ovos_number_parser.numbers_sv import pronounce_number_sv, pronounce_ordinal_sv, extract_number_sv, \
     is_fractional_sv
 from ovos_number_parser.numbers_uk import numbers_to_digits_uk, pronounce_number_uk, extract_number_uk, is_fractional_uk
@@ -242,6 +243,8 @@ def pronounce_ordinal(number: Union[int, float], lang: str,
         return pronounce_ordinal_sv(number)
     if lang.startswith("gl"):
         return pronounce_ordinal_gl(number, gender=gender, scale=scale)
+    if lang.startswith("sl"):
+        return pronounce_number_sl(number, ordinals=True)
     # fallback to unicode RBNF
     try:
         engine = RbnfEngine.for_language(lang.split("-")[0])
@@ -320,6 +323,8 @@ def extract_number(text: str, lang: str,
         return extract_number_uk(text, short_scale, ordinals)
     if lang.startswith("hu"):
         return extract_number_hu(text, short_scale, ordinals)
+    if lang.startswith("sl"):
+        return extract_number_sl(text, short_scale, ordinals)
     raise NotImplementedError(f"Unsupported language: '{lang}'")
 
 
@@ -386,6 +391,8 @@ def is_fractional(input_str: str, lang: str,
         return is_fractional_uk(input_str, short_scale)
     if lang.startswith("hu"):
         return is_fractional_hu(input_str, short_scale)
+    if lang.startswith("sl"):
+        return is_fractional_sl(input_str, short_scale)
     raise NotImplementedError(f"Unsupported language: '{lang}'")
 
 
@@ -420,4 +427,6 @@ def is_ordinal(input_str: str, lang: str) -> Union[bool, float]:
         return is_ordinal_gl(input_str)
     if lang.startswith("hu"):
         return is_ordinal_hu(input_str)
+    if lang.startswith("sl"):
+        return is_ordinal_sl(input_str)
     raise NotImplementedError(f"Unsupported language: '{lang}'")

--- a/ovos_number_parser/numbers_sl.py
+++ b/ovos_number_parser/numbers_sl.py
@@ -461,3 +461,215 @@ def pronounce_number_sl(num, places=2, short_scale=True, scientific=False,
         for char in _num_str:
             result += " " + number_names[int(char)]
     return result
+
+
+_MINUS_SL = ("minus",)
+
+_DECIMAL_MARKERS_SL = ("cela", "celi", "cele", "celih")
+
+# unit word → value map, including the allomorphs used inside compounds
+_STRING_NUM_SL = {word: val for val, word in _NUM_STRING_SL.items()}
+_STRING_NUM_SL["en"] = 1
+_STRING_NUM_SL["eno"] = 1
+_STRING_NUM_SL["dva"] = 2
+_STRING_NUM_SL["trije"] = 3
+
+# scale stems match declined forms too ("milijona", "milijonov", ...)
+_SCALE_STEMS_SHORT_SL = {
+    'tisoč': 1000,
+    'milijon': 1000000,
+    'bilijon': 1000000000,
+    'trilijon': 1000000000000,
+    'kvadrilijon': 1000000000000000,
+    'kvintilijon': 1000000000000000000,
+}
+
+_SCALE_STEMS_LONG_SL = {
+    'tisoč': 1000,
+    'milijon': 1000000,
+    'milijard': 1000000000,
+    'bilijon': 1000000000000,
+    'bilijard': 1000000000000000,
+    'trilijon': 1000000000000000000,
+}
+
+_TENS_WORDS_SL = {word: val for val, word in _NUM_STRING_SL.items()
+                  if 20 <= val <= 90 and val % 10 == 0}
+
+
+def _parse_number_word_sl(word):
+    """Parse a single Slovenian number word into its value, or None.
+
+    Handles simple words ("pet"), in-compounds ("enaindvajset" = 21) and
+    hundred compounds ("dvesto" = 200, "sto" = 100).
+    """
+    word = word.lower().strip()
+    if not word:
+        return None
+    if word in _STRING_NUM_SL:
+        return _STRING_NUM_SL[word]
+    if word == "sto":
+        return 100
+    # "enaindvajset" → ena + in + dvajset
+    for tens_word, tens_val in _TENS_WORDS_SL.items():
+        if word.endswith(tens_word):
+            prefix = word[:-len(tens_word)]
+            if prefix.endswith("in"):
+                unit = prefix[:-2]
+                if unit in _STRING_NUM_SL and _STRING_NUM_SL[unit] < 10:
+                    return tens_val + _STRING_NUM_SL[unit]
+    # "dvesto", "tristo", "sto petdeset" (remainder is a separate token)
+    if word.endswith("sto"):
+        prefix = word[:-3]
+        if not prefix:
+            return 100
+        if prefix in _STRING_NUM_SL and _STRING_NUM_SL[prefix] < 10:
+            return _STRING_NUM_SL[prefix] * 100
+    return None
+
+
+def _parse_scale_word_sl(word, short_scale=True):
+    """Return the scale value for a (possibly declined) Slovenian scale word."""
+    word = word.lower().strip()
+    stems = _SCALE_STEMS_SHORT_SL if short_scale else _SCALE_STEMS_LONG_SL
+    # "milijarda" is unambiguous and only exists in the long scale
+    if word.startswith("milijard") and len(word) - len("milijard") <= 2:
+        return 1000000000
+    for stem, val in stems.items():
+        if word == stem or (word.startswith(stem) and
+                            len(word) - len(stem) <= 2):
+            return val
+    return None
+
+
+def is_fractional_sl(input_str, short_scale=True):
+    """
+    Check if the given word is a Slovenian fraction.
+
+    Accepts the inflected forms used after numerals ("dve tretjini",
+    "pet tretjin") as well as the base form.
+
+    Args:
+        input_str (str): the string to check if fractional
+        short_scale (bool): ignored, present for API compatibility
+    Returns:
+        (bool) or (float): False if not a fraction, otherwise the fraction
+    """
+    word = input_str.lower().strip()
+    for den, base in _FRACTION_STRING_SL.items():
+        forms = {base, base[:-1], base[:-1] + 'i', base[:-1] + 'e'}
+        if word in forms:
+            return 1.0 / den
+    return False
+
+
+_ORDINAL_REVERSE_SL = {}
+
+
+def is_ordinal_sl(input_str):
+    """
+    Check if the given word is a Slovenian ordinal number.
+
+    Args:
+        input_str (str): the string to check if ordinal
+    Returns:
+        (bool) or (int): False if not an ordinal, otherwise the number
+    """
+    if not _ORDINAL_REVERSE_SL:
+        candidates = list(range(1, 101)) + \
+            [n * 100 for n in range(1, 11)] + [1000, 1000000]
+        for n in candidates:
+            _ORDINAL_REVERSE_SL[pronounce_number_sl(n, ordinals=True)] = n
+    return _ORDINAL_REVERSE_SL.get(input_str.lower().strip(), False)
+
+
+def extract_number_sl(text, short_scale=True, ordinals=False):
+    """
+    Extract the first number from Slovenian text.
+
+    Args:
+        text (str): the string to extract a number from
+        short_scale (bool): use short (True) or long (False) scale
+        ordinals (bool): consider ordinal numbers ("drugi" → 2)
+    Returns:
+        (int, float or False): the extracted number or False if no number
+                               was found
+    """
+    tokens = [t.strip('.,!?;:').lower() for t in text.split()]
+    tokens = [t for t in tokens if t]
+
+    for idx, token in enumerate(tokens):
+        negative = idx > 0 and tokens[idx - 1] in _MINUS_SL
+
+        # digits, including comma decimals
+        cleaned = token.replace(',', '.')
+        try:
+            val = float(cleaned)
+            if val == int(val) and '.' not in cleaned:
+                val = int(val)
+            return -val if negative else val
+        except ValueError:
+            pass
+
+        if ordinals:
+            val = is_ordinal_sl(token)
+            if val is not False:
+                return -val if negative else val
+
+        if _parse_number_word_sl(token) is None and \
+                _parse_scale_word_sl(token, short_scale) is None:
+            frac = is_fractional_sl(token)
+            if frac:
+                return -frac if negative else frac
+            continue
+
+        # accumulate a run of number/scale words starting here
+        total = 0
+        current = 0
+        j = idx
+        while j < len(tokens):
+            tok = tokens[j]
+            scale = _parse_scale_word_sl(tok, short_scale)
+            if scale is not None:
+                total += (current or 1) * scale
+                current = 0
+                j += 1
+                continue
+            v = _parse_number_word_sl(tok)
+            if v is None:
+                try:
+                    v = int(tok)
+                except ValueError:
+                    v = None
+            if v is None:
+                break
+            if v == 100 or (v % 100 == 0 and v < 1000 and current == 0):
+                # "sto" after a unit multiplies implicitly only in compounds,
+                # standalone "sto"/"dvesto" tokens are additive values
+                current += v
+            else:
+                current += v
+            j += 1
+        val = total + current
+
+        # decimals: "pet celih dve tri" → 5.23
+        if j < len(tokens) and tokens[j] in _DECIMAL_MARKERS_SL:
+            digits = ""
+            k = j + 1
+            while k < len(tokens):
+                d = _parse_number_word_sl(tokens[k])
+                if d is None or d > 9:
+                    break
+                digits += str(d)
+                k += 1
+            if digits:
+                val = float(f"{val}.{digits}")
+
+        # fractions: "dve tretjini" → 2/3
+        elif j < len(tokens):
+            frac = is_fractional_sl(tokens[j])
+            if frac:
+                val = val * frac
+
+        return -val if negative else val
+    return False

--- a/tests/test_number_parser_sl.py
+++ b/tests/test_number_parser_sl.py
@@ -1,0 +1,101 @@
+import unittest
+
+from ovos_number_parser import (extract_number, is_fractional, is_ordinal,
+                                pronounce_number, pronounce_ordinal)
+
+
+class TestPronounceNumberSl(unittest.TestCase):
+    def test_anchors(self):
+        cases = [(0, "nič"), (1, "ena"), (2, "dve"), (5, "pet"),
+                 (11, "enajst"), (20, "dvajset"), (21, "enaindvajset"),
+                 (25, "petindvajset"), (99, "devetindevetdeset"),
+                 (100, "sto"), (200, "dvesto"), (1000, "tisoč")]
+        for n, expected in cases:
+            self.assertEqual(pronounce_number(n, "sl"), expected, n)
+
+    def test_negative(self):
+        self.assertEqual(pronounce_number(-5, "sl"), "minus pet")
+
+    def test_ordinals(self):
+        cases = [(1, "prvi"), (2, "drugi"), (3, "tretji"), (10, "deseti"),
+                 (21, "enaindvajseti"), (100, "stoti")]
+        for n, expected in cases:
+            self.assertEqual(pronounce_ordinal(n, "sl"), expected, n)
+
+
+class TestExtractNumberSl(unittest.TestCase):
+    def test_anchors(self):
+        cases = [("nič", 0), ("ena", 1), ("dve", 2), ("dva", 2),
+                 ("enajst", 11), ("dvajset", 20), ("enaindvajset", 21),
+                 ("petindvajset", 25), ("devetindevetdeset", 99),
+                 ("sto", 100), ("dvesto", 200), ("sto enaindvajset", 121),
+                 ("tisoč", 1000), ("dva tisoč tristo", 2300),
+                 ("milijon", 1000000), ("dva milijona", 2000000)]
+        for spoken, expected in cases:
+            self.assertEqual(extract_number(spoken, "sl"), expected, spoken)
+
+    def test_digits(self):
+        self.assertEqual(extract_number("5 mačk", "sl"), 5)
+        self.assertEqual(extract_number("5,2 kilograma", "sl"), 5.2)
+
+    def test_negative(self):
+        self.assertEqual(extract_number("minus pet", "sl"), -5)
+        self.assertEqual(extract_number("minus dvajset stopinj", "sl"), -20)
+
+    def test_decimals(self):
+        self.assertEqual(extract_number("pet celih dve", "sl"), 5.2)
+        self.assertEqual(extract_number("dve celi tri pet", "sl"), 2.35)
+
+    def test_fractions(self):
+        self.assertEqual(extract_number("polovica", "sl"), 0.5)
+        self.assertAlmostEqual(extract_number("dve tretjini", "sl"), 2 / 3)
+
+    def test_in_sentence(self):
+        self.assertEqual(extract_number("imam petindvajset mačk", "sl"), 25)
+        self.assertEqual(
+            extract_number("to stane dva tisoč evrov", "sl"), 2000)
+
+    def test_ordinals_flag(self):
+        self.assertEqual(
+            extract_number("drugi poskus", "sl", ordinals=True), 2)
+        self.assertEqual(
+            extract_number("enaindvajseti dan", "sl", ordinals=True), 21)
+
+    def test_no_number(self):
+        self.assertFalse(extract_number("dobro jutro", "sl"))
+        self.assertFalse(extract_number("", "sl"))
+
+    def test_round_trip_sweep(self):
+        values = list(range(0, 121)) + [150, 222, 345, 999, 1000, 1001,
+                                        2500, 9999, 12345, 100000, 123456,
+                                        1000000, 2000000]
+        for n in values:
+            spoken = pronounce_number(n, "sl")
+            self.assertEqual(extract_number(spoken, "sl"), n,
+                             f"{n} -> {spoken!r}")
+
+    def test_negative_round_trip(self):
+        for n in (-1, -21, -100, -2500):
+            spoken = pronounce_number(n, "sl")
+            self.assertEqual(extract_number(spoken, "sl"), n,
+                             f"{n} -> {spoken!r}")
+
+
+class TestHelpersSl(unittest.TestCase):
+    def test_is_fractional(self):
+        self.assertEqual(is_fractional("polovica", "sl"), 0.5)
+        self.assertAlmostEqual(is_fractional("tretjina", "sl"), 1 / 3)
+        # inflected forms used after numerals
+        self.assertAlmostEqual(is_fractional("tretjini", "sl"), 1 / 3)
+        self.assertAlmostEqual(is_fractional("tretjine", "sl"), 1 / 3)
+        self.assertFalse(is_fractional("mačka", "sl"))
+
+    def test_is_ordinal(self):
+        self.assertEqual(is_ordinal("prvi", "sl"), 1)
+        self.assertEqual(is_ordinal("deseti", "sl"), 10)
+        self.assertEqual(is_ordinal("enaindvajseti", "sl"), 21)
+        self.assertFalse(is_ordinal("pes", "sl"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sl_edges.py
+++ b/tests/test_sl_edges.py
@@ -1,0 +1,65 @@
+"""Edge-path tests for the Slovenian number module."""
+import unittest
+
+from ovos_number_parser.numbers_sl import (extract_number_sl, nice_number_sl,
+                                           pronounce_number_sl)
+
+
+class TestSlovenianEdges(unittest.TestCase):
+    def test_decimal_digit_run_stops_at_word(self):
+        self.assertEqual(extract_number_sl("pet celih dve mačke"), 5.2)
+
+    def test_long_scale_pronounce(self):
+        self.assertEqual(pronounce_number_sl(1000000, short_scale=False),
+                         "milijon")
+
+    def test_scientific(self):
+        spoken = pronounce_number_sl(2e100, scientific=True)
+        self.assertIn("krat deset na", spoken)
+
+    def test_nice_number(self):
+        self.assertEqual(nice_number_sl(0.5), "1 polovica")
+        self.assertEqual(nice_number_sl(4.5, speech=False), "4 1/2")
+
+    def test_declined_scale_words(self):
+        self.assertEqual(extract_number_sl("pet milijonov"), 5000000)
+        self.assertEqual(extract_number_sl("trije milijoni"), 3000000)
+
+    def test_ordinal_pronounce_flag(self):
+        self.assertEqual(pronounce_number_sl(3, ordinals=True), "tretji")
+        self.assertEqual(pronounce_number_sl(21, ordinals=True),
+                         "enaindvajseti")
+
+
+
+
+
+class TestSlovenianPronounceLegacy(unittest.TestCase):
+    """Anchors for the plural/declension branches of pronounce_number_sl."""
+
+    def test_decimals(self):
+        self.assertEqual(pronounce_number_sl(5.2), "pet celih dve")
+        self.assertEqual(pronounce_number_sl(-5.2), "minus pet celih dve")
+        self.assertEqual(pronounce_number_sl(2.5), "dve celi pet")
+
+    def test_million_declension(self):
+        self.assertEqual(pronounce_number_sl(2000000), "dve milijona")
+        self.assertEqual(pronounce_number_sl(3000000), "tri milijoni")
+        self.assertEqual(pronounce_number_sl(5000000), "pet milijonov")
+
+    def test_long_scale(self):
+        self.assertEqual(
+            pronounce_number_sl(1000000000, short_scale=False), "milijarda")
+        self.assertEqual(extract_number_sl("milijarda"), 1000000000)
+        self.assertEqual(
+            extract_number_sl("dva bilijona", short_scale=False),
+            2000000000000)
+
+    def test_large_composite_round_trip(self):
+        for n in (1234567, 2000001, 100100100):
+            spoken = pronounce_number_sl(n)
+            self.assertEqual(extract_number_sl(spoken), n, spoken)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Slovenian could pronounce numbers but never parse them back — `extract_number`, `is_fractional`, `is_ordinal` and `pronounce_ordinal` all raised `NotImplementedError`.

This adds the reverse direction on top of the existing vocabulary:

- in-compound splitting: `enaindvajset` (ena+in+dvajset) → 21, hundred compounds `dvesto` → 200
- declined scale words match by stem: `dva milijona`, `pet milijonov`, `milijarda` (long-scale, unambiguous) and short/long `bilijon` handling behind `short_scale`
- decimal idiom `pet celih dve` → 5.2 across all four `cela/celi/cele/celih` marker forms
- inflected fraction forms after numerals (`dve tretjini`, `pet tretjin`) → 1/3
- ordinals via the native `pronounce_number_sl(ordinals=True)`: `enaindvajseti` ↔ 21 both directions

Tests: anchor suite + pronounce→extract round-trip sweep over ~135 values, plural/declension anchors for the legacy pronunciation branches (`tests/test_number_parser_sl.py`, `tests/test_sl_edges.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)