### PR TITLE
feat: ordinal pronunciation for czech, polish, ukrainian, basque and farsi

### DIFF
--- a/ovos_number_parser/__init__.py
+++ b/ovos_number_parser/__init__.py
@@ -6,7 +6,8 @@ from unicode_rbnf import RbnfEngine, FormatPurpose
 from ovos_number_parser.numbers_ast import AST
 from ovos_number_parser.numbers_az import numbers_to_digits_az, extract_number_az, is_fractional_az, pronounce_number_az
 from ovos_number_parser.numbers_ca import numbers_to_digits_ca, pronounce_number_ca, is_fractional_ca, extract_number_ca
-from ovos_number_parser.numbers_cs import numbers_to_digits_cs, pronounce_number_cs, is_fractional_cs, extract_number_cs
+from ovos_number_parser.numbers_cs import numbers_to_digits_cs, pronounce_number_cs, is_fractional_cs, \
+    extract_number_cs, pronounce_ordinal_cs
 from ovos_number_parser.numbers_da import numbers_to_digits_da, pronounce_number_da, is_fractional_da, is_ordinal_da, \
     pronounce_ordinal_da, extract_number_da
 from ovos_number_parser.numbers_de import numbers_to_digits_de, pronounce_number_de, pronounce_ordinal_de, \
@@ -14,8 +15,10 @@ from ovos_number_parser.numbers_de import numbers_to_digits_de, pronounce_number
 from ovos_number_parser.numbers_en import numbers_to_digits_en, is_ordinal_en, pronounce_number_en, extract_number_en, \
     is_fractional_en
 from ovos_number_parser.numbers_es import numbers_to_digits_es, pronounce_number_es, extract_number_es, is_fractional_es
-from ovos_number_parser.numbers_eu import pronounce_number_eu, extract_number_eu, is_fractional_eu
-from ovos_number_parser.numbers_fa import pronounce_number_fa, extract_number_fa
+from ovos_number_parser.numbers_eu import pronounce_number_eu, extract_number_eu, is_fractional_eu, \
+    pronounce_ordinal_eu
+from ovos_number_parser.numbers_fa import pronounce_number_fa, extract_number_fa, is_fractional_fa, \
+    pronounce_ordinal_fa
 from ovos_number_parser.numbers_fr import (pronounce_number_fr, extract_number_fr, is_fractional_fr)
 from ovos_number_parser.numbers_gl import pronounce_number_gl, extract_number_gl, is_fractional_gl, \
     numbers_to_digits_gl, pronounce_ordinal_gl, is_ordinal_gl, pronounce_fraction_gl
@@ -25,14 +28,16 @@ from ovos_number_parser.numbers_it import (extract_number_it, pronounce_number_i
 from ovos_number_parser.numbers_mwl import MWL
 from ovos_number_parser.numbers_nl import numbers_to_digits_nl, pronounce_number_nl, pronounce_ordinal_nl, \
     extract_number_nl, is_fractional_nl
-from ovos_number_parser.numbers_pl import numbers_to_digits_pl, pronounce_number_pl, extract_number_pl, is_fractional_pl
+from ovos_number_parser.numbers_pl import numbers_to_digits_pl, pronounce_number_pl, extract_number_pl, \
+    is_fractional_pl, pronounce_ordinal_pl
 from ovos_number_parser.numbers_pt import PortugueseVariant, PT_PT, PT_BR
 from ovos_number_parser.numbers_ru import numbers_to_digits_ru, pronounce_number_ru, extract_number_ru, is_fractional_ru
 from ovos_number_parser.numbers_sl import pronounce_number_sl, extract_number_sl, is_fractional_sl, \
     is_ordinal_sl
 from ovos_number_parser.numbers_sv import pronounce_number_sv, pronounce_ordinal_sv, extract_number_sv, \
     is_fractional_sv
-from ovos_number_parser.numbers_uk import numbers_to_digits_uk, pronounce_number_uk, extract_number_uk, is_fractional_uk
+from ovos_number_parser.numbers_uk import numbers_to_digits_uk, pronounce_number_uk, extract_number_uk, \
+    is_fractional_uk, pronounce_ordinal_uk
 from ovos_number_parser.util import Scale, GrammaticalGender, DigitPronunciation
 
 
@@ -245,6 +250,16 @@ def pronounce_ordinal(number: Union[int, float], lang: str,
         return pronounce_ordinal_gl(number, gender=gender, scale=scale)
     if lang.startswith("sl"):
         return pronounce_number_sl(number, ordinals=True)
+    if lang.startswith("cs"):
+        return pronounce_ordinal_cs(number)
+    if lang.startswith("pl"):
+        return pronounce_ordinal_pl(number)
+    if lang.startswith("uk"):
+        return pronounce_ordinal_uk(number)
+    if lang.startswith("eu"):
+        return pronounce_ordinal_eu(number)
+    if lang.startswith("fa"):
+        return pronounce_ordinal_fa(number)
     # fallback to unicode RBNF
     try:
         engine = RbnfEngine.for_language(lang.split("-")[0])
@@ -393,6 +408,8 @@ def is_fractional(input_str: str, lang: str,
         return is_fractional_hu(input_str, short_scale)
     if lang.startswith("sl"):
         return is_fractional_sl(input_str, short_scale)
+    if lang.startswith("fa"):
+        return is_fractional_fa(input_str, short_scale)
     raise NotImplementedError(f"Unsupported language: '{lang}'")
 
 

--- a/ovos_number_parser/numbers_cs.py
+++ b/ovos_number_parser/numbers_cs.py
@@ -1281,3 +1281,36 @@ def pronounce_number_cs(number, places=2, short_scale=True, scientific=False,
         for char in _num_str:
             result += " " + number_names[int(char)]
     return result
+
+
+_ORDINAL_HUNDREDS_CS = {
+    200: "dvoustý", 300: "třístý", 400: "čtyřstý", 500: "pětistý",
+    600: "šestistý", 700: "sedmistý", 800: "osmistý", 900: "devítistý",
+}
+
+
+def pronounce_ordinal_cs(number):
+    """
+    Pronounce a number as a Czech ordinal.
+
+    Args:
+        number (int): the number to pronounce
+    Returns:
+        (str): the ordinal in Czech
+    """
+    number = int(number)
+    if number <= 0:
+        raise ValueError("Czech ordinals start at 1")
+    if number in _SHORT_ORDINAL_CS:
+        return _SHORT_ORDINAL_CS[number]
+    if number in _ORDINAL_HUNDREDS_CS:
+        return _ORDINAL_HUNDREDS_CS[number]
+    if number < 100:
+        tens = number // 10 * 10
+        unit = number % 10
+        return f"{_SHORT_ORDINAL_CS[tens]} {_SHORT_ORDINAL_CS[unit]}"
+    last = number % 100
+    if last:
+        prefix = number - last
+        return f"{pronounce_number_cs(prefix)} {pronounce_ordinal_cs(last)}"
+    raise NotImplementedError(f"cannot pronounce {number} as a Czech ordinal")

--- a/ovos_number_parser/numbers_eu.py
+++ b/ovos_number_parser/numbers_eu.py
@@ -533,3 +533,27 @@ def eu_number_parse(words, i):
         return None
 
     return eu_number(i)
+
+
+def pronounce_ordinal_eu(number):
+    """
+    Pronounce a number as a Basque ordinal.
+
+    Basque ordinals add the suffix "-garren" to the cardinal; "first" is the
+    irregular "lehen".
+
+    Args:
+        number (int): the number to pronounce
+    Returns:
+        (str): the ordinal in Basque
+    """
+    number = int(number)
+    if number <= 0:
+        raise ValueError("Basque ordinals start at 1")
+    if number == 1:
+        return "lehen"
+    cardinal = pronounce_number_eu(number)
+    # final -t of "bost" assimilates before the suffix
+    if cardinal.endswith("bost"):
+        cardinal = cardinal[:-1]
+    return cardinal + "garren"

--- a/ovos_number_parser/numbers_fa.py
+++ b/ovos_number_parser/numbers_fa.py
@@ -427,3 +427,48 @@ def pronounce_number_fa(number, places=2, scientific=False,
     if ordinals:
         return _to_ordinal(number)
     return _to_cardinal(number, places)
+
+
+_STRING_FRACTION_FA = {word: val for val, word in _FRACTION_STRING_FA.items()}
+_STRING_FRACTION_FA["نیم"] = 2
+
+
+def is_fractional_fa(input_str, short_scale=True):
+    """
+    Check if the given word is a Farsi fraction.
+
+    Args:
+        input_str (str): the string to check if fractional
+        short_scale (bool): ignored, present for API compatibility
+    Returns:
+        (bool) or (float): False if not a fraction, otherwise the fraction
+    """
+    word = input_str.strip()
+    if word in _STRING_FRACTION_FA:
+        return 1.0 / _STRING_FRACTION_FA[word]
+    return False
+
+
+def pronounce_ordinal_fa(number):
+    """
+    Pronounce a number as a Farsi ordinal.
+
+    Uses the irregular "اول" for 1 and the fraction/ordinal names up to 20,
+    beyond that the cardinal takes the suffix "م" ("ام" after a vowel).
+
+    Args:
+        number (int): the number to pronounce
+    Returns:
+        (str): the ordinal in Farsi
+    """
+    number = int(number)
+    if number <= 0:
+        raise ValueError("Farsi ordinals start at 1")
+    if number == 1:
+        return "اول"
+    if number in _FRACTION_STRING_FA:
+        return _FRACTION_STRING_FA[number]
+    cardinal = pronounce_number_fa(number)
+    if cardinal[-1] in "اوهی":
+        return cardinal + "‌ام"
+    return cardinal + "م"

--- a/ovos_number_parser/numbers_pl.py
+++ b/ovos_number_parser/numbers_pl.py
@@ -1096,3 +1096,37 @@ def normalize_word_pl(word):
         return 'dwa'
 
     return word
+
+
+_ORDINAL_HUNDREDS_PL = {
+    200: "dwusetny", 300: "trzechsetny", 400: "czterechsetny",
+    500: "pięćsetny", 600: "sześćsetny", 700: "siedemsetny",
+    800: "osiemsetny", 900: "dziewięćsetny",
+}
+
+
+def pronounce_ordinal_pl(number):
+    """
+    Pronounce a number as a Polish ordinal (masculine nominative).
+
+    Args:
+        number (int): the number to pronounce
+    Returns:
+        (str): the ordinal in Polish
+    """
+    number = int(number)
+    if number <= 0:
+        raise ValueError("Polish ordinals start at 1")
+    if number in _SHORT_ORDINAL_PL:
+        return _SHORT_ORDINAL_PL[number]
+    if number in _ORDINAL_HUNDREDS_PL:
+        return _ORDINAL_HUNDREDS_PL[number]
+    if number < 100:
+        tens = number // 10 * 10
+        unit = number % 10
+        return f"{_SHORT_ORDINAL_PL[tens]} {_SHORT_ORDINAL_PL[unit]}"
+    last = number % 100
+    if last:
+        prefix = number - last
+        return f"{pronounce_number_pl(prefix)} {pronounce_ordinal_pl(last)}"
+    raise NotImplementedError(f"cannot pronounce {number} as a Polish ordinal")

--- a/ovos_number_parser/numbers_uk.py
+++ b/ovos_number_parser/numbers_uk.py
@@ -1403,3 +1403,30 @@ def plural_uk(num: int, one: str, few: str, many: str):
     if 2 <= num % 10 <= 4:
         return few
     return many
+
+
+def pronounce_ordinal_uk(number):
+    """
+    Pronounce a number as a Ukrainian ordinal (masculine nominative).
+
+    Only the final word is ordinal, preceding groups stay cardinal.
+
+    Args:
+        number (int): the number to pronounce
+    Returns:
+        (str): the ordinal in Ukrainian
+    """
+    number = int(number)
+    if number <= 0:
+        raise ValueError("Ukrainian ordinals start at 1")
+    if number in _ORDINAL_BASE_UK:
+        return _ORDINAL_BASE_UK[number]
+    if number < 100:
+        tens = number // 10 * 10
+        unit = number % 10
+        return f"{pronounce_number_uk(tens)} {_ORDINAL_BASE_UK[unit]}"
+    last = number % 100
+    if last:
+        prefix = number - last
+        return f"{pronounce_number_uk(prefix)} {pronounce_ordinal_uk(last)}"
+    raise NotImplementedError(f"cannot pronounce {number} as a Ukrainian ordinal")

--- a/tests/test_ordinal_anchors.py
+++ b/tests/test_ordinal_anchors.py
@@ -1,0 +1,48 @@
+"""Hand-verified ordinal anchors for the newly supported languages."""
+import unittest
+
+from ovos_number_parser import is_fractional, pronounce_ordinal
+
+
+class TestPronounceOrdinalAnchors(unittest.TestCase):
+    """Hand-verified ordinals for the newly wired languages."""
+    ANCHORS = {
+        "cs": [(1, "první"), (2, "druhý"), (21, "dvacátý první"),
+               (45, "čtyřicátý pátý"), (100, "stý"), (200, "dvoustý"),
+               (1000, "tisící")],
+        "pl": [(1, "pierwszy"), (2, "drugi"), (21, "dwudziesty pierwszy"),
+               (45, "czterdziesty piąty"), (100, "setny"), (200, "dwusetny"),
+               (1000, "tysięczny")],
+        "uk": [(1, "перший"), (2, "другий"), (21, "двадцять перший"),
+               (100, "сотий"), (200, "двохсотий"), (1000, "тисячний")],
+        "eu": [(1, "lehen"), (2, "bigarren"), (3, "hirugarren"),
+               (4, "laugarren"), (5, "bosgarren"), (10, "hamargarren"),
+               (20, "hogeigarren")],
+        "fa": [(1, "اول"), (2, "دوم"), (3, "سوم"), (5, "پنجم"),
+               (10, "دهم"), (20, "بیستم")],
+        "sl": [(1, "prvi"), (2, "drugi"), (3, "tretji"), (10, "deseti"),
+               (21, "enaindvajseti"), (100, "stoti")],
+        "gl": [(1, "primeiro"), (2, "segundo"), (3, "terceiro")],
+    }
+
+    def test_anchors(self):
+        for lang, pairs in self.ANCHORS.items():
+            for n, expected in pairs:
+                self.assertEqual(pronounce_ordinal(n, lang), expected,
+                                 f"{lang} {n}")
+
+    def test_invalid_ordinals_raise(self):
+        for lang in ("cs", "pl", "uk", "eu", "fa"):
+            with self.assertRaises(ValueError, msg=lang):
+                pronounce_ordinal(0, lang)
+
+
+class TestFarsiFractions(unittest.TestCase):
+    def test_is_fractional(self):
+        self.assertEqual(is_fractional("نیم", "fa"), 0.5)
+        self.assertAlmostEqual(is_fractional("سوم", "fa"), 1 / 3)
+        self.assertFalse(is_fractional("خانه", "fa"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`pronounce_ordinal` raised `NotImplementedError` for cs, pl, uk, eu and fa (the unicode-rbnf fallback does not cover them). Each language composes ordinals differently:

- **cs/pl** — both words of a compound ordinal inflect: `dvacátý první`, `dwudziesty pierwszy`. Round hundreds have dedicated forms (`dvoustý`, `dwusetny`) added as small tables.
- **uk** — only the final word inflects: `двадцять перший`. The existing table already carries the round hundreds (`двохсотий`).
- **eu** — cardinal + `-garren`, with irregular `lehen` (1st) and the `bost` → `bosgarren` final-consonant assimilation.
- **fa** — irregular `اول` (1st), the ordinal names up to 20 from the existing vocabulary, beyond that cardinal + `م` (`ام` after a vowel: `سی‌ام`).

Farsi also gains `is_fractional` from its existing fraction table (`نیم` → 0.5, `سوم` → 1/3).

Hand-verified anchors per language in `tests/test_ordinal_anchors.py`, including compounds, round hundreds/thousands and the invalid-input error path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)