### PR TITLE
feat: arabic number support

### DIFF
--- a/ovos_number_parser/__init__.py
+++ b/ovos_number_parser/__init__.py
@@ -4,6 +4,8 @@ from typing import Union
 from unicode_rbnf import RbnfEngine, FormatPurpose
 
 from ovos_number_parser.numbers_ast import AST
+from ovos_number_parser.numbers_ar import pronounce_number_ar, pronounce_ordinal_ar, extract_number_ar, \
+    is_fractional_ar, is_ordinal_ar, nice_number_ar
 from ovos_number_parser.numbers_az import numbers_to_digits_az, extract_number_az, is_fractional_az, pronounce_number_az
 from ovos_number_parser.numbers_ca import numbers_to_digits_ca, pronounce_number_ca, is_fractional_ca, extract_number_ca
 from ovos_number_parser.numbers_cs import numbers_to_digits_cs, pronounce_number_cs, is_fractional_cs, \
@@ -61,7 +63,7 @@ from ovos_number_parser.util import Scale, GrammaticalGender, DigitPronunciation
 # --- generic language fallbacks -------------------------------------------
 
 _NICE_NUMBER_FNS = {
-    "az": nice_number_az, "ca": nice_number_ca, "cs": nice_number_cs,
+    "ar": nice_number_ar, "az": nice_number_az, "ca": nice_number_ca, "cs": nice_number_cs,
     "da": nice_number_da, "de": nice_number_de, "es": nice_number_es,
     "eu": nice_number_eu, "fa": nice_number_fa, "fr": nice_number_fr,
     "hu": nice_number_hu, "it": nice_number_it, "nl": nice_number_nl,
@@ -81,7 +83,7 @@ _FRACTION_NUMERATOR_OVERRIDES = {
 
 # words that may join two spoken numbers ("vingt et un", "sto in ena")
 _NUMBER_CONNECTORS = {
-    "ca": {"i"}, "da": {"og"}, "en": {"and"}, "es": {"y"}, "eu": {"eta"},
+    "ar": {"و"}, "ca": {"i"}, "da": {"og"}, "en": {"and"}, "es": {"y"}, "eu": {"eta"},
     "fr": {"et"}, "it": {"e"}, "nl": {"en"}, "sv": {"och"},
     "fa": {"و"}, "sl": {"in"}, "hu": set(),
 }
@@ -299,6 +301,8 @@ def pronounce_number(number: Union[int, float], lang: str,
         return pronounce_number_en(number, places, short_scale, scientific, ordinals)
     if lang.startswith("az"):
         return pronounce_number_az(number, places, short_scale, scientific, ordinals)
+    if lang.startswith("ar"):
+        return pronounce_number_ar(number, places, scientific, ordinals)
     if lang.startswith("ca"):
         return pronounce_number_ca(number, places)
     if lang.startswith("ast"):
@@ -408,6 +412,8 @@ def pronounce_ordinal(number: Union[int, float], lang: str,
         return MWL.pronounce_ordinal(number, scale=scale, gender=gender)
     if lang.startswith("ast"):
         return AST.pronounce_ordinal(number, scale=scale, gender=gender)
+    if lang.startswith("ar"):
+        return pronounce_ordinal_ar(number)
     if lang.startswith("da"):
         return pronounce_ordinal_da(number)
     if lang.startswith("de"):
@@ -471,6 +477,8 @@ def extract_number(text: str, lang: str,
         return extract_number_en(text, short_scale, ordinals)
     if lang.startswith("az"):
         return extract_number_az(text, short_scale, ordinals)
+    if lang.startswith("ar"):
+        return extract_number_ar(text, ordinals)
     if lang.startswith("ca"):
         return extract_number_ca(text, short_scale, ordinals)
     if lang.startswith("cs"):
@@ -542,6 +550,8 @@ def is_fractional(input_str: str, lang: str,
         return is_fractional_en(input_str, short_scale)
     if lang.startswith("az"):
         return is_fractional_az(input_str, short_scale)
+    if lang.startswith("ar"):
+        return is_fractional_ar(input_str, short_scale)
     if lang.startswith("ca"):
         return is_fractional_ca(input_str, short_scale)
     if lang.startswith("cs"):
@@ -605,6 +615,8 @@ def is_ordinal(input_str: str, lang: str) -> Union[bool, float]:
         return AST.is_ordinal(input_str)
     if lang.startswith("en"):
         return is_ordinal_en(input_str)
+    if lang.startswith("ar"):
+        return is_ordinal_ar(input_str)
     if lang.startswith("de"):
         val = is_ordinal_de(input_str)
         if isinstance(val, str) and val.endswith("."):

--- a/ovos_number_parser/numbers_ar.py
+++ b/ovos_number_parser/numbers_ar.py
@@ -1,0 +1,593 @@
+"""Number tools for Modern Standard Arabic.
+
+Pronunciation defaults to the masculine citation forms (the forms used for
+counting in the abstract). Extraction accepts both genders, since Arabic
+numerals 3-10 take the opposite gender of the counted noun (gender
+polarity), both nominative and oblique dual/plural case endings
+(``اثنان``/``اثنين``, ``عشرون``/``عشرين``), and both Western (0-9) and
+Eastern Arabic-Indic (٠-٩) digits.
+"""
+
+from ovos_number_parser.util import convert_to_mixed_fraction
+
+_AR_SEPARATOR = " و"  # the conjunction attaches to the following word
+
+# Arabic-Indic digits and decimal/thousands separators, hamza/taa
+# normalization and diacritics stripping used to match typed variants
+_NORM_TABLE = {ord(e): w for e, w in zip("٠١٢٣٤٥٦٧٨٩", "0123456789")}
+_NORM_TABLE[ord("٫")] = "."  # Arabic decimal separator
+_NORM_TABLE[ord("٬")] = None  # Arabic thousands separator
+_NORM_TABLE[ord("أ")] = "ا"
+_NORM_TABLE[ord("إ")] = "ا"
+_NORM_TABLE[ord("آ")] = "ا"
+_NORM_TABLE[ord("ى")] = "ي"
+_NORM_TABLE[ord("ة")] = "ه"
+_NORM_TABLE[ord("ـ")] = None  # tatweel
+for _c in range(0x064B, 0x0653):  # tashkeel (fathatan .. sukun)
+    _NORM_TABLE[_c] = None
+_NORM_TABLE[0x0670] = None  # superscript alef
+
+
+def _normalize_ar(text: str) -> str:
+    return text.translate(_NORM_TABLE)
+
+
+# masculine citation forms used for pronunciation
+_ONES_AR = ["صفر", "واحد", "اثنان", "ثلاثة", "أربعة", "خمسة",
+            "ستة", "سبعة", "ثمانية", "تسعة", "عشرة"]
+# feminine forms, accepted in extraction (gender polarity)
+_ONES_FEM_AR = ["", "واحدة", "اثنتان", "ثلاث", "أربع", "خمس",
+                "ست", "سبع", "ثمان", "تسع", "عشر"]
+_TENS_AR = {20: "عشرون", 30: "ثلاثون", 40: "أربعون", 50: "خمسون",
+            60: "ستون", 70: "سبعون", 80: "ثمانون", 90: "تسعون"}
+# 300-900 are written fused: feminine unit + مئة
+_HUNDREDS_AR = {100: "مئة", 200: "مئتان", 300: "ثلاثمئة", 400: "أربعمئة",
+                500: "خمسمئة", 600: "ستمئة", 700: "سبعمئة",
+                800: "ثمانمئة", 900: "تسعمئة"}
+
+# singular / dual / plural (3-10) of the scale words
+_SCALES_AR = [
+    (1000, "ألف", "ألفان", "آلاف"),
+    (1000000, "مليون", "مليونان", "ملايين"),
+    (1000000000, "مليار", "ملياران", "مليارات"),
+    (1000000000000, "تريليون", "تريليونان", "تريليونات"),
+]
+
+_MINUS_AR = "سالب"
+_DECIMAL_AR = "فاصلة"
+_INFINITY_AR = "ما لا نهاية"
+
+# fraction nouns: denominator -> (singular, dual, plural)
+_FRACTIONS_AR = {
+    2: ("نصف", "نصفان", "أنصاف"),
+    3: ("ثلث", "ثلثان", "أثلاث"),
+    4: ("ربع", "ربعان", "أرباع"),
+    5: ("خمس", "خمسان", "أخماس"),
+    6: ("سدس", "سدسان", "أسداس"),
+    7: ("سبع", "سبعان", "أسباع"),
+    8: ("ثمن", "ثمنان", "أثمان"),
+    9: ("تسع", "تسعان", "أتساع"),
+    10: ("عشر", "عشران", "أعشار"),
+}
+
+# ordinal stems (without the article); 1 is irregular, 1 in compounds is حادي
+_ORDINAL_STEMS_AR = {1: "أول", 2: "ثاني", 3: "ثالث", 4: "رابع", 5: "خامس",
+                     6: "سادس", 7: "سابع", 8: "ثامن", 9: "تاسع", 10: "عاشر"}
+_ORDINAL_COMPOUND_UNIT_AR = {1: "حادي", 2: "ثاني", 3: "ثالث", 4: "رابع",
+                             5: "خامس", 6: "سادس", 7: "سابع", 8: "ثامن",
+                             9: "تاسع"}
+# feminine ordinal stems, accepted in extraction
+_ORDINAL_STEMS_FEM_AR = {1: "أولى", 2: "ثانية", 3: "ثالثة", 4: "رابعة",
+                         5: "خامسة", 6: "سادسة", 7: "سابعة", 8: "ثامنة",
+                         9: "تاسعة", 10: "عاشرة"}
+
+
+# ---------------------------------------------------------------------------
+# pronunciation
+# ---------------------------------------------------------------------------
+
+def _cardinal_two_digit_ar(number: int) -> str:
+    """0-99 in masculine citation forms; units come before tens."""
+    if number <= 10:
+        return _ONES_AR[number]
+    if number == 11:
+        return "أحد عشر"
+    if number == 12:
+        return "اثنا عشر"
+    if number < 20:
+        return _ONES_AR[number - 10] + " عشر"
+    tens, unit = divmod(number, 10)
+    if unit == 0:
+        return _TENS_AR[tens * 10]
+    return _ONES_AR[unit] + _AR_SEPARATOR + _TENS_AR[tens * 10]
+
+
+def _cardinal_three_digit_ar(number: int) -> str:
+    """0-999 in masculine citation forms."""
+    if number < 100:
+        return _cardinal_two_digit_ar(number)
+    hundreds, rest = divmod(number, 100)
+    result = _HUNDREDS_AR[hundreds * 100]
+    if rest:
+        result += _AR_SEPARATOR + _cardinal_two_digit_ar(rest)
+    return result
+
+
+def _cardinal_ar(number: int) -> str:
+    if number < 1000:
+        return _cardinal_three_digit_ar(number)
+    parts = []
+    remainder = number
+    for value, singular, dual, plural in reversed(_SCALES_AR):
+        count, remainder = divmod(remainder, value)
+        if not count:
+            continue
+        if count == 1:
+            parts.append(singular)
+        elif count == 2:
+            parts.append(dual)
+        elif 3 <= count <= 10:
+            # scale nouns are masculine, so 3-10 take the ة-marked numeral
+            parts.append(_ONES_AR[count] + " " + plural)
+        else:
+            parts.append(_cardinal_ar(count) + " " + singular)
+    if remainder:
+        parts.append(_cardinal_three_digit_ar(remainder))
+    return _AR_SEPARATOR.join(parts)
+
+
+def pronounce_number_ar(number, places=2, scientific=False, ordinals=False):
+    """
+    Convert a number to its spoken Modern Standard Arabic equivalent.
+
+    Uses masculine citation forms; the decimal part is read digit by digit
+    after "فاصلة" (e.g. 5.2 -> "خمسة فاصلة اثنان").
+
+    Args:
+        number (float or int): the number to pronounce
+        places (int): maximum decimal places to speak
+        scientific (bool): pronounce in scientific notation
+        ordinals (bool): pronounce in ordinal form "الأول" instead of "واحد"
+    Returns:
+        (str): The pronounced number
+    """
+    if number == float("inf"):
+        return _INFINITY_AR
+    if number == float("-inf"):
+        return _MINUS_AR + " " + _INFINITY_AR
+    if scientific:
+        if number == 0:
+            return _ONES_AR[0]
+        n, power = ('%E' % number).replace("+", "").split("E")
+        power = int(power)
+        if power != 0:
+            mantissa = pronounce_number_ar(abs(float(n)), places)
+            exponent = pronounce_number_ar(abs(power), places)
+            return "{}{} في عشرة أس {}{}".format(
+                _MINUS_AR + " " if float(n) < 0 else "", mantissa,
+                _MINUS_AR + " " if power < 0 else "", exponent)
+    if ordinals:
+        return pronounce_ordinal_ar(number)
+    if number < 0:
+        return _MINUS_AR + " " + pronounce_number_ar(abs(number), places)
+
+    whole = int(number)
+    result = _cardinal_ar(whole)
+    if isinstance(number, float) and number != whole and places > 0:
+        digits = ("%." + str(places) + "f") % (number - whole)
+        digits = digits.split(".")[1].rstrip("0")
+        if digits:
+            result += " " + _DECIMAL_AR + " " + \
+                " ".join(_ONES_AR[int(d)] for d in digits)
+    return result
+
+
+def pronounce_ordinal_ar(number):
+    """
+    Pronounce a number as a Modern Standard Arabic ordinal (masculine,
+    with the definite article), e.g. 1 -> "الأول", 25 -> "الخامس والعشرون".
+
+    Args:
+        number (int): the number to pronounce
+    Returns:
+        (str): the ordinal in Arabic
+    """
+    number = int(number)
+    if number <= 0:
+        raise ValueError("Arabic ordinals start at 1")
+    if number <= 10:
+        return "ال" + _ORDINAL_STEMS_AR[number]
+    if number < 20:
+        return "ال" + _ORDINAL_COMPOUND_UNIT_AR[number - 10] + " عشر"
+    if number < 100:
+        tens, unit = divmod(number, 10)
+        tens_word = "ال" + _TENS_AR[tens * 10]
+        if unit == 0:
+            return tens_word
+        return "ال" + _ORDINAL_COMPOUND_UNIT_AR[unit] + " و" + tens_word
+    # beyond 99 Arabic uses the definite cardinal ("المئة", "الألف")
+    return "ال" + _cardinal_ar(number)
+
+
+def nice_number_ar(number, speech=True, denominators=range(1, 11)):
+    """Arabic helper for nice_number
+
+    Formats a float as a whole number plus an Arabic fraction noun, e.g.
+    4.5 becomes "4 ونصف" for speech and "4 1/2" for text. Fraction nouns
+    exist for denominators 2-10 (نصف, ثلث, ربع, ...); the dual is used for
+    a numerator of 2 (ثلثان) and the plural for 3-10 (ثلاثة أرباع).
+
+    Args:
+        number (int or float): the float to format
+        speech (bool): format for speech (True) or display (False)
+        denominators (iter of ints): denominators to use, default [1 .. 10]
+    Returns:
+        (str): The formatted string.
+    """
+    result = convert_to_mixed_fraction(number, denominators)
+    if not result:
+        return str(round(number, 3))
+    whole, num, den = result
+    if not speech:
+        if num == 0:
+            return str(whole)
+        return '{} {}/{}'.format(whole, num, den)
+    if num == 0:
+        return str(whole)
+    if den in _FRACTIONS_AR:
+        singular, dual, plural = _FRACTIONS_AR[den]
+        if num == 1:
+            frac = singular
+        elif num == 2:
+            frac = dual
+        else:
+            frac = '{} {}'.format(num, plural)
+    elif num == 1:
+        frac = 'جزء من {}'.format(_cardinal_ar(den))
+    else:
+        frac = '{} أجزاء من {}'.format(num, _cardinal_ar(den))
+    if whole == 0:
+        return frac
+    return '{} و{}'.format(whole, frac)
+
+
+# ---------------------------------------------------------------------------
+# extraction
+# ---------------------------------------------------------------------------
+
+def _norm_keys(words):
+    return {_normalize_ar(w) for w in words}
+
+
+def _norm_map(mapping):
+    return {_normalize_ar(k): v for k, v in mapping.items()}
+
+
+def _build_lookup():
+    units = {}
+    for i, w in enumerate(_ONES_AR):
+        units[w] = i
+    for i, w in enumerate(_ONES_FEM_AR):
+        if w:
+            units[w] = i
+    units["اثنين"] = 2  # oblique masculine dual
+    units["اثنتين"] = 2  # oblique feminine dual
+    units["ثماني"] = 8  # alternative feminine 8
+    tens = {}
+    for value, word in _TENS_AR.items():
+        tens[word] = value
+        tens[word[:-2] + "ين"] = value  # oblique case: عشرين, ثلاثين ...
+    hundreds = {"مئة": 100, "مائة": 100}
+    for value, word in _HUNDREDS_AR.items():
+        if value >= 200:
+            hundreds[word] = value
+            hundreds[word.replace("مئة", "مائة")] = value
+    hundreds.update({"مئتين": 200, "مائتين": 200, "ثمانيمئة": 800,
+                     "ثمانيمائة": 800})
+    scales = {}
+    scale_duals = {}
+    for value, singular, dual, plural in _SCALES_AR:
+        scales[singular] = value
+        scales[plural] = value
+        scale_duals[dual] = 2 * value
+    scales.update({"ألفا": 1000, "ألوف": 1000, "مليونا": 1000000,
+                   "مليارا": 1000000000})
+    scale_duals.update({"ألفين": 2000, "مليونين": 2000000,
+                        "مليارين": 2000000000})
+    # unambiguous fraction words usable inside a number ("خمسة ونصف")
+    fractions = {"نصف": 0.5, "ثلث": 1 / 3, "ربع": 0.25, "سدس": 1 / 6,
+                 "ثمن": 0.125}
+    return (_norm_map(units), _norm_map(tens), _norm_map(hundreds),
+            _norm_map(scales), _norm_map(scale_duals), _norm_map(fractions))
+
+
+(_UNITS_LOOKUP, _TENS_LOOKUP, _HUNDREDS_LOOKUP, _SCALES_LOOKUP,
+ _SCALE_DUALS_LOOKUP, _FRACTIONS_LOOKUP) = _build_lookup()
+
+_TEEN_FIRST_LOOKUP = _norm_map({"أحد": 1, "إحدى": 1, "اثنا": 2, "اثني": 2,
+                                "اثنتا": 2, "اثنتي": 2})
+_TEEN_SECOND_LOOKUP = _norm_keys({"عشر", "عشرة"})
+_MINUS_LOOKUP = _norm_keys({"سالب", "ناقص"})
+_DECIMAL_LOOKUP = _norm_keys({"فاصلة", "فاصله"})
+_HUNDRED_MULT_LOOKUP = _norm_keys({"مئة", "مائة"})
+
+_ORDINAL_UNITS_LOOKUP = _norm_map(
+    {stem: value for value, stem in _ORDINAL_STEMS_AR.items()})
+_ORDINAL_UNITS_LOOKUP.update(_norm_map(
+    {stem: value for value, stem in _ORDINAL_STEMS_FEM_AR.items()}))
+_ORDINAL_UNITS_LOOKUP.update(_norm_map({"حادي": 1, "حادية": 1}))
+
+
+def _is_number(s):
+    try:
+        float(s)
+        return True
+    except ValueError:
+        return False
+
+
+def _tokenize_ar(text):
+    """Normalize and split, detaching the attached conjunction "و"."""
+    tokens = []
+    for token in _normalize_ar(text).split():
+        token = token.strip(".,!?;:؟،؛")
+        if not token:
+            continue
+        vocab = (_UNITS_LOOKUP, _TENS_LOOKUP, _HUNDREDS_LOOKUP,
+                 _SCALES_LOOKUP, _SCALE_DUALS_LOOKUP, _FRACTIONS_LOOKUP,
+                 _TEEN_FIRST_LOOKUP, _ORDINAL_UNITS_LOOKUP)
+        whole_word = any(token in v for v in (
+            _UNITS_LOOKUP, _TENS_LOOKUP, _HUNDREDS_LOOKUP, _SCALES_LOOKUP,
+            _SCALE_DUALS_LOOKUP, _FRACTIONS_LOOKUP, _TEEN_FIRST_LOOKUP,
+            _ORDINAL_UNITS_LOOKUP)) or token in _TEEN_SECOND_LOOKUP
+        if not whole_word and len(token) > 1 and token[0] == "و" and (
+                any(token[1:] in v for v in vocab) or
+                token[1:] in _TEEN_SECOND_LOOKUP or
+                token[1:].startswith("ال") and
+                any(token[3:] in v for v in vocab)):
+            tokens.append("و")
+            token = token[1:]
+        tokens.append(token)
+    return tokens
+
+
+def _parse_ordinal_span(tokens, i):
+    """Try to read an ordinal starting at tokens[i].
+
+    Returns (value, next_index) or (None, i)."""
+    def strip_article(tok):
+        return tok[2:] if tok.startswith("ال") else tok
+
+    tok = strip_article(tokens[i])
+    if tok in _ORDINAL_UNITS_LOOKUP:
+        unit = _ORDINAL_UNITS_LOOKUP[tok]
+        j = i + 1
+        # teens: "الحادي عشر" = 11
+        if j < len(tokens) and strip_article(tokens[j]) in _TEEN_SECOND_LOOKUP:
+            return 10 + unit, j + 1
+        # compounds: "الخامس والعشرون" = 25
+        if j + 1 < len(tokens) and tokens[j] == "و" and \
+                strip_article(tokens[j + 1]) in _TENS_LOOKUP:
+            return unit + _TENS_LOOKUP[strip_article(tokens[j + 1])], j + 2
+        return unit, j
+    if tok in _TENS_LOOKUP and tokens[i].startswith("ال"):
+        return _TENS_LOOKUP[tok], i + 1
+    return None, i
+
+
+def extract_numbers_ar(text, short_scale=True, ordinals=False):
+    """
+    Takes in a string and extracts a list of numbers.
+
+    Accepts both genders of the numerals, nominative and oblique case
+    endings, Eastern Arabic-Indic digits and the "٫" decimal separator.
+
+    Args:
+        text (str): the string to extract numbers from
+        short_scale (bool): ignored, Arabic scale words are unambiguous
+        ordinals (bool): consider ordinal numbers ("الثالث" = 3)
+    Returns:
+        list: list of extracted numbers as floats
+    """
+    tokens = _tokenize_ar(text)
+    results = []
+    i = 0
+    n = len(tokens)
+    while i < n:
+        tok = tokens[i]
+        negative = False
+        if tok in _MINUS_LOOKUP and i + 1 < n:
+            negative = True
+            i += 1
+            tok = tokens[i]
+        if ordinals:
+            value, j = _parse_ordinal_span(tokens, i)
+            if value is not None:
+                results.append(-value if negative else value)
+                i = j
+                continue
+        value, j = _parse_number_span(tokens, i)
+        if value is None:
+            i += 1
+            continue
+        # decimal part: "فاصلة" + digits or a number
+        if j < n and tokens[j] in _DECIMAL_LOOKUP:
+            frac, j2 = _parse_decimal_part(tokens, j + 1)
+            if frac is not None:
+                value += frac
+                j = j2
+        results.append(-value if negative else value)
+        i = j
+    return results
+
+
+def _parse_number_span(tokens, i):
+    """Parse one number starting at tokens[i].
+
+    Returns (value, next_index); value is None if no number starts here."""
+    total = 0
+    current = 0
+    started = False
+    n = len(tokens)
+    j = i
+    while j < n:
+        tok = tokens[j]
+        if tok == "و" and started and j + 1 < n:
+            # the conjunction only continues the number if a number word
+            # follows and forms part of the same number
+            nxt = tokens[j + 1]
+            if (nxt in _UNITS_LOOKUP or nxt in _TENS_LOOKUP or
+                    nxt in _HUNDREDS_LOOKUP or nxt in _SCALES_LOOKUP or
+                    nxt in _SCALE_DUALS_LOOKUP or
+                    nxt in _TEEN_FIRST_LOOKUP or
+                    nxt in _FRACTIONS_LOOKUP):
+                j += 1
+                continue
+            break
+        if _is_number(tok):
+            if started:
+                break
+            value = float(tok)
+            if value.is_integer():
+                value = int(value)
+            return value, j + 1
+        # teens: unit word followed by عشر/عشرة
+        if (tok in _TEEN_FIRST_LOOKUP or
+                (tok in _UNITS_LOOKUP and 1 <= _UNITS_LOOKUP[tok] <= 9)) and \
+                j + 1 < n and tokens[j + 1] in _TEEN_SECOND_LOOKUP:
+            unit = _TEEN_FIRST_LOOKUP.get(tok) or _UNITS_LOOKUP[tok]
+            current += 10 + unit
+            started = True
+            j += 2
+            continue
+        if tok in _UNITS_LOOKUP:
+            # unit followed by مئة multiplies: "ثلاث مئة" = 300
+            if j + 1 < n and tokens[j + 1] in _HUNDRED_MULT_LOOKUP and \
+                    1 <= _UNITS_LOOKUP[tok] <= 9:
+                current += _UNITS_LOOKUP[tok] * 100
+                started = True
+                j += 2
+                continue
+            current += _UNITS_LOOKUP[tok]
+            started = True
+            j += 1
+            continue
+        if tok in _TENS_LOOKUP:
+            current += _TENS_LOOKUP[tok]
+            started = True
+            j += 1
+            continue
+        if tok in _HUNDREDS_LOOKUP:
+            current += _HUNDREDS_LOOKUP[tok]
+            started = True
+            j += 1
+            continue
+        if tok in _SCALES_LOOKUP:
+            total += (current if current else 1) * _SCALES_LOOKUP[tok]
+            current = 0
+            started = True
+            j += 1
+            continue
+        if tok in _SCALE_DUALS_LOOKUP:
+            total += _SCALE_DUALS_LOOKUP[tok]
+            current = 0
+            started = True
+            j += 1
+            continue
+        if tok in _FRACTIONS_LOOKUP:
+            current += _FRACTIONS_LOOKUP[tok]
+            started = True
+            j += 1
+            break  # a fraction noun ends the number
+        break
+    if not started:
+        return None, i
+    return total + current, j
+
+
+def _parse_decimal_part(tokens, i):
+    """Parse what follows "فاصلة".
+
+    A run of bare digit words (no conjunction) is read digit by digit
+    ("فاصلة اثنان خمسة" = .25); otherwise the following number N with d
+    integer digits is N / 10^d ("فاصلة خمسة وعشرون" = .25).
+
+    Returns (fraction, next_index) or (None, i)."""
+    n = len(tokens)
+    digits = []
+    j = i
+    while j < n and tokens[j] in _UNITS_LOOKUP and \
+            _UNITS_LOOKUP[tokens[j]] <= 9 and \
+            not (j + 1 < n and tokens[j + 1] in _TEEN_SECOND_LOOKUP) and \
+            not (j + 1 < n and tokens[j + 1] in _HUNDRED_MULT_LOOKUP):
+        digits.append(_UNITS_LOOKUP[tokens[j]])
+        j += 1
+        if j < n and tokens[j] == "و":
+            digits = None
+            break
+    if digits:
+        return sum(d / 10 ** (k + 1) for k, d in enumerate(digits)), j
+    value, j = _parse_number_span(tokens, i)
+    if value is None or value != int(value):
+        return None, i
+    return value / 10 ** len(str(int(value))), j
+
+
+def extract_number_ar(text, ordinals=False):
+    """
+    Extract the first number found in Modern Standard Arabic text.
+
+    Args:
+        text (str): the string to extract a number from
+        ordinals (bool): consider ordinal numbers ("الثالث" = 3)
+    Returns:
+        (int, float or False): the extracted number, or False if the text
+                               contains no number
+    """
+    numbers = extract_numbers_ar(text, ordinals=ordinals)
+    if not numbers:
+        return False
+    value = numbers[0]
+    if isinstance(value, float) and value.is_integer():
+        return int(value)
+    return value
+
+
+def is_fractional_ar(input_str, short_scale=True):
+    """
+    Check if the given word is an Arabic fraction noun.
+
+    Recognizes the fraction nouns for 1/2 .. 1/10 (نصف, ثلث, ربع, خمس,
+    سدس, سبع, ثمن, تسع, عشر), with or without the definite article.
+
+    Args:
+        input_str (str): the string to check if fractional
+        short_scale (bool): ignored, present for API compatibility
+    Returns:
+        (bool) or (float): False if not a fraction, otherwise the fraction
+    """
+    word = _normalize_ar(input_str.strip())
+    if word.startswith("ال"):
+        word = word[2:]
+    for den, (singular, dual, plural) in _FRACTIONS_AR.items():
+        if word == _normalize_ar(singular):
+            return 1.0 / den
+    return False
+
+
+def is_ordinal_ar(input_str):
+    """
+    Check if the given text is an Arabic ordinal number.
+
+    Args:
+        input_str (str): the string to check if ordinal
+    Returns:
+        (bool) or (int): False if not an ordinal, otherwise the number
+    """
+    tokens = _tokenize_ar(input_str)
+    if not tokens:
+        return False
+    value, j = _parse_ordinal_span(tokens, 0)
+    if value is not None and j == len(tokens):
+        return value
+    return False

--- a/tests/test_lang_parity.py
+++ b/tests/test_lang_parity.py
@@ -9,7 +9,7 @@ from ovos_number_parser import (extract_number, is_fractional, is_ordinal,
                                 numbers_to_digits, pronounce_fraction,
                                 pronounce_number, pronounce_ordinal)
 
-LANGS = ["az", "ast", "ca", "cs", "da", "de", "en", "es", "eu", "fa", "fr",
+LANGS = ["ar", "az", "ast", "ca", "cs", "da", "de", "en", "es", "eu", "fa", "fr",
          "gl", "hu", "it", "mwl", "nl", "pl", "pt", "ru", "sl", "sv", "uk"]
 
 

--- a/tests/test_number_parser_ar.py
+++ b/tests/test_number_parser_ar.py
@@ -1,0 +1,182 @@
+import unittest
+
+from ovos_number_parser import (extract_number, pronounce_number,
+                                pronounce_ordinal, pronounce_fraction,
+                                is_fractional, is_ordinal, numbers_to_digits)
+
+
+class TestArabicPronounce(unittest.TestCase):
+    """Anchors for spoken Modern Standard Arabic numbers (masculine forms)."""
+
+    def test_pronounce_number(self):
+        expected = {
+            0: 'صفر', 1: 'واحد', 2: 'اثنان', 3: 'ثلاثة', 4: 'أربعة',
+            5: 'خمسة', 6: 'ستة', 7: 'سبعة', 8: 'ثمانية', 9: 'تسعة',
+            10: 'عشرة', 11: 'أحد عشر', 12: 'اثنا عشر', 13: 'ثلاثة عشر',
+            14: 'أربعة عشر', 15: 'خمسة عشر', 16: 'ستة عشر', 17: 'سبعة عشر',
+            18: 'ثمانية عشر', 19: 'تسعة عشر', 20: 'عشرون',
+            # units come before tens, joined by the conjunction و
+            21: 'واحد وعشرون', 25: 'خمسة وعشرون', 30: 'ثلاثون',
+            42: 'اثنان وأربعون', 50: 'خمسون', 66: 'ستة وستون', 70: 'سبعون',
+            80: 'ثمانون', 90: 'تسعون', 99: 'تسعة وتسعون', 100: 'مئة',
+            101: 'مئة وواحد', 123: 'مئة وثلاثة وعشرون',
+            # duals
+            200: 'مئتان', 2000: 'ألفان', 2000000: 'مليونان',
+            300: 'ثلاثمئة', 500: 'خمسمئة', 999: 'تسعمئة وتسعة وتسعون',
+            1000: 'ألف', 1985: 'ألف وتسعمئة وخمسة وثمانون',
+            2023: 'ألفان وثلاثة وعشرون',
+            # scale nouns are masculine, 3-10 take the ة-marked numeral
+            3000: 'ثلاثة آلاف', 10000: 'عشرة آلاف', 100000: 'مئة ألف',
+            1000000: 'مليون', 3000000: 'ثلاثة ملايين',
+            1000000000: 'مليار',
+        }
+        for number, spoken in expected.items():
+            with self.subTest(number=number):
+                self.assertEqual(pronounce_number(number, lang="ar"), spoken)
+
+    def test_pronounce_negative_and_decimal(self):
+        expected = {-7: 'سالب سبعة', -42: 'سالب اثنان وأربعون',
+                    5.2: 'خمسة فاصلة اثنان',
+                    5.25: 'خمسة فاصلة اثنان خمسة',
+                    0.5: 'صفر فاصلة خمسة',
+                    -3.5: 'سالب ثلاثة فاصلة خمسة'}
+        for number, spoken in expected.items():
+            with self.subTest(number=number):
+                self.assertEqual(pronounce_number(number, lang="ar"), spoken)
+
+    def test_pronounce_ordinal(self):
+        expected = {1: 'الأول', 2: 'الثاني', 3: 'الثالث', 4: 'الرابع',
+                    5: 'الخامس', 6: 'السادس', 7: 'السابع', 8: 'الثامن',
+                    9: 'التاسع', 10: 'العاشر', 11: 'الحادي عشر',
+                    12: 'الثاني عشر', 20: 'العشرون',
+                    21: 'الحادي والعشرون', 25: 'الخامس والعشرون',
+                    30: 'الثلاثون', 100: 'المئة', 1000: 'الألف'}
+        for number, spoken in expected.items():
+            with self.subTest(number=number):
+                self.assertEqual(pronounce_ordinal(number, lang="ar"), spoken)
+
+    def test_pronounce_fraction(self):
+        self.assertEqual(pronounce_fraction("1/2", lang="ar"), 'نصف')
+        self.assertEqual(pronounce_fraction("1/3", lang="ar"), 'ثلث')
+        self.assertEqual(pronounce_fraction("1/4", lang="ar"), 'ربع')
+        self.assertEqual(pronounce_fraction("2/3", lang="ar"), 'ثلثان')
+        self.assertEqual(pronounce_fraction("3/4", lang="ar"), 'ثلاثة أرباع')
+
+
+class TestArabicExtract(unittest.TestCase):
+    """Anchors for extracting numbers from Arabic text."""
+
+    def test_extract_number(self):
+        expected = {
+            0: 'صفر', 1: 'واحد', 2: 'اثنان', 3: 'ثلاثة', 10: 'عشرة',
+            11: 'أحد عشر', 12: 'اثنا عشر', 15: 'خمسة عشر', 20: 'عشرون',
+            25: 'خمسة وعشرون', 99: 'تسعة وتسعون', 100: 'مئة',
+            123: 'مئة وثلاثة وعشرون', 200: 'مئتان', 1000: 'ألف',
+            2000: 'ألفان', 3000: 'ثلاثة آلاف', 1000000: 'مليون',
+        }
+        for number, spoken in expected.items():
+            with self.subTest(spoken=spoken):
+                self.assertEqual(extract_number(spoken, lang="ar"), number)
+
+    def test_extract_gender_and_case_variants(self):
+        # numbers 3-10 show gender polarity: both genders are accepted
+        expected = {1: 'واحدة', 2: 'اثنتان', 3: 'ثلاث', 4: 'أربع',
+                    5: 'خمس', 8: 'ثمان', 10: 'عشر',
+                    # oblique case endings
+                    22: 'اثنين وعشرين', 200: 'مئتين', 2000: 'ألفين',
+                    # alternative hundred spelling and unfused hundreds
+                    100: 'مائة', 300: 'ثلاث مئة', 400: 'أربعمائة',
+                    # feminine teens
+                    11: 'إحدى عشرة', 13: 'ثلاث عشرة'}
+        for number, spoken in expected.items():
+            with self.subTest(spoken=spoken):
+                self.assertEqual(extract_number(spoken, lang="ar"), number)
+
+    def test_extract_negative_and_decimal(self):
+        expected = {-7: 'سالب سبعة', -9: 'ناقص تسعة',
+                    -42: 'سالب اثنان وأربعون',
+                    5.2: 'خمسة فاصلة اثنان',
+                    5.25: 'خمسة فاصلة خمسة وعشرون',
+                    3.14: 'ثلاثة فاصلة واحد أربعة',
+                    5.5: 'خمسة ونصف', 2.25: 'اثنان وربع',
+                    0.5: 'نصف', 0.25: 'ربع'}
+        for number, spoken in expected.items():
+            with self.subTest(spoken=spoken):
+                self.assertAlmostEqual(extract_number(spoken, lang="ar"),
+                                       number)
+
+    def test_extract_eastern_digits(self):
+        # Eastern Arabic-Indic digits and the ٫ decimal separator
+        self.assertEqual(extract_number("٢٥", lang="ar"), 25)
+        self.assertEqual(extract_number("لدي ٣ قطط", lang="ar"), 3)
+        self.assertAlmostEqual(extract_number("٥٫٢", lang="ar"), 5.2)
+        self.assertEqual(extract_number("١٩٨٥", lang="ar"), 1985)
+
+    def test_extract_from_sentence(self):
+        self.assertEqual(extract_number("لدي خمسة وعشرون كتاباً", lang="ar"),
+                         25)
+        self.assertEqual(extract_number("اشتريت ثلاث تفاحات", lang="ar"), 3)
+        self.assertEqual(
+            extract_number("هذا هو اليوم الثالث", lang="ar", ordinals=True), 3)
+        self.assertEqual(
+            extract_number("الخامس والعشرون", lang="ar", ordinals=True), 25)
+
+    def test_no_number(self):
+        self.assertIn(extract_number("مرحبا كيف حالك", lang="ar"),
+                      (False, None))
+        self.assertIn(extract_number("", lang="ar"), (False, None))
+
+    def test_is_fractional(self):
+        self.assertEqual(is_fractional("نصف", lang="ar"), 0.5)
+        self.assertEqual(is_fractional("ربع", lang="ar"), 0.25)
+        self.assertEqual(is_fractional("الربع", lang="ar"), 0.25)
+        self.assertAlmostEqual(is_fractional("ثلث", lang="ar"), 1 / 3)
+        self.assertAlmostEqual(is_fractional("خمس", lang="ar"), 0.2)
+        self.assertAlmostEqual(is_fractional("عشر", lang="ar"), 0.1)
+        self.assertFalse(is_fractional("كتاب", lang="ar"))
+
+    def test_is_ordinal(self):
+        self.assertEqual(is_ordinal("الأول", lang="ar"), 1)
+        self.assertEqual(is_ordinal("الأولى", lang="ar"), 1)
+        self.assertEqual(is_ordinal("الثالثة", lang="ar"), 3)
+        self.assertEqual(is_ordinal("الحادي عشر", lang="ar"), 11)
+        self.assertEqual(is_ordinal("الخامس والعشرون", lang="ar"), 25)
+        self.assertFalse(is_ordinal("مرحبا", lang="ar"))
+
+    def test_numbers_to_digits(self):
+        self.assertEqual(
+            numbers_to_digits("لدي خمسة وعشرون قطة", lang="ar"),
+            "لدي 25 قطة")
+
+
+class TestArabicRoundTrip(unittest.TestCase):
+    """pronounce_number output must be understood by extract_number."""
+
+    def test_round_trip(self):
+        numbers = list(range(0, 200)) + [
+            201, 222, 300, 345, 400, 456, 500, 678, 700, 891, 900, 999,
+            1000, 1001, 1234, 1985, 2000, 2023, 3000, 5000, 9999, 10000,
+            11000, 15000, 100000, 123456, 1000000, 2000000, 3000000,
+            1000000000, 2000000000]
+        for number in numbers:
+            with self.subTest(number=number):
+                spoken = pronounce_number(number, lang="ar")
+                self.assertEqual(extract_number(spoken, lang="ar"), number)
+
+    def test_round_trip_negative_and_decimal(self):
+        for number in [-7, -42, -100, 2.5, 3.14, 5.2, -3.5, 0.5, 5.25,
+                       0.75, 12.34]:
+            with self.subTest(number=number):
+                spoken = pronounce_number(number, lang="ar")
+                self.assertAlmostEqual(extract_number(spoken, lang="ar"),
+                                       number)
+
+    def test_round_trip_ordinals(self):
+        for number in range(1, 100):
+            with self.subTest(number=number):
+                spoken = pronounce_ordinal(number, lang="ar")
+                self.assertEqual(is_ordinal(spoken, lang="ar"), number)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds Modern Standard Arabic (`ar`) support to every public function: `pronounce_number`, `pronounce_ordinal`, `pronounce_fraction`, `extract_number`, `is_fractional`, `is_ordinal`, `numbers_to_digits`.

## Design
Arabic uses a dedicated `numbers_ar.py` module (like fa/ru/uk) rather than the `NumberVocabulary`/`RomanceNumberExtractor` engine, because Arabic number grammar does not fit the Romance shape:
- units come **before** tens, joined by the attached conjunction و: "خمسة وعشرون" = 25
- distinct **dual** word forms: اثنان (2), مئتان (200), ألفان (2000), مليونان
- **gender polarity**: numerals 3-10 take the opposite gender of the counted noun; pronunciation defaults to the masculine citation forms, extraction accepts both genders (ثلاثة/ثلاث) plus oblique case endings (عشرين, اثنين, مئتين, ألفين)
- Eastern Arabic-Indic digits ٠-٩ and the ٫ decimal separator are normalized early; diacritics, hamza variants and ة/ه spelling variants are normalized before matching
- negatives سالب/ناقص; decimals read digit-by-digit after فاصلة ("خمسة فاصلة اثنان" = 5.2); fraction nouns نصف/ثلث/ربع... with dual (ثلثان) and plural (ثلاثة أرباع) forms; ordinals with the definite article (الأول, الخامس والعشرون)

## Tests
- hand-verified anchors for pronunciation, ordinals, fractions, gender/case variants, Eastern digits, negatives, decimals, in-sentence extraction and no-number cases
- round-trip sweeps pronounce→extract over 0-199 plus representative values to 2 000 000 000, and ordinals 1-99
- `ar` added to the language parity suite