### PR TITLE
feat: Kabyle (kab) number support

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ fractional and ordinal numbers, and more.
 | `fr` (French)           | ✅                | 🚧                 | ✅              | ❌                 |
 | `hu` (Hungarian)        | ✅                | ✅                 | ❌              | ❌                 |
 | `it` (Italian)          | ✅                | 🚧                | ✅              | ❌                 |
+| `kab` (Kabyle)          | ✅                | ✅                 | ✅              | 🚧                 |
 | `nl` (Dutch)            | ✅                | ✅                 | ✅              | ✅                 |
 | `pl` (Polish)           | ✅                | 🚧                 | ✅              | ✅                 |
 | `pt` (Portuguese)       | ✅                | ✅                  | ✅              | ✅                |

--- a/docs/languages.md
+++ b/docs/languages.md
@@ -56,6 +56,25 @@ hundreds (`quinientos`, `setecientos`, `novecientos`), scale words including
 (`one hundred and one` = 101), digit grouping (`1,000,000`) and spoken-style
 comma pauses (`two thousand, twenty three`).
 
+## Kabyle
+
+Kabyle carries two numeral systems: the pan-Amazigh cardinals (`yiwen`,
+`sin`, `kṛaḍ`, ... `mraw`) and the Algerian-Arabic borrowed numerals used
+for everyday counting above ten (`ḥḍac` = 11, `ɛecrin` = 20, `mya` = 100,
+`alef` = 1000). Pronunciation uses the Amazigh forms for 0-10 and the
+Arabic-derived forms above ten, joining compounds with the conjunction `u`
+with the unit before the ten (`waḥed u ɛecrin` = 21). Extraction accepts
+both systems, feminine forms (`yiwet`, `snat`), additive Amazigh compounds
+(`mraw d yiwen` = 11) and diacritic-stripped spellings (`hdac`).
+
+Ordinals use `amezwaru` (f. `tamezwarut`) for "first" and `wis`/`tis` +
+cardinal otherwise. The only attested fraction noun is `azgen` (half).
+
+Coverage boundary: pronunciation spans 0–9999. The minus word, a
+decimal-separator word, ordinal suffix forms, larger scale words and
+further fraction nouns are not reliably attested and are deliberately
+omitted.
+
 ## Persian
 
 Numbers are written and parsed in Persian script (`بیست و یک` = 21). Both

--- a/ovos_number_parser/__init__.py
+++ b/ovos_number_parser/__init__.py
@@ -27,6 +27,8 @@ from ovos_number_parser.numbers_gl import pronounce_number_gl, extract_number_gl
 from ovos_number_parser.numbers_hu import pronounce_number_hu, pronounce_ordinal_hu, extract_number_hu, \
     is_fractional_hu, is_ordinal_hu, nice_number_hu
 from ovos_number_parser.numbers_it import (extract_number_it, pronounce_number_it, is_fractional_it)
+from ovos_number_parser.numbers_kab import (pronounce_number_kab, pronounce_ordinal_kab, extract_number_kab,
+                                             is_fractional_kab, is_ordinal_kab)
 from ovos_number_parser.numbers_mwl import MWL
 from ovos_number_parser.numbers_nl import numbers_to_digits_nl, pronounce_number_nl, pronounce_ordinal_nl, \
     extract_number_nl, is_fractional_nl
@@ -85,7 +87,7 @@ _FRACTION_NUMERATOR_OVERRIDES = {
 _NUMBER_CONNECTORS = {
     "ar": {"و"}, "ca": {"i"}, "da": {"og"}, "en": {"and"}, "es": {"y"}, "eu": {"eta"},
     "fr": {"et"}, "it": {"e"}, "nl": {"en"}, "sv": {"och"},
-    "fa": {"و"}, "sl": {"in"}, "hu": set(),
+    "fa": {"و"}, "sl": {"in"}, "hu": set(), "kab": {"u", "d", "ed"},
 }
 
 
@@ -327,6 +329,8 @@ def pronounce_number(number: Union[int, float], lang: str,
         return pronounce_number_hu(number, places, short_scale, scientific, ordinals)
     if lang.startswith("it"):
         return pronounce_number_it(number, places, short_scale, scientific)
+    if lang.startswith("kab"):
+        return pronounce_number_kab(number, places, ordinals, gender)
     if lang.startswith("nl"):
         return pronounce_number_nl(number, places, short_scale, scientific, ordinals)
     if lang.startswith("pl"):
@@ -438,6 +442,8 @@ def pronounce_ordinal(number: Union[int, float], lang: str,
         return pronounce_ordinal_fa(number)
     if lang.startswith("sl"):
         return pronounce_number_sl(number, ordinals=True)
+    if lang.startswith("kab"):
+        return pronounce_ordinal_kab(number, gender)
     # fallback to unicode RBNF
     try:
         engine = RbnfEngine.for_language(lang.split("-")[0])
@@ -499,6 +505,8 @@ def extract_number(text: str, lang: str,
         return extract_number_fr(text, short_scale, ordinals)
     if lang.startswith("it"):
         return extract_number_it(text, short_scale, ordinals)
+    if lang.startswith("kab"):
+        return extract_number_kab(text, short_scale, ordinals)
     if lang.startswith("nl"):
         return extract_number_nl(text, short_scale, ordinals)
     if lang.startswith("pl"):
@@ -570,6 +578,8 @@ def is_fractional(input_str: str, lang: str,
         return is_fractional_fr(input_str)
     if lang.startswith("it"):
         return is_fractional_it(input_str, short_scale)
+    if lang.startswith("kab"):
+        return is_fractional_kab(input_str, short_scale)
     if lang.startswith("nl"):
         return is_fractional_nl(input_str, short_scale)
     if lang.startswith("pl"):
@@ -628,6 +638,8 @@ def is_ordinal(input_str: str, lang: str) -> Union[bool, float]:
         return is_ordinal_gl(input_str)
     if lang.startswith("hu"):
         return is_ordinal_hu(input_str)
+    if lang.startswith("kab"):
+        return is_ordinal_kab(input_str)
     if lang.startswith("sl"):
         return is_ordinal_sl(input_str)
     return _is_ordinal_generic(input_str, lang)

--- a/ovos_number_parser/numbers_kab.py
+++ b/ovos_number_parser/numbers_kab.py
@@ -1,0 +1,267 @@
+"""Kabyle (Taqbaylit, ``kab``) number tools.
+
+Kabyle has two numeral systems in active use:
+
+- the pan-Amazigh (Berber) numerals, universally used for 1-10:
+  yiwen, sin, kṛaḍ, kuẓ, semmus, sḍis, sa, tam, tẓa, mraw
+- the Algerian-Arabic borrowed numerals, which carry everyday counting
+  above ten: ḥḍac (11), ɛecrin (20), mya (100), alef (1000), joined with
+  the conjunction "u" ("waḥed u ɛecrin" = 21, unit before ten)
+
+Pronunciation uses the Amazigh forms for 0-10 and the Arabic-derived
+forms above ten (the system with consistent attestation for large
+values). Extraction accepts both systems, including feminine forms
+(yiwet, snat, ...) and additive Amazigh compounds ("mraw d yiwen" = 11).
+
+Ordinals are formed with wis (masculine) / tis (feminine) + cardinal;
+"first" is the adjective amezwaru / tamezwarut.
+
+Sources:
+- https://en.wikipedia.org/wiki/Kabyle_language (grammar & numeral notes)
+- https://www.omniglot.com/language/numbers/kabyle.htm
+- https://www.languagesandnumbers.com/how-to-count-in-kabyle/en/kab/
+- https://fr.wikipedia.org/wiki/Num%C3%A9ration_amazighe
+"""
+import re
+from typing import Union
+
+from ovos_number_parser.util import GrammaticalGender
+
+# pan-Amazigh cardinals, masculine (pronunciation defaults)
+_UNITS_AMAZIGH_M = {0: "ilem", 1: "yiwen", 2: "sin", 3: "kṛaḍ", 4: "kuẓ",
+                    5: "semmus", 6: "sḍis", 7: "sa", 8: "tam", 9: "tẓa",
+                    10: "mraw"}
+# feminine counterparts (only 1 and 2 are pronounced; all are extracted)
+_UNITS_AMAZIGH_F = {1: "yiwet", 2: "snat", 3: "kṛaḍet", 4: "kuẓet",
+                    5: "semmuset", 6: "sḍiset", 7: "sat", 8: "tamet",
+                    9: "tẓat", 10: "mrawet"}
+
+# Arabic-derived cardinals (everyday counting system)
+_UNITS_LOAN = {1: "waḥed", 2: "tnayn", 3: "tlata", 4: "ṛebɛa", 5: "xemsa",
+               6: "setta", 7: "sebɛa", 8: "tmanya", 9: "tesɛa", 10: "ɛecṛa"}
+_TEENS_LOAN = {11: "ḥḍac", 12: "tnac", 13: "tleṭṭac", 14: "ṛbeɛṭac",
+               15: "xemseṭṭac", 16: "seṭṭac", 17: "sebeɛṭac",
+               18: "temmenṭac", 19: "tseɛṭac"}
+_TENS_LOAN = {20: "ɛecrin", 30: "tlatin", 40: "ṛebɛin", 50: "xemsin",
+              60: "settin", 70: "sebɛin", 80: "tmanyin", 90: "tsɛin"}
+_HUNDREDS_LOAN = {100: "mya", 200: "mitin", 300: "telt-mya", 400: "ṛebɛ-mya",
+                  500: "xems-mya", 600: "sett-mya", 700: "sebɛ-mya",
+                  800: "temn-mya", 900: "tesɛ-mya"}
+_THOUSANDS_LOAN = {1000: "alef", 2000: "juǧ alaf", 3000: "tlat-alaf",
+                   4000: "ṛebɛ-alaf", 5000: "xems-alaf", 6000: "sett-alaf",
+                   7000: "sebɛ-alaf", 8000: "temn-alaf", 9000: "tesɛ-alaf"}
+
+# conjunction joining number words ("waḥed u ɛecrin" = 21,
+# "mraw d yiwen" = 11)
+_CONNECTORS = {"u", "d", "ed"}
+
+_FRACTIONS = {"azgen": 0.5}  # half; other fraction nouns are not attested
+
+_ORDINAL_FIRST = {"amezwaru": 1, "tamezwarut": 1}
+_ORDINAL_MARKERS = {"wis", "tis"}
+
+
+def _normalize(token: str) -> str:
+    """Diacritic-tolerant lookup key (ṛ→r, ṭ→t, ḍ→d, ẓ→z, ḥ→h, ǧ→g)."""
+    table = str.maketrans("ṛṭḍẓḥǧṣč", "rtdzhgsc")
+    return token.lower().translate(table)
+
+
+def _build_word_map():
+    words = {}
+    for table in (_UNITS_AMAZIGH_M, _UNITS_AMAZIGH_F, _UNITS_LOAN,
+                  _TEENS_LOAN, _TENS_LOAN, _HUNDREDS_LOAN, _THOUSANDS_LOAN):
+        for val, word in table.items():
+            words[_normalize(word)] = val
+    for word, val in _FRACTIONS.items():
+        words[_normalize(word)] = val
+    return words
+
+
+_WORDS = _build_word_map()
+
+
+def _slot(val) -> str:
+    if val < 1:
+        return "frac"
+    if val >= 1000:
+        return "thousand"
+    if val >= 100:
+        return "hundred"
+    if 11 <= val <= 19:
+        return "teen"
+    if val == 10 or (val % 10 == 0 and val >= 20):
+        return "ten"
+    return "unit"
+
+
+def pronounce_number_kab(number: Union[int, float], places: int = 3,
+                         ordinals: bool = False,
+                         gender: GrammaticalGender = GrammaticalGender.MASCULINE) -> str:
+    """Pronounce a number in Kabyle.
+
+    Supports integers from 0 to 9999; the minus word and decimal-separator
+    word are not reliably attested, so negative and non-integer values are
+    rejected rather than guessed.
+    """
+    if ordinals:
+        return pronounce_ordinal_kab(number, gender)
+    if isinstance(number, float):
+        if not number.is_integer():
+            raise ValueError(
+                "Kabyle decimal pronunciation is not supported")
+        number = int(number)
+    if number < 0:
+        raise ValueError("Kabyle negative pronunciation is not supported")
+    if number > 9999:
+        raise OverflowError(
+            "Kabyle pronunciation is supported up to 9999")
+
+    if number <= 10:
+        if gender == GrammaticalGender.FEMININE and number in (1, 2):
+            return _UNITS_AMAZIGH_F[number]
+        return _UNITS_AMAZIGH_M[number]
+
+    parts = []
+    thousands = number // 1000 * 1000
+    hundreds = number % 1000 // 100 * 100
+    rest = number % 100
+    if thousands:
+        parts.append(_THOUSANDS_LOAN[thousands])
+    if hundreds:
+        parts.append(_HUNDREDS_LOAN[hundreds])
+    if rest:
+        if rest <= 10:
+            # units keep the Amazigh form even inside compounds when they
+            # stand alone; the Arabic-loan unit is used before a ten
+            parts.append(_UNITS_AMAZIGH_M[rest] if not parts
+                         else _UNITS_LOAN[rest])
+        elif rest in _TEENS_LOAN:
+            parts.append(_TEENS_LOAN[rest])
+        elif rest in _TENS_LOAN:
+            parts.append(_TENS_LOAN[rest])
+        else:
+            ten = rest // 10 * 10
+            unit = rest % 10
+            parts.append(f"{_UNITS_LOAN[unit]} u {_TENS_LOAN[ten]}")
+    return " u ".join(parts)
+
+
+def pronounce_ordinal_kab(number: Union[int, float],
+                          gender: GrammaticalGender = GrammaticalGender.MASCULINE) -> str:
+    """Ordinals: amezwaru "first", otherwise wis/tis + cardinal."""
+    number = int(number)
+    if number < 1:
+        raise ValueError("Kabyle ordinals start at 1")
+    if number == 1:
+        return "tamezwarut" if gender == GrammaticalGender.FEMININE \
+            else "amezwaru"
+    marker = "tis" if gender == GrammaticalGender.FEMININE else "wis"
+    return f"{marker} {pronounce_number_kab(number, gender=gender)}"
+
+
+def is_fractional_kab(input_str: str, short_scale: bool = False) -> Union[bool, float]:
+    """Only the well-attested "azgen" (half) is recognized."""
+    return _FRACTIONS.get(_normalize(input_str.strip())) or False
+
+
+def is_ordinal_kab(input_str: str) -> Union[bool, int]:
+    """Detect wis/tis + cardinal ordinals and amezwaru/tamezwarut."""
+    text = _normalize(input_str.strip())
+    if text in {_normalize(k) for k in _ORDINAL_FIRST}:
+        return 1
+    tokens = text.split()
+    if len(tokens) >= 2 and tokens[0] in _ORDINAL_MARKERS:
+        val = extract_number_kab(" ".join(tokens[1:]))
+        if val and float(val).is_integer():
+            return int(val)
+    return False
+
+
+def _token_values(tokens):
+    """Map cleaned tokens to (index, value) pairs, joining the multiword
+    and hyphenated hundred/thousand forms."""
+    vals = []
+    i = 0
+    while i < len(tokens):
+        tok = tokens[i]
+        two = f"{tok} {tokens[i + 1]}" if i + 1 < len(tokens) else None
+        two_hyphen = f"{tok}-{tokens[i + 1]}" if i + 1 < len(tokens) else None
+        if two and _normalize(two) in _WORDS:
+            vals.append((i, 2, _WORDS[_normalize(two)]))
+            i += 2
+            continue
+        if two_hyphen and _normalize(two_hyphen) in _WORDS:
+            vals.append((i, 2, _WORDS[_normalize(two_hyphen)]))
+            i += 2
+            continue
+        if _normalize(tok) in _WORDS:
+            vals.append((i, 1, _WORDS[_normalize(tok)]))
+            i += 1
+            continue
+        vals.append((i, 1, None))
+        i += 1
+    return vals
+
+
+def extract_number_kab(text: str, short_scale: bool = False,
+                       ordinals: bool = False) -> Union[int, float, bool]:
+    """Extract the first number from Kabyle text.
+
+    Understands digits, both numeral systems (Amazigh and Arabic-derived),
+    feminine forms, "u"/"d" joined compounds in either order
+    ("waḥed u ɛecrin" = 21, "mraw d yiwen" = 11) and the fraction azgen.
+    With ``ordinals=True``, wis/tis + cardinal and amezwaru return the
+    ordinal value.
+    """
+    tokens = [t.strip(".,!?;:()\"'") for t in text.lower().split()]
+    tokens = [t for t in tokens if t]
+
+    # ordinals
+    for i, tok in enumerate(tokens):
+        norm = _normalize(tok)
+        if ordinals:
+            if norm in {_normalize(k) for k in _ORDINAL_FIRST}:
+                return 1
+            if norm in _ORDINAL_MARKERS and i + 1 < len(tokens):
+                val = extract_number_kab(" ".join(tokens[i + 1:]))
+                if val is not False:
+                    return val
+
+    parsed = _token_values(tokens)
+    i = 0
+    while i < len(parsed):
+        idx, width, val = parsed[i]
+        tok = tokens[idx]
+        # digits
+        m = re.fullmatch(r"-?\d+(?:[.,]\d+)?", tok)
+        if m:
+            num = m.group().replace(",", ".")
+            return float(num) if "." in num else int(num)
+        if val is None:
+            i += 1
+            continue
+        # combine a run of number words joined directly or by u/d
+        total_parts = [val]
+        slots = {_slot(val)}
+        j = i + 1
+        while j < len(parsed):
+            nidx, nwidth, nval = parsed[j]
+            if nval is None:
+                # connectors may join two number words
+                if _normalize(tokens[nidx]) in _CONNECTORS \
+                        and j + 1 < len(parsed) and parsed[j + 1][2] is not None:
+                    j += 1
+                    continue
+                break
+            nslot = _slot(nval)
+            if nslot in slots:
+                break
+            total_parts.append(nval)
+            slots.add(nslot)
+            j += 1
+        total = sum(total_parts)
+        if isinstance(total, float) and total.is_integer():
+            total = int(total)
+        return total
+    return False

--- a/tests/test_lang_parity.py
+++ b/tests/test_lang_parity.py
@@ -10,7 +10,7 @@ from ovos_number_parser import (extract_number, is_fractional, is_ordinal,
                                 pronounce_number, pronounce_ordinal)
 
 LANGS = ["ar", "az", "ast", "ca", "cs", "da", "de", "en", "es", "eu", "fa", "fr",
-         "gl", "hu", "it", "mwl", "nl", "pl", "pt", "ru", "sl", "sv", "uk"]
+         "gl", "hu", "it", "kab", "mwl", "nl", "pl", "pt", "ru", "sl", "sv", "uk"]
 
 
 class TestLanguageParity(unittest.TestCase):

--- a/tests/test_number_parser_kab.py
+++ b/tests/test_number_parser_kab.py
@@ -1,0 +1,149 @@
+import unittest
+
+from ovos_number_parser import (extract_number, is_fractional, is_ordinal,
+                                pronounce_number, pronounce_ordinal)
+from ovos_number_parser.util import GrammaticalGender
+
+
+class TestPronounceNumberKab(unittest.TestCase):
+    def test_amazigh_units(self):
+        cases = [(0, "ilem"), (1, "yiwen"), (2, "sin"), (3, "kṛaḍ"),
+                 (4, "kuẓ"), (5, "semmus"), (6, "sḍis"), (7, "sa"),
+                 (8, "tam"), (9, "tẓa"), (10, "mraw")]
+        for n, expected in cases:
+            self.assertEqual(pronounce_number(n, "kab"), expected, n)
+
+    def test_feminine(self):
+        self.assertEqual(pronounce_number(1, "kab",
+                                          gender=GrammaticalGender.FEMININE),
+                         "yiwet")
+        self.assertEqual(pronounce_number(2, "kab",
+                                          gender=GrammaticalGender.FEMININE),
+                         "snat")
+
+    def test_teens(self):
+        cases = [(11, "ḥḍac"), (12, "tnac"), (13, "tleṭṭac"),
+                 (15, "xemseṭṭac"), (19, "tseɛṭac")]
+        for n, expected in cases:
+            self.assertEqual(pronounce_number(n, "kab"), expected, n)
+
+    def test_tens_and_compounds(self):
+        cases = [(20, "ɛecrin"), (21, "waḥed u ɛecrin"),
+                 (22, "tnayn u ɛecrin"), (30, "tlatin"),
+                 (45, "xemsa u ṛebɛin"), (58, "tmanya u xemsin"),
+                 (90, "tsɛin"), (99, "tesɛa u tsɛin")]
+        for n, expected in cases:
+            self.assertEqual(pronounce_number(n, "kab"), expected, n)
+
+    def test_hundreds_and_thousands(self):
+        cases = [(100, "mya"), (200, "mitin"), (300, "telt-mya"),
+                 (101, "mya u waḥed"), (121, "mya u waḥed u ɛecrin"),
+                 (1000, "alef"), (2000, "juǧ alaf"), (3000, "tlat-alaf"),
+                 (2500, "juǧ alaf u xems-mya")]
+        for n, expected in cases:
+            self.assertEqual(pronounce_number(n, "kab"), expected, n)
+
+    def test_unsupported(self):
+        with self.assertRaises(OverflowError):
+            pronounce_number(10000, "kab")
+        with self.assertRaises(ValueError):
+            pronounce_number(-5, "kab")
+        with self.assertRaises(ValueError):
+            pronounce_number(1.5, "kab")
+
+    def test_ordinals(self):
+        cases = [(1, "amezwaru"), (2, "wis sin"), (3, "wis kṛaḍ"),
+                 (10, "wis mraw"), (21, "wis waḥed u ɛecrin")]
+        for n, expected in cases:
+            self.assertEqual(pronounce_ordinal(n, "kab"), expected, n)
+        self.assertEqual(
+            pronounce_ordinal(1, "kab", gender=GrammaticalGender.FEMININE),
+            "tamezwarut")
+        self.assertEqual(
+            pronounce_ordinal(2, "kab", gender=GrammaticalGender.FEMININE),
+            "tis snat")
+
+
+class TestExtractNumberKab(unittest.TestCase):
+    def test_amazigh(self):
+        cases = [("yiwen", 1), ("yiwet", 1), ("sin", 2), ("snat", 2),
+                 ("kṛaḍ", 3), ("kuẓ", 4), ("semmus", 5), ("sḍis", 6),
+                 ("sa", 7), ("tam", 8), ("tẓa", 9), ("mraw", 10),
+                 ("mraw d yiwen", 11), ("mraw d sin", 12)]
+        for spoken, expected in cases:
+            self.assertEqual(extract_number(spoken, "kab"), expected, spoken)
+
+    def test_loans(self):
+        cases = [("waḥed", 1), ("tnayn", 2), ("tlata", 3), ("ṛebɛa", 4),
+                 ("xemsa", 5), ("setta", 6), ("sebɛa", 7), ("tmanya", 8),
+                 ("tesɛa", 9), ("ɛecṛa", 10), ("ḥḍac", 11), ("tnac", 12),
+                 ("ɛecrin", 20), ("waḥed u ɛecrin", 21),
+                 ("tlata u ṛebɛin", 43), ("mya", 100), ("mitin", 200),
+                 ("telt-mya", 300), ("telt mya", 300), ("alef", 1000),
+                 ("juǧ alaf", 2000)]
+        for spoken, expected in cases:
+            self.assertEqual(extract_number(spoken, "kab"), expected, spoken)
+
+    def test_diacritic_tolerance(self):
+        self.assertEqual(extract_number("hdac", "kab"), 11)
+        self.assertEqual(extract_number("krad", "kab"), 3)
+
+    def test_in_sentence(self):
+        self.assertEqual(extract_number("sin n yirgazen", "kab"), 2)
+        self.assertEqual(extract_number("7 n wussan", "kab"), 7)
+
+    def test_digits_and_negatives(self):
+        self.assertEqual(extract_number("5 kilu", "kab"), 5)
+        self.assertEqual(extract_number("5.2", "kab"), 5.2)
+        self.assertEqual(extract_number("5,2", "kab"), 5.2)
+
+    def test_no_number(self):
+        self.assertFalse(extract_number("xyzzy", "kab"))
+        self.assertFalse(extract_number("azul fell-awen", "kab"))
+
+    def test_fraction_word(self):
+        self.assertEqual(extract_number("azgen", "kab"), 0.5)
+
+    def test_ordinals_flag(self):
+        self.assertEqual(extract_number("wis sin", "kab", ordinals=True), 2)
+        self.assertEqual(extract_number("amezwaru", "kab", ordinals=True), 1)
+
+    def test_roundtrip_sweep(self):
+        nums = list(range(0, 200)) + [222, 300, 345, 999, 1000, 1001,
+                                      2000, 2500, 3333, 9999]
+        for n in nums:
+            spoken = pronounce_number(n, "kab")
+            self.assertEqual(extract_number(spoken, "kab"), n,
+                             f"{n}: {spoken!r}")
+
+    def test_ordinal_roundtrip_sweep(self):
+        for n in list(range(1, 100)) + [100, 999]:
+            spoken = pronounce_ordinal(n, "kab")
+            self.assertEqual(is_ordinal(spoken, "kab"), n,
+                             f"{n}: {spoken!r}")
+
+
+class TestIsFractionalKab(unittest.TestCase):
+    def test_half(self):
+        self.assertEqual(is_fractional("azgen", "kab"), 0.5)
+
+    def test_not_fraction(self):
+        self.assertFalse(is_fractional("xyzzy", "kab"))
+        self.assertFalse(is_fractional("yiwen", "kab"))
+
+
+class TestIsOrdinalKab(unittest.TestCase):
+    def test_ordinals(self):
+        self.assertEqual(is_ordinal("amezwaru", "kab"), 1)
+        self.assertEqual(is_ordinal("tamezwarut", "kab"), 1)
+        self.assertEqual(is_ordinal("wis sin", "kab"), 2)
+        self.assertEqual(is_ordinal("tis snat", "kab"), 2)
+        self.assertEqual(is_ordinal("wis tlata", "kab"), 3)
+
+    def test_not_ordinal(self):
+        self.assertFalse(is_ordinal("xyzzy", "kab"))
+        self.assertFalse(is_ordinal("sin", "kab"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds Kabyle (Taqbaylit, `kab`) support to every public function.

## Numeral-system decision

Kabyle uses two numeral systems side by side:

- the pan-Amazigh cardinals, universal for 1-10: `yiwen` (f. `yiwet`), `sin` (f. `snat`), `kṛaḍ`, `kuẓ`, `semmus`, `sḍis`, `sa`, `tam`, `tẓa`, `mraw`
- the Algerian-Arabic borrowed numerals that carry everyday counting above ten: `ḥḍac` (11), `ɛecrin` (20), `waḥed u ɛecrin` (21, unit before ten), `mya` (100), `alef` (1000)

Pronunciation uses the Amazigh forms for 0-10 and the Arabic-derived forms above ten — the only system with consistent attestation for large values. Extraction accepts **both** systems, feminine forms, additive Amazigh compounds (`mraw d yiwen` = 11) and diacritic-stripped spellings.

Ordinals: `amezwaru` / `tamezwarut` "first", otherwise `wis`/`tis` + cardinal. The only fraction noun shipped is the well-attested `azgen` (half).

## Coverage boundary

Pronunciation spans 0–9999. A minus word, a decimal-separator word, further fraction nouns and larger scale words are not reliably attested and are deliberately omitted rather than guessed (documented in `docs/languages.md`).

## Sources

- https://en.wikipedia.org/wiki/Kabyle_language — gender forms, genitive counting, ordinal formation (`wis`/`tis`, `amezwaru`)
- https://www.omniglot.com/language/numbers/kabyle.htm — Amazigh and Arabic-loan cardinal tables, feminine forms
- https://www.languagesandnumbers.com/how-to-count-in-kabyle/en/kab/ — full colloquial system: teens, tens, compound rule (`u`, unit-first), hundreds, thousands
- https://fr.wikipedia.org/wiki/Num%C3%A9ration_amazighe — standardized Amazigh system, `d`/`ed` additive compounding

## Tests

- `tests/test_number_parser_kab.py`: anchors for both systems, feminine forms, ordinals, diacritic tolerance, a pronounce→extract round-trip sweep over 0-199 plus selected values to 9999, and an ordinal round-trip 1-99
- `kab` added to `tests/test_lang_parity.py` LANGS, exercising the generic `pronounce_fraction`, `numbers_to_digits` and ordinal fallbacks

This PR was authored with Claude (Fable 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
