### PR TITLE
feat(ro): Romanian number parsing and pronunciation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ fractional and ordinal numbers, and more.
 | `pt` (Portuguese)       | ✅                | ✅                  | ✅              | ✅                |
 | `mwl` (Mirandese)       | ✅                | ✅                  | ✅              | ✅                |
 | `ast` (Asturian)        | ✅                | ✅                  | ✅              | ✅                |
+| `ro` (Romanian)         | ✅                | ✅                  | ✅              | ✅                |
 | `ru` (Russian)          | ✅                | 🚧                 | ✅              | ✅                 |
 | `sv` (Swedish)          | ✅                | ✅                 | ✅              | ❌                 |
 | `sl` (Slovenian)        | ✅                | 🚧                 | ❌              | ❌                 |

--- a/docs/adding-a-language.md
+++ b/docs/adding-a-language.md
@@ -34,7 +34,13 @@ XX = RomanceNumberExtractor(_XX)
 ```
 
 See `numbers_gl.py` or `numbers_ast.py` for complete worked examples, and the
-`NumberVocabulary` docstrings in `util.py` for every knob.
+`NumberVocabulary` docstrings in `util.py` for every knob. Languages with
+articled scale groups ("o mie"), a count-to-scale linker word
+("douăzeci **de** mii"), multiplicative hundreds words ("două sute" = 200)
+or particle-based ordinals ("al doilea"/"a doua") can describe those with
+`SCALE_ONE`, `SCALE_LINKER`, `SCALE_GENDERS`, `MULTIPLY_HUNDREDS`,
+`FRACTION_ONE`, `JOINER_ON_SCALE_REMAINDER` and the `ORDINAL_PREFIX` family —
+see `numbers_ro.py` for a worked example.
 
 **Other language families** implement the functions directly. Use an existing
 module of the same family as a template:

--- a/ovos_number_parser/__init__.py
+++ b/ovos_number_parser/__init__.py
@@ -35,6 +35,7 @@ from ovos_number_parser.numbers_nl import numbers_to_digits_nl, pronounce_number
 from ovos_number_parser.numbers_pl import numbers_to_digits_pl, pronounce_number_pl, extract_number_pl, \
     is_fractional_pl, pronounce_ordinal_pl
 from ovos_number_parser.numbers_pt import PortugueseVariant, PT_PT, PT_BR
+from ovos_number_parser.numbers_ro import RO
 from ovos_number_parser.numbers_ru import numbers_to_digits_ru, pronounce_number_ru, extract_number_ru, is_fractional_ru
 from ovos_number_parser.numbers_sl import pronounce_number_sl, extract_number_sl, is_fractional_sl, \
     is_ordinal_sl, nice_number_sl
@@ -258,6 +259,8 @@ def numbers_to_digits(utterance: str, lang: str, scale: Optional[Scale] = None) 
         return PT_PT.numbers_to_digits(utterance, scale=scale)
     if lang.startswith("mwl"):
         return MWL.numbers_to_digits(utterance, scale=scale)
+    if lang.startswith("ro"):
+        return RO.numbers_to_digits(utterance, scale=scale)
     if lang.startswith("ru"):
         return numbers_to_digits_ru(utterance)
     if lang.startswith("uk"):
@@ -341,6 +344,8 @@ def pronounce_number(number: Union[int, float], lang: str,
         return PT_PT.pronounce_number(number, places, scale, ordinals, digits, gender)
     if lang.startswith("mwl"):
         return MWL.pronounce_number(number, places, scale, ordinals, digits, gender)
+    if lang.startswith("ro"):
+        return RO.pronounce_number(number, places, scale, ordinals, digits, gender)
     if lang.startswith("ru"):
         return pronounce_number_ru(number, places, short_scale, scientific, ordinals)
     if lang.startswith("sl"):
@@ -381,6 +386,8 @@ def pronounce_fraction(fraction_word: str, lang: str, scale: Optional[Scale] = N
         return MWL.pronounce_fraction(fraction_word, scale=scale)
     elif lang.startswith("gl"):
         return pronounce_fraction_gl(fraction_word, scale=scale)
+    elif lang.startswith("ro"):
+        return RO.pronounce_fraction(fraction_word, scale=scale)
     else:
         return _pronounce_fraction_generic(fraction_word, lang)
 
@@ -414,6 +421,8 @@ def pronounce_ordinal(number: Union[int, float], lang: str,
             else PT_PT.pronounce_ordinal(number, scale=scale, gender=gender)
     if lang.startswith("mwl"):
         return MWL.pronounce_ordinal(number, scale=scale, gender=gender)
+    if lang.startswith("ro"):
+        return RO.pronounce_ordinal(number, scale=scale, gender=gender)
     if lang.startswith("ast"):
         return AST.pronounce_ordinal(number, scale=scale, gender=gender)
     if lang.startswith("ar"):
@@ -516,6 +525,8 @@ def extract_number(text: str, lang: str,
             else PT_PT.extract_number(text, scale=scale, ordinals=ordinals)
     if lang.startswith("mwl"):
         return MWL.extract_number(text, scale=scale, ordinals=ordinals)
+    if lang.startswith("ro"):
+        return RO.extract_number(text, scale=scale, ordinals=ordinals)
     if lang.startswith("ast"):
         return AST.extract_number(text, scale=scale, ordinals=ordinals)
     if lang.startswith("ru"):
@@ -588,6 +599,8 @@ def is_fractional(input_str: str, lang: str,
         return PT_PT.is_fractional(input_str)
     if lang.startswith("mwl"):
         return MWL.is_fractional(input_str)
+    if lang.startswith("ro"):
+        return RO.is_fractional(input_str)
     if lang.startswith("ast"):
         return AST.is_fractional(input_str)
     if lang.startswith("ru"):
@@ -621,6 +634,8 @@ def is_ordinal(input_str: str, lang: str) -> Union[bool, float]:
         return PT_PT.is_ordinal(input_str)
     if lang.startswith("mwl"):
         return MWL.is_ordinal(input_str)
+    if lang.startswith("ro"):
+        return RO.is_ordinal(input_str)
     if lang.startswith("ast"):
         return AST.is_ordinal(input_str)
     if lang.startswith("en"):

--- a/ovos_number_parser/numbers_ro.py
+++ b/ovos_number_parser/numbers_ro.py
@@ -1,0 +1,319 @@
+from ovos_number_parser.util import (Scale, GrammaticalGender, NumberVocabulary,
+                                     RomanceNumberExtractor)
+
+# feminine forms of the words that mark gender, applied token by token
+_FEMININE_FORMS = {
+    # cardinals
+    "unu": "una",
+    "doi": "două",
+    "doisprezece": "douăsprezece",
+    # ordinals
+    "primul": "prima",
+    "unulea": "una",
+    "doilea": "doua",
+    "treilea": "treia",
+    "patrulea": "patra",
+    "cincilea": "cincea",
+    "șaselea": "șasea",
+    "șaptelea": "șaptea",
+    "optulea": "opta",
+    "nouălea": "noua",
+    "zecelea": "zecea",
+    "sutălea": "suta",
+    "miilea": "mia",
+    "milionulea": "milioana",
+    "miliardulea": "miliarda",
+}
+
+_MASCULINE_FORMS = {v: k for k, v in _FEMININE_FORMS.items()}
+
+_PLURAL_FORMS = {
+    "sută": "sute",
+    "mie": "mii",
+    "milion": "milioane",
+    "miliard": "miliarde",
+    "bilion": "bilioane",
+    "biliard": "biliarde",
+    "trilion": "trilioane",
+    "jumătate": "jumătăți",
+    "sfert": "sferturi",
+    "pătrime": "pătrimi",
+}
+
+
+def _swap_token_ro(word: str, gender: GrammaticalGender) -> str:
+    if gender == GrammaticalGender.FEMININE:
+        if word in _FEMININE_FORMS:
+            return _FEMININE_FORMS[word]
+        # regular ordinal endings: "-zecilea" -> "-zecea",
+        # "-sprezecelea" -> "-sprezecea"
+        if word.endswith("zecilea"):
+            return word[:-len("zecilea")] + "zecea"
+        if word.endswith("celea"):
+            return word[:-len("celea")] + "cea"
+    elif gender == GrammaticalGender.MASCULINE and word in _MASCULINE_FORMS:
+        return _MASCULINE_FORMS[word]
+    return word
+
+
+def swap_gender_ro(word: str, gender: GrammaticalGender) -> str:
+    """Swap the grammatical gender of a Romanian number word (or phrase)."""
+    return " ".join(_swap_token_ro(w, gender) for w in word.split())
+
+
+def pluralize_ro(word: str) -> str:
+    if word in _PLURAL_FORMS:
+        return _PLURAL_FORMS[word]
+    # fraction nouns in "-ime" take "-imi" ("treime" -> "treimi")
+    if word.endswith("ime"):
+        return word[:-1] + "i"
+    return word
+
+
+_RO = NumberVocabulary(
+    LANG="ro-RO",
+    swap_gender=swap_gender_ro,
+    pluralize=pluralize_ro,
+
+    HUNDRED_PARTICLE="o sută",  # how to read "1XX"
+    DENOMINATOR_PARTICLE="părți",  # for fractions X / N {PARTICLE}
+    DIVIDED_BY_ZERO="împărțit la zero",
+    NO_PREV_UNIT=[],
+    NO_PLURAL=[],
+
+    NUMBER_OVERFLOW="număr exagerat de mare",
+    # Romanian uses the long scale: milion 10^6, miliard 10^9, bilion 10^12
+    DEFAULT_SCALE=Scale.LONG,
+
+    # "și" joins tens to units and is the only joiner that is pronounced;
+    # "de" links counts of twenty and above to their scale word
+    # ("douăzeci de mii") and is dropped during extraction
+    JOIN_WORD=["și", "de"],
+    JOINER_ON_TWENTYS=True,  # "douăzeci și unu"
+    JOINER_ON_HUNDREDS=False,  # "o sută douăzeci" - no joiner after hundreds
+    JOINER_ON_HUNDRED_PARTICLE=False,
+    JOINER_ON_THOUSANDS=False,
+    JOINER_ON_SCALE_REMAINDER=False,  # "două mii unu" - remainder stands bare
+
+    SCALE_LINKER="de",  # "douăzeci de mii", "o sută de milioane"
+    MULTIPLY_HUNDREDS=True,  # "două sute" = 200
+    SCALE_ONE={
+        100: "o sută",
+        1000: "o mie",
+        10 ** 6: "un milion",
+        10 ** 9: "un miliard",
+        10 ** 12: "un bilion",
+        10 ** 15: "un biliard",
+        10 ** 18: "un trilion",
+    },
+    # "mie" is feminine ("două mii", "douăzeci și una de mii"); "milion",
+    # "miliard" and "bilion" are neuter - masculine in the singular,
+    # feminine agreement in the plural ("două milioane",
+    # "douăzeci și unu de milioane")
+    SCALE_GENDERS={
+        1000: GrammaticalGender.FEMININE,
+        10 ** 6: GrammaticalGender.NEUTRAL,
+        10 ** 9: GrammaticalGender.NEUTRAL,
+        10 ** 12: GrammaticalGender.NEUTRAL,
+        10 ** 15: GrammaticalGender.NEUTRAL,
+        10 ** 18: GrammaticalGender.NEUTRAL,
+    },
+
+    DECIMAL_MARKER=["virgulă", "virgula", ",", "."],
+    NEGATIVE_SIGN=["minus"],
+    UNITS={
+        0: "zero",
+        1: "unu",
+        2: "doi",
+        3: "trei",
+        4: "patru",
+        5: "cinci",
+        6: "șase",
+        7: "șapte",
+        8: "opt",
+        9: "nouă",
+    },
+    TENS={
+        10: "zece",
+        11: "unsprezece",
+        12: "doisprezece",
+        13: "treisprezece",
+        14: "paisprezece",
+        15: "cincisprezece",
+        16: "șaisprezece",
+        17: "șaptesprezece",
+        18: "optsprezece",
+        19: "nouăsprezece",
+        20: "douăzeci",
+        30: "treizeci",
+        40: "patruzeci",
+        50: "cincizeci",
+        60: "șaizeci",
+        70: "șaptezeci",
+        80: "optzeci",
+        90: "nouăzeci",
+    },
+    HUNDREDS={
+        100: "o sută",
+        200: "două sute",
+        300: "trei sute",
+        400: "patru sute",
+        500: "cinci sute",
+        600: "șase sute",
+        700: "șapte sute",
+        800: "opt sute",
+        900: "nouă sute",
+    },
+    FRACTION={
+        2: "jumătate",
+        3: "treime",
+        4: "sfert",
+        5: "cincime",
+        6: "șesime",
+        7: "șeptime",
+        8: "optime",
+        9: "noime",
+        10: "zecime",
+        11: "unsprezecime",
+        12: "douăsprezecime",
+        13: "treisprezecime",
+        14: "paisprezecime",
+        15: "cincisprezecime",
+        16: "șaisprezecime",
+        17: "șaptesprezecime",
+        18: "optsprezecime",
+        19: "nouăsprezecime",
+        20: "douăzecime",
+        100: "sutime",
+        1000: "miime",
+    },
+    FRACTION_FEMALE={
+        4: "pătrime",  # synonym of "sfert"
+    },
+    FRACTION_ONE={
+        2: "o jumătate",
+        3: "o treime",
+        4: "un sfert",
+        5: "o cincime",
+        6: "o șesime",
+        7: "o șeptime",
+        8: "o optime",
+        9: "o noime",
+        10: "o zecime",
+        20: "o douăzecime",
+        100: "o sutime",
+        1000: "o miime",
+    },
+    # fraction nouns are feminine: "două treimi", "două jumătăți"
+    FRACTION_NUMERATOR_GENDER=GrammaticalGender.FEMININE,
+    # Romanian follows the long scale (DOOM, Academia Română); both maps
+    # carry the same standard readings
+    SHORT_SCALE={
+        1000: "mie",
+        10 ** 6: "milion",
+        10 ** 9: "miliard",
+        10 ** 12: "bilion",
+        10 ** 15: "biliard",
+        10 ** 18: "trilion",
+    },
+    LONG_SCALE={
+        1000: "mie",
+        10 ** 6: "milion",
+        10 ** 9: "miliard",
+        10 ** 12: "bilion",
+        10 ** 15: "biliard",
+        10 ** 18: "trilion",
+    },
+
+    GENDERED_SPELLINGS={
+        GrammaticalGender.FEMININE: {
+            1: "una",
+            2: "două",
+            12: "douăsprezece",
+        },
+        # neuter: masculine agreement in the singular, feminine in the plural
+        GrammaticalGender.NEUTRAL: {
+            2: "două",
+            12: "douăsprezece",
+        },
+    },
+    DIGIT_SPELLINGS={},
+    ALT_SPELLINGS={
+        # "un"/"o" - the forms of "one" used before nouns and scale words
+        "un": 1,
+        # bare hundreds word, for extraction ("două sute", "sute de mii")
+        "sută": 100,
+        "suta": 100,
+        "sute": 100,
+        # colloquial short teens (accepted for extraction, never pronounced)
+        "unșpe": 11,
+        "doișpe": 12,
+        "treișpe": 13,
+        "paișpe": 14,
+        "cinșpe": 15,
+        "cincișpe": 15,
+        "șaișpe": 16,
+        "șapteșpe": 17,
+        "șaptișpe": 17,
+        "optișpe": 18,
+        "opșpe": 18,
+        "nouășpe": 19,
+        # uncontracted teen variants
+        "patrusprezece": 14,
+        "șasesprezece": 16,
+    },
+    # ordinals take the particle "al" (m) / "a" (f): "al doilea", "a doua"
+    ORDINAL_PREFIX={
+        GrammaticalGender.MASCULINE: "al",
+        GrammaticalGender.FEMININE: "a",
+    },
+    ORDINAL_UNPREFIXED=[1],  # "primul"/"prima" stand alone
+    ORDINAL_COMPOUND_CARDINAL_TENS=True,  # "al douăzeci și unulea"
+    ORDINAL_COMPOUND_UNITS={1: "unulea"},  # 1st is "primul", but 21st "unulea"
+    ORDINAL_UNITS={
+        1: "primul",
+        2: "doilea",
+        3: "treilea",
+        4: "patrulea",
+        5: "cincilea",
+        6: "șaselea",
+        7: "șaptelea",
+        8: "optulea",
+        9: "nouălea",
+    },
+    ORDINAL_TENS={
+        10: "zecelea",
+        11: "unsprezecelea",
+        12: "doisprezecelea",
+        13: "treisprezecelea",
+        14: "paisprezecelea",
+        15: "cincisprezecelea",
+        16: "șaisprezecelea",
+        17: "șaptesprezecelea",
+        18: "optsprezecelea",
+        19: "nouăsprezecelea",
+        20: "douăzecilea",
+        30: "treizecilea",
+        40: "patruzecilea",
+        50: "cincizecilea",
+        60: "șaizecilea",
+        70: "șaptezecilea",
+        80: "optzecilea",
+        90: "nouăzecilea",
+    },
+    ORDINAL_HUNDREDS={
+        100: "sutălea",
+    },
+    ORDINAL_SHORT_SCALE={
+        10 ** 3: "miilea",
+        10 ** 6: "milionulea",
+        10 ** 9: "miliardulea",
+    },
+    ORDINAL_LONG_SCALE={
+        10 ** 3: "miilea",
+        10 ** 6: "milionulea",
+        10 ** 9: "miliardulea",
+    },
+)
+
+RO = RomanceNumberExtractor(_RO)

--- a/tests/test_lang_parity.py
+++ b/tests/test_lang_parity.py
@@ -10,7 +10,8 @@ from ovos_number_parser import (extract_number, is_fractional, is_ordinal,
                                 pronounce_number, pronounce_ordinal)
 
 LANGS = ["ar", "az", "ast", "ca", "cs", "da", "de", "en", "es", "eu", "fa", "fr",
-         "gl", "hu", "it", "kab", "mwl", "nl", "pl", "pt", "ru", "sl", "sv", "uk"]
+         "gl", "hu", "it", "kab", "mwl", "nl", "pl", "pt", "ro", "ru", "sl",
+         "sv", "uk"]
 
 
 class TestLanguageParity(unittest.TestCase):
@@ -97,6 +98,8 @@ class TestPronounceFractionAnchors(unittest.TestCase):
         "ca": [("1/2", "un mig")],
         "az": [("1/2", "yarım"), ("2/3", "üçdə iki")],
         "pt": [("1/2", "um meio"), ("2/3", "dois terços")],
+        "ro": [("1/2", "o jumătate"), ("2/3", "două treimi"),
+               ("3/4", "trei sferturi"), ("1/4", "un sfert")],
     }
 
     def test_anchors(self):
@@ -143,6 +146,8 @@ class TestPronounceOrdinalAnchors(unittest.TestCase):
         "sl": [(1, "prvi"), (2, "drugi"), (3, "tretji"), (10, "deseti"),
                (21, "enaindvajseti"), (100, "stoti")],
         "gl": [(1, "primeiro"), (2, "segundo"), (3, "terceiro")],
+        "ro": [(1, "primul"), (2, "al doilea"), (3, "al treilea"),
+               (10, "al zecelea"), (21, "al douăzeci și unulea")],
     }
 
     def test_anchors(self):
@@ -168,6 +173,8 @@ class TestIsOrdinalAnchors(unittest.TestCase):
             ("sl", "prvi", 1), ("sl", "enaindvajseti", 21),
             ("hu", "első", 1), ("hu", "második", 2), ("hu", "huszadik", 20),
             ("gl", "segundo", 2),
+            ("ro", "al doilea", 2), ("ro", "a treia", 3),
+            ("ro", "primul", 1),
         ]
         for lang, word, expected in cases:
             self.assertEqual(is_ordinal(word, lang), expected,

--- a/tests/test_number_parser_ro.py
+++ b/tests/test_number_parser_ro.py
@@ -1,0 +1,280 @@
+"""Romanian number parsing and pronunciation.
+
+Anchor expectations follow the Romanian Academy orthography (DOOM,
+ă/â/î/ș/ț with comma diacritics): compound tens join units with "și"
+("douăzeci și unu"), counts of twenty and above link to their scale word
+with "de" ("douăzeci de mii"), "mie" takes feminine agreement
+("două mii", "douăzeci și una de mii") while "milion"/"miliard" are
+neuter ("un milion", "două milioane", "douăzeci și unu de milioane"),
+and ordinals take the particles "al"/"a" ("al doilea"/"a doua").
+"""
+import unittest
+
+from ovos_number_parser.numbers_ro import RO
+from ovos_number_parser.util import GrammaticalGender
+
+
+class TestPronunciationRO(unittest.TestCase):
+
+    def test_units(self):
+        anchors = {0: "zero", 1: "unu", 2: "doi", 3: "trei", 4: "patru",
+                   5: "cinci", 6: "șase", 7: "șapte", 8: "opt", 9: "nouă",
+                   10: "zece"}
+        for n, expected in anchors.items():
+            self.assertEqual(RO.pronounce_number(n), expected)
+
+    def test_gendered_units(self):
+        self.assertEqual(RO.pronounce_number(1, gender=GrammaticalGender.FEMININE), "una")
+        self.assertEqual(RO.pronounce_number(2, gender=GrammaticalGender.FEMININE), "două")
+        self.assertEqual(RO.pronounce_number(12, gender=GrammaticalGender.FEMININE),
+                         "douăsprezece")
+
+    def test_teens(self):
+        anchors = {11: "unsprezece", 12: "doisprezece", 13: "treisprezece",
+                   14: "paisprezece", 15: "cincisprezece", 16: "șaisprezece",
+                   17: "șaptesprezece", 18: "optsprezece", 19: "nouăsprezece"}
+        for n, expected in anchors.items():
+            self.assertEqual(RO.pronounce_number(n), expected)
+
+    def test_tens(self):
+        anchors = {20: "douăzeci", 30: "treizeci", 40: "patruzeci",
+                   50: "cincizeci", 60: "șaizeci", 70: "șaptezeci",
+                   80: "optzeci", 90: "nouăzeci"}
+        for n, expected in anchors.items():
+            self.assertEqual(RO.pronounce_number(n), expected)
+
+    def test_si_joins(self):
+        self.assertEqual(RO.pronounce_number(21), "douăzeci și unu")
+        self.assertEqual(RO.pronounce_number(22), "douăzeci și doi")
+        self.assertEqual(RO.pronounce_number(22, gender=GrammaticalGender.FEMININE),
+                         "douăzeci și două")
+        self.assertEqual(RO.pronounce_number(35), "treizeci și cinci")
+        self.assertEqual(RO.pronounce_number(68), "șaizeci și opt")
+        self.assertEqual(RO.pronounce_number(99), "nouăzeci și nouă")
+
+    def test_hundreds(self):
+        self.assertEqual(RO.pronounce_number(100), "o sută")
+        self.assertEqual(RO.pronounce_number(101), "o sută unu")
+        self.assertEqual(RO.pronounce_number(120), "o sută douăzeci")
+        self.assertEqual(RO.pronounce_number(123), "o sută douăzeci și trei")
+        self.assertEqual(RO.pronounce_number(200), "două sute")
+        self.assertEqual(RO.pronounce_number(245), "două sute patruzeci și cinci")
+        self.assertEqual(RO.pronounce_number(999), "nouă sute nouăzeci și nouă")
+
+    def test_thousands(self):
+        self.assertEqual(RO.pronounce_number(1000), "o mie")
+        self.assertEqual(RO.pronounce_number(1001), "o mie unu")
+        self.assertEqual(RO.pronounce_number(2000), "două mii")
+        self.assertEqual(RO.pronounce_number(2001), "două mii unu")
+        self.assertEqual(RO.pronounce_number(1234),
+                         "o mie două sute treizeci și patru")
+        self.assertEqual(RO.pronounce_number(2023), "două mii douăzeci și trei")
+
+    def test_de_insertion(self):
+        # counts of twenty and above link to the scale word with "de"
+        self.assertEqual(RO.pronounce_number(20_000), "douăzeci de mii")
+        self.assertEqual(RO.pronounce_number(21_000), "douăzeci și una de mii")
+        self.assertEqual(RO.pronounce_number(100_000), "o sută de mii")
+        self.assertEqual(RO.pronounce_number(100_000_000), "o sută de milioane")
+        self.assertEqual(RO.pronounce_number(45_000),
+                         "patruzeci și cinci de mii")
+        # counts below twenty take no "de"
+        self.assertEqual(RO.pronounce_number(15_000), "cincisprezece mii")
+
+    def test_millions(self):
+        self.assertEqual(RO.pronounce_number(1_000_000), "un milion")
+        self.assertEqual(RO.pronounce_number(2_000_000), "două milioane")
+        self.assertEqual(RO.pronounce_number(21_000_000),
+                         "douăzeci și unu de milioane")
+        self.assertEqual(RO.pronounce_number(22_000_000),
+                         "douăzeci și două de milioane")
+        self.assertEqual(RO.pronounce_number(1_000_000_000), "un miliard")
+        self.assertEqual(RO.pronounce_number(2_000_000_000), "două miliarde")
+        self.assertEqual(
+            RO.pronounce_number(1_234_567),
+            "un milion două sute treizeci și patru de mii cinci sute șaizeci și șapte")
+
+    def test_decimals(self):
+        self.assertEqual(RO.pronounce_number(5.2), "cinci virgulă doi")
+        self.assertEqual(RO.pronounce_number(3.14), "trei virgulă paisprezece")
+        self.assertEqual(RO.pronounce_number(10.05), "zece virgulă zero cinci")
+
+    def test_negative(self):
+        self.assertEqual(RO.pronounce_number(-3), "minus trei")
+        self.assertEqual(RO.pronounce_number(-5.2), "minus cinci virgulă doi")
+
+    def test_ordinals_masculine(self):
+        anchors = {1: "primul", 2: "al doilea", 3: "al treilea",
+                   4: "al patrulea", 5: "al cincilea", 6: "al șaselea",
+                   7: "al șaptelea", 8: "al optulea", 9: "al nouălea",
+                   10: "al zecelea", 12: "al doisprezecelea",
+                   20: "al douăzecilea", 21: "al douăzeci și unulea",
+                   45: "al patruzeci și cincilea", 100: "al sutălea",
+                   1000: "al miilea"}
+        for n, expected in anchors.items():
+            self.assertEqual(RO.pronounce_ordinal(n), expected)
+            self.assertEqual(RO.pronounce_number(n, ordinals=True), expected)
+
+    def test_ordinals_feminine(self):
+        anchors = {1: "prima", 2: "a doua", 3: "a treia", 4: "a patra",
+                   5: "a cincea", 6: "a șasea", 7: "a șaptea", 8: "a opta",
+                   9: "a noua", 10: "a zecea", 20: "a douăzecea",
+                   1000: "a mia"}
+        for n, expected in anchors.items():
+            self.assertEqual(
+                RO.pronounce_ordinal(n, gender=GrammaticalGender.FEMININE),
+                expected)
+
+    def test_fractions(self):
+        self.assertEqual(RO.pronounce_fraction("1/2"), "o jumătate")
+        self.assertEqual(RO.pronounce_fraction("1/3"), "o treime")
+        self.assertEqual(RO.pronounce_fraction("1/4"), "un sfert")
+        self.assertEqual(RO.pronounce_fraction("1/5"), "o cincime")
+        self.assertEqual(RO.pronounce_fraction("2/3"), "două treimi")
+        self.assertEqual(RO.pronounce_fraction("3/4"), "trei sferturi")
+        self.assertEqual(RO.pronounce_fraction("3/2"), "trei jumătăți")
+        self.assertEqual(RO.pronounce_fraction("5/8"), "cinci optimi")
+        self.assertEqual(RO.pronounce_fraction("7/10"), "șapte zecimi")
+
+
+class TestExtractionRO(unittest.TestCase):
+
+    def test_units_and_gender_variants(self):
+        self.assertEqual(RO.extract_number("unu"), 1)
+        self.assertEqual(RO.extract_number("una"), 1)
+        self.assertEqual(RO.extract_number("un milion"), 1_000_000)
+        self.assertEqual(RO.extract_number("doi"), 2)
+        self.assertEqual(RO.extract_number("două"), 2)
+        self.assertEqual(RO.extract_number("doisprezece"), 12)
+        self.assertEqual(RO.extract_number("douăsprezece"), 12)
+
+    def test_si_joins(self):
+        self.assertEqual(RO.extract_number("douăzeci și unu"), 21)
+        self.assertEqual(RO.extract_number("douăzeci și una"), 21)
+        self.assertEqual(RO.extract_number("treizeci și cinci"), 35)
+        self.assertEqual(RO.extract_number("nouăzeci și nouă"), 99)
+
+    def test_hundreds_multiply(self):
+        self.assertEqual(RO.extract_number("o sută"), 100)
+        self.assertEqual(RO.extract_number("două sute"), 200)
+        self.assertEqual(RO.extract_number("două sute treizeci și cinci"), 235)
+        self.assertEqual(RO.extract_number("nouă sute nouăzeci și nouă"), 999)
+
+    def test_de_insertion(self):
+        # "de" is number-internal when it links a count to a scale word
+        self.assertEqual(RO.extract_number("douăzeci de mii"), 20_000)
+        self.assertEqual(RO.extract_number("douăzeci și una de mii"), 21_000)
+        self.assertEqual(RO.extract_number("o sută de milioane"), 100_000_000)
+        self.assertEqual(RO.extract_number("patruzeci și cinci de mii"), 45_000)
+
+    def test_thousands(self):
+        self.assertEqual(RO.extract_number("o mie"), 1000)
+        self.assertEqual(RO.extract_number("două mii"), 2000)
+        self.assertEqual(RO.extract_number("două mii unu"), 2001)
+        self.assertEqual(RO.extract_number("o mie două sute"), 1200)
+        self.assertEqual(
+            RO.extract_number("un milion două sute treizeci și patru de mii "
+                              "cinci sute șaizeci și șapte"),
+            1_234_567)
+
+    def test_colloquial_teens(self):
+        # short spoken forms are accepted for extraction only
+        self.assertEqual(RO.extract_number("unșpe"), 11)
+        self.assertEqual(RO.extract_number("doișpe"), 12)
+        self.assertEqual(RO.extract_number("paișpe"), 14)
+        self.assertEqual(RO.extract_number("șaișpe"), 16)
+        self.assertEqual(RO.extract_number("nouășpe"), 19)
+
+    def test_decimals(self):
+        self.assertEqual(RO.extract_number("cinci virgulă doi"), 5.2)
+        self.assertEqual(RO.extract_number("trei virgulă paisprezece"), 3.14)
+        self.assertEqual(RO.extract_number("zece virgulă zero cinci"), 10.05)
+
+    def test_negative(self):
+        self.assertEqual(RO.extract_number("minus zece"), -10)
+        self.assertEqual(RO.extract_number("minus cinci virgulă doi"), -5.2)
+
+    def test_fractions(self):
+        self.assertEqual(RO.extract_number("doi și jumătate"), 2.5)
+        self.assertEqual(RO.extract_number("două treimi"), 2 / 3)
+        self.assertEqual(RO.extract_number("trei sferturi"), 3 / 4)
+        self.assertEqual(RO.is_fractional("jumătate"), 1 / 2)
+        self.assertEqual(RO.is_fractional("treime"), 1 / 3)
+        self.assertEqual(RO.is_fractional("sfert"), 1 / 4)
+        self.assertEqual(RO.is_fractional("pătrime"), 1 / 4)
+        self.assertEqual(RO.is_fractional("cincime"), 1 / 5)
+        self.assertFalse(RO.is_fractional("pisică"))
+
+    def test_ordinals(self):
+        self.assertEqual(RO.extract_number("al doilea om", ordinals=True), 2)
+        self.assertEqual(RO.extract_number("a treia oară", ordinals=True), 3)
+        self.assertEqual(RO.extract_number("primul loc", ordinals=True), 1)
+        self.assertEqual(RO.extract_number("prima oară", ordinals=True), 1)
+        self.assertEqual(
+            RO.extract_number("al douăzeci și unulea etaj", ordinals=True), 21)
+        self.assertEqual(RO.is_ordinal("al doilea"), 2)
+        self.assertEqual(RO.is_ordinal("doua"), 2)
+        self.assertEqual(RO.is_ordinal("primul"), 1)
+        self.assertEqual(RO.is_ordinal("prima"), 1)
+        self.assertEqual(RO.is_ordinal("miilea"), 1000)
+        self.assertFalse(RO.is_ordinal("pisică"))
+
+    def test_digits_win(self):
+        self.assertEqual(RO.extract_number("7"), 7)
+        self.assertEqual(RO.extract_number("am 7 mere"), 7)
+        self.assertEqual(RO.extract_number("3,5"), 3.5)
+
+    def test_no_number(self):
+        self.assertFalse(RO.extract_number("nicio cifră aici"))
+
+    def test_in_sentence(self):
+        self.assertEqual(RO.extract_number("am douăzeci și cinci de mere"), 25)
+        self.assertEqual(RO.extract_number("peste trei zile"), 3)
+
+
+class TestNumbersToDigitsRO(unittest.TestCase):
+
+    def test_plain(self):
+        self.assertEqual(RO.numbers_to_digits("douăzeci și cinci"), "25")
+        self.assertEqual(RO.numbers_to_digits("două sute cincizeci"), "250")
+        self.assertEqual(RO.numbers_to_digits("un milion"), "1000000")
+
+    def test_in_sentence(self):
+        self.assertEqual(
+            RO.numbers_to_digits("am douăzeci și cinci de mere și trei pere"),
+            "am 25 de mere și 3 pere")
+
+
+class TestRoundTripRO(unittest.TestCase):
+    def test_round_trip_sweep(self):
+        values = list(range(0, 1000)) + [
+            1000, 1001, 1015, 1200, 2000, 2001, 9999, 10_000, 20_000, 21_000,
+            45_678, 100_000, 123_456, 999_999, 1_000_000, 2_000_000,
+            2_500_123, 21_000_000, 100_000_000, 123_456_789, 1_000_000_000,
+            2_000_000_001]
+        for n in values:
+            spoken = RO.pronounce_number(n)
+            self.assertEqual(RO.extract_number(spoken), n, spoken)
+
+    def test_round_trip_feminine(self):
+        for n in (1, 2, 12, 22, 42, 101):
+            spoken = RO.pronounce_number(n, gender=GrammaticalGender.FEMININE)
+            self.assertEqual(RO.extract_number(spoken), n, spoken)
+
+    def test_round_trip_ordinals(self):
+        for n in (1, 2, 3, 7, 10, 13, 20, 21, 45, 100, 1000):
+            spoken = RO.pronounce_ordinal(n)
+            self.assertEqual(RO.extract_number(spoken, ordinals=True), n, spoken)
+            # is_ordinal only matches single ordinal words (plus particle)
+            if len(spoken.split()) <= 2:
+                self.assertEqual(RO.is_ordinal(spoken), n, spoken)
+
+    def test_round_trip_decimals(self):
+        for n in (0.5, 5.2, 3.14, 12.34, 100.01):
+            spoken = RO.pronounce_number(n)
+            self.assertAlmostEqual(RO.extract_number(spoken), n, places=2,
+                                   msg=spoken)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds Romanian (`ro`) support as a declarative `NumberVocabulary` on the `RomanceNumberExtractor` engine (`ovos_number_parser/numbers_ro.py`), wired into every public dispatcher function, plus a full per-language test suite and language-parity coverage. Builds on the engine knobs from #72.

All forms follow the Romanian Academy orthography (ă/â/î and comma-below ș/ț):

- units *unu/una* (m/f), *doi/două*, teens *unsprezece–nouăsprezece* (colloquial *unșpe/doișpe/...* accepted for extraction only)
- tens join units with *și*: *douăzeci și unu* = 21
- multiplicative hundreds: *o sută*, *două sute*, *două sute treizeci și cinci* = 235
- scale words with the *de* linker for counts ≥ 20 or round hundreds: *douăzeci de mii* = 20 000, *o sută de milioane* = 10⁸
- gender agreement on scale counts: feminine *mie* (*două mii*, *douăzeci și una de mii*), neuter *milion/miliard* (*un milion*, *două milioane*, *douăzeci și unu de milioane*)
- long scale: *mie* 10³, *milion* 10⁶, *miliard* 10⁹, *bilion* 10¹²
- decimals with *virgulă* (*cinci virgulă doi* = 5.2), negatives with *minus*
- fractions *jumătate/treime/sfert* (synonym *pătrime*)*/cincime/.../sutime/miime*, with articled 1/x forms (*o jumătate*, *un sfert*) and plural multiplication (*două treimi* = 2/3)
- ordinals with the particles *al/a*: *primul/prima*, *al doilea/a doua*, *al treilea/a treia*, compounds with cardinal tens (*al douăzeci și unulea* = 21st); masculine pronounced by default, both genders extracted

## Sources

- Academia Română, *DOOM* (Dicționarul ortografic, ortoepic și morfologic al limbii române) — standard spellings of numerals, contracted teens *paisprezece/șaisprezece*, ordinal particle forms
- *DEX* (dexonline.ro) — *sută, mie, milion, miliard, jumătate, treime, sfert, pătrime* and their plurals
- *Gramatica limbii române* (Academia Română) — numeral-noun linking with *de* for numbers ≥ 20, gender agreement of *unu/una, doi/două*, neuter agreement of *milion/miliard*

## Testing

- `tests/test_number_parser_ro.py`: hand-verified pronounce/extract anchors (și-joins, de-insertion, gender variants, decimals, negatives, fractions, ordinals both genders, colloquial teens) plus round-trip sweeps (0–999 exhaustive and large-number/decimal/ordinal/feminine sweeps)
- `ro` added to `tests/test_lang_parity.py` LANGS and its fraction/ordinal anchor tables
- full suite: 550 passed, 1 skipped, 1 xfailed