### PR TITLE
feat: west frisian and aragonese number support

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ fractional and ordinal numbers, and more.
 | `ast` (Asturian)        | ✅                | ✅                  | ✅              | ✅                |
 | `oc` (Occitan)          | ✅                | ✅                  | ✅              | ✅                |
 | `ro` (Romanian)         | ✅                | ✅                  | ✅              | ✅                |
+| `an` (Aragonese)        | ✅                | ✅                  | ✅              | ✅                |
+| `fy` (West Frisian)     | ✅                | ✅                  | ✅              | ✅                |
 | `ru` (Russian)          | ✅                | 🚧                 | ✅              | ✅                 |
 | `sv` (Swedish)          | ✅                | ✅                 | ✅              | ❌                 |
 | `sl` (Slovenian)        | ✅                | 🚧                 | ❌              | ❌                 |

--- a/docs/languages.md
+++ b/docs/languages.md
@@ -2,7 +2,7 @@
 
 Per-language behaviour that goes beyond the support matrix in the README.
 
-## Germanic compound numbers (de, nl, da, sv)
+## Germanic compound numbers (de, nl, da, sv, fy)
 
 These languages write numbers as single compound words. The extractors split
 them into their component number words and evaluate the result, so both the
@@ -14,8 +14,12 @@ compound and the spaced form parse:
 | Dutch    | `eenentwintig`, `tweehonderddrieëntwintig` | 21, 223 |
 | Danish   | `toogfyrre`, `nihundredenioghalvfems` | 42, 999 |
 | Swedish  | `tjugoen`, `etthundratjugotre`, `tvåtusen tjugotre` | 21, 123, 2023 |
+| West Frisian | `ienentweintich`, `twahûnderttrijeentweintich` | 21, 223 |
 
 Dutch diacritics (`één`, `drieëntwintig`) are normalized before parsing.
+West Frisian diacritics (`sân`, `hûndert`, `tûzen`) are likewise normalized,
+and the variant spellings without the etymological `-s-` (`sechtjin`,
+`sechtich`) are accepted alongside the standard `sechstjin`/`sechstich`.
 Danish accepts both the standard spellings (`elleve`, `halvtreds`,
 `halvfjerds`) and the legacy variants kept for backward compatibility.
 
@@ -30,9 +34,9 @@ Basque counts in twenties. The `-ta` joiner forms are understood when
 extracting: `hogeita bat` (20 + 1 = 21), `berrogeita hamar` (40 + 10 = 50),
 `laurogeita hemeretzi` (80 + 19 = 99).
 
-## Romance languages (pt, gl, mwl, ast)
+## Romance languages (pt, gl, mwl, ast, an)
 
-Portuguese, Galician, Mirandese and Asturian share a declarative
+Portuguese, Galician, Mirandese, Asturian and Aragonese share a declarative
 `NumberVocabulary` + `RomanceNumberExtractor` implementation in
 `ovos_number_parser.util`. Each language is described by its vocabulary
 (units, tens, hundreds, scales, ordinals, fractions, gender rules and joiner
@@ -42,6 +46,13 @@ of them. This is the preferred path for adding new Romance languages.
 Portuguese distinguishes European and Brazilian variants (`pt-PT` reads
 16 as `dezasseis`, `pt-BR` as `dezesseis`) and inflects `um/uma`,
 `dois/duas` and the hundreds (`duzentos/duzentas`) for grammatical gender.
+
+Aragonese pronounces the general forms of the current academic norm
+(`cuatre`, `ueito`, `deciséis`, `vintiún`, `trenta y cinco`, `cient`) and
+accepts the dialectal variants (`quatre`, `güeito`, `setse`, `vente`,
+`noranta`) on extraction. Ordinals use the characteristic `-eno` series
+(`cuatreno`, `cinqueno`, `onceno`); tens ordinals above the attested range
+follow the same productive `-eno` pattern.
 
 ## Spanish and Catalan
 

--- a/ovos_number_parser/__init__.py
+++ b/ovos_number_parser/__init__.py
@@ -4,6 +4,7 @@ from typing import Union
 from unicode_rbnf import RbnfEngine, FormatPurpose
 
 from ovos_number_parser.numbers_ast import AST
+from ovos_number_parser.numbers_an import AN
 from ovos_number_parser.numbers_ar import pronounce_number_ar, pronounce_ordinal_ar, extract_number_ar, \
     is_fractional_ar, is_ordinal_ar, nice_number_ar
 from ovos_number_parser.numbers_az import numbers_to_digits_az, extract_number_az, is_fractional_az, pronounce_number_az
@@ -22,6 +23,8 @@ from ovos_number_parser.numbers_eu import pronounce_number_eu, extract_number_eu
 from ovos_number_parser.numbers_fa import pronounce_number_fa, extract_number_fa, is_fractional_fa, \
     pronounce_ordinal_fa
 from ovos_number_parser.numbers_fr import (pronounce_number_fr, extract_number_fr, is_fractional_fr)
+from ovos_number_parser.numbers_fy import numbers_to_digits_fy, pronounce_number_fy, pronounce_ordinal_fy, \
+    extract_number_fy, is_fractional_fy, nice_number_fy
 from ovos_number_parser.numbers_gl import pronounce_number_gl, extract_number_gl, is_fractional_gl, \
     numbers_to_digits_gl, pronounce_ordinal_gl, is_ordinal_gl, pronounce_fraction_gl
 from ovos_number_parser.numbers_hu import pronounce_number_hu, pronounce_ordinal_hu, extract_number_hu, \
@@ -69,7 +72,7 @@ from ovos_number_parser.util import Scale, GrammaticalGender, DigitPronunciation
 _NICE_NUMBER_FNS = {
     "ar": nice_number_ar, "az": nice_number_az, "ca": nice_number_ca, "cs": nice_number_cs,
     "da": nice_number_da, "de": nice_number_de, "es": nice_number_es,
-    "eu": nice_number_eu, "fa": nice_number_fa, "fr": nice_number_fr,
+    "eu": nice_number_eu, "fa": nice_number_fa, "fr": nice_number_fr, "fy": nice_number_fy,
     "hu": nice_number_hu, "it": nice_number_it, "nl": nice_number_nl,
     "pl": nice_number_pl, "ru": nice_number_ru, "sl": nice_number_sl,
     "sv": nice_number_sv, "uk": nice_number_uk,
@@ -88,7 +91,7 @@ _FRACTION_NUMERATOR_OVERRIDES = {
 # words that may join two spoken numbers ("vingt et un", "sto in ena")
 _NUMBER_CONNECTORS = {
     "ar": {"و"}, "ca": {"i"}, "da": {"og"}, "en": {"and"}, "es": {"y"}, "eu": {"eta"},
-    "fr": {"et"}, "it": {"e"}, "nl": {"en"}, "sv": {"och"},
+    "fr": {"et"}, "fy": {"en"}, "it": {"e"}, "nl": {"en"}, "sv": {"och"},
     "fa": {"و"}, "sl": {"in"}, "hu": set(), "kab": {"u", "d", "ed"},
 }
 
@@ -254,6 +257,10 @@ def numbers_to_digits(utterance: str, lang: str, scale: Optional[Scale] = None) 
         return AST.numbers_to_digits(utterance)
     if lang.startswith("oc"):
         return OC.numbers_to_digits(utterance, scale=scale)
+    if lang.startswith("an"):
+        return AN.numbers_to_digits(utterance)
+    if lang.startswith("fy"):
+        return numbers_to_digits_fy(utterance)
     if lang.startswith("gl"):
         return numbers_to_digits_gl(utterance)
     if lang.startswith("de"):
@@ -317,6 +324,8 @@ def pronounce_number(number: Union[int, float], lang: str,
         return AST.pronounce_number(number, places, scale, ordinals, digits, gender)
     if lang.startswith("oc"):
         return OC.pronounce_number(number, places, scale, ordinals, digits, gender)
+    if lang.startswith("an"):
+        return AN.pronounce_number(number, places, scale, ordinals, digits, gender)
     if lang.startswith("cs"):
         return pronounce_number_cs(number, places, short_scale, scientific, ordinals)
     if lang.startswith("da"):
@@ -339,6 +348,8 @@ def pronounce_number(number: Union[int, float], lang: str,
         return pronounce_number_it(number, places, short_scale, scientific)
     if lang.startswith("kab"):
         return pronounce_number_kab(number, places, ordinals, gender)
+    if lang.startswith("fy"):
+        return pronounce_number_fy(number, places, short_scale, scientific, ordinals)
     if lang.startswith("nl"):
         return pronounce_number_nl(number, places, short_scale, scientific, ordinals)
     if lang.startswith("pl"):
@@ -389,6 +400,8 @@ def pronounce_fraction(fraction_word: str, lang: str, scale: Optional[Scale] = N
         return AST.pronounce_fraction(fraction_word, scale=scale)
     elif lang.startswith("oc"):
         return OC.pronounce_fraction(fraction_word, scale=scale)
+    elif lang.startswith("an"):
+        return AN.pronounce_fraction(fraction_word, scale=scale)
     elif lang.startswith("mwl"):
         return MWL.pronounce_fraction(fraction_word, scale=scale)
     elif lang.startswith("gl"):
@@ -434,6 +447,8 @@ def pronounce_ordinal(number: Union[int, float], lang: str,
         return AST.pronounce_ordinal(number, scale=scale, gender=gender)
     if lang.startswith("oc"):
         return OC.pronounce_ordinal(number, scale=scale, gender=gender)
+    if lang.startswith("an"):
+        return AN.pronounce_ordinal(number, scale=scale, gender=gender)
     if lang.startswith("ar"):
         return pronounce_ordinal_ar(number)
     if lang.startswith("da"):
@@ -442,6 +457,8 @@ def pronounce_ordinal(number: Union[int, float], lang: str,
         return pronounce_ordinal_de(number)
     if lang.startswith("hu"):
         return pronounce_ordinal_hu(number)
+    if lang.startswith("fy"):
+        return pronounce_ordinal_fy(number)
     if lang.startswith("nl"):
         return pronounce_ordinal_nl(number)
     if lang.startswith("sv"):
@@ -525,6 +542,8 @@ def extract_number(text: str, lang: str,
         return extract_number_it(text, short_scale, ordinals)
     if lang.startswith("kab"):
         return extract_number_kab(text, short_scale, ordinals)
+    if lang.startswith("fy"):
+        return extract_number_fy(text, short_scale, ordinals)
     if lang.startswith("nl"):
         return extract_number_nl(text, short_scale, ordinals)
     if lang.startswith("pl"):
@@ -540,6 +559,8 @@ def extract_number(text: str, lang: str,
         return AST.extract_number(text, scale=scale, ordinals=ordinals)
     if lang.startswith("oc"):
         return OC.extract_number(text, scale=scale, ordinals=ordinals)
+    if lang.startswith("an"):
+        return AN.extract_number(text, scale=scale, ordinals=ordinals)
     if lang.startswith("ru"):
         return extract_number_ru(text, short_scale, ordinals)
     if lang.startswith("sv"):
@@ -602,6 +623,8 @@ def is_fractional(input_str: str, lang: str,
         return is_fractional_it(input_str, short_scale)
     if lang.startswith("kab"):
         return is_fractional_kab(input_str, short_scale)
+    if lang.startswith("fy"):
+        return is_fractional_fy(input_str, short_scale)
     if lang.startswith("nl"):
         return is_fractional_nl(input_str, short_scale)
     if lang.startswith("pl"):
@@ -616,6 +639,8 @@ def is_fractional(input_str: str, lang: str,
         return AST.is_fractional(input_str)
     if lang.startswith("oc"):
         return OC.is_fractional(input_str)
+    if lang.startswith("an"):
+        return AN.is_fractional(input_str)
     if lang.startswith("ru"):
         return is_fractional_ru(input_str, short_scale)
     if lang.startswith("sv"):
@@ -653,6 +678,8 @@ def is_ordinal(input_str: str, lang: str) -> Union[bool, float]:
         return AST.is_ordinal(input_str)
     if lang.startswith("oc"):
         return OC.is_ordinal(input_str)
+    if lang.startswith("an"):
+        return AN.is_ordinal(input_str)
     if lang.startswith("en"):
         return is_ordinal_en(input_str)
     if lang.startswith("ar"):

--- a/ovos_number_parser/numbers_an.py
+++ b/ovos_number_parser/numbers_an.py
@@ -1,0 +1,235 @@
+from ovos_number_parser.util import (Scale, GrammaticalGender, NumberVocabulary, RomanceNumberExtractor)
+
+
+def swap_gender_an(word: str, gender: GrammaticalGender) -> str:
+    """Swap ordinal/adjective endings between masculine and feminine.
+
+    Aragonese ordinals end in -o (masc.) and -a (fem.): primero/primera,
+    cuatreno/cuatrena.
+    """
+    if gender == GrammaticalGender.FEMININE:
+        if word.endswith('o'):
+            return word[:-1] + 'a'
+        if word.endswith('os'):
+            return word[:-2] + 'as'
+    else:
+        if word.endswith('a'):
+            return word[:-1] + 'o'
+        if word.endswith('as'):
+            return word[:-2] + 'os'
+    return word
+
+
+def pluralize_an(word: str):
+    if word.endswith("ón"):
+        return word[:-2] + "ones"
+    if not word.endswith("s"):
+        return word + "s"
+    return word
+
+
+_AN = NumberVocabulary(
+    LANG="an",
+    swap_gender=swap_gender_an,  # used for female forms
+    pluralize=pluralize_an,  # used for plural forms
+
+    HUNDRED_PARTICLE="ciento",  # how to read "1XX" - "ciento vinte"
+    DENOMINATOR_PARTICLE="avos",  # for fractions  X / N {PARTICLE}
+    DIVIDED_BY_ZERO="dividiu por zero",  # how to read X/0 values
+    NO_PREV_UNIT=[100, 1000],  # "mil" not "un mil" / "cient" not "un cient"
+    NO_PLURAL=[1000],  # "dos mil" not "dos mils"
+
+    NUMBER_OVERFLOW="numero exageradament gran",
+    DEFAULT_SCALE=Scale.LONG,
+    JOIN_WORD=["y"],
+
+    JOINER_ON_TWENTYS=True,  # 21-29 have fused spellings, joiner kept for extraction
+    JOINER_ON_HUNDREDS=False,  # "ciento trenta", "docientos vintiún"
+    JOINER_ON_THOUSANDS=False,  # "mil docientos"
+
+    DECIMAL_MARKER=["coma", "punto", ".", ","],
+    NEGATIVE_SIGN=["menos"],
+    UNITS={
+        0: 'zero',
+        1: 'un',
+        2: 'dos',
+        3: 'tres',
+        4: 'cuatre',
+        5: 'cinco',
+        6: 'seis',
+        7: 'siet',
+        8: 'ueito',
+        9: 'nueu'
+    },
+    TENS={
+        10: 'diez',
+        11: 'once',
+        12: 'doce',
+        13: 'trece',
+        14: 'catorze',
+        15: 'quince',
+        16: 'deciséis',
+        17: 'decisiet',
+        18: 'deciueito',
+        19: 'decinueu',
+        20: 'vinte',
+        21: 'vintiún',
+        22: 'vintidós',
+        23: 'vintitrés',
+        24: 'vinticuatre',
+        25: 'vinticinco',
+        26: 'vintiséis',
+        27: 'vintisiet',
+        28: 'vintiueito',
+        29: 'vintinueu',
+        30: 'trenta',
+        40: 'cuaranta',
+        50: 'cincuanta',
+        60: 'sixanta',
+        70: 'setanta',
+        80: 'uitanta',
+        90: 'novanta'
+    },
+    HUNDREDS={
+        100: 'cient',
+        200: 'docientos',
+        300: 'trecientos',
+        400: 'cuatrecientos',
+        500: 'cincocientos',
+        600: 'seicientos',
+        700: 'sietecientos',
+        800: 'uitcientos',
+        900: 'noucientos'
+    },
+    FRACTION={
+        2: 'meyo',
+        3: 'tercio',
+        4: 'cuarto'
+    },
+    FRACTION_FEMALE={
+        2: "meya"  # una y meya -> 1.5
+    },
+    SHORT_SCALE={
+        10 ** 3: "mil",
+        10 ** 6: "millón"
+    },
+    LONG_SCALE={
+        10 ** 3: "mil",
+        10 ** 6: "millón"
+    },
+
+    GENDERED_SPELLINGS={
+        GrammaticalGender.FEMININE: {
+            1: "una"
+        }
+    },
+    DIGIT_SPELLINGS={},
+    ALT_SPELLINGS={
+        # dialectal / variant spellings kept for extraction only
+        "uno": 1,
+        "quatre": 4,
+        "quatro": 4,
+        "cuatro": 4,
+        "cinc": 5,
+        "sies": 6,
+        "sieis": 6,
+        "siete": 7,
+        "set": 7,
+        "ueit": 8,
+        "güeito": 8,
+        "nou": 9,
+        "deu": 10,
+        "dotse": 12,
+        "dotze": 12,
+        "tretse": 13,
+        "tretze": 13,
+        "catorce": 14,
+        "sece": 16,
+        "setse": 16,
+        "decisiete": 17,
+        "decinou": 19,
+        "vint": 20,
+        "vente": 20,
+        "vintiuno": 21,
+        "ventiún": 21,
+        "ventiuno": 21,
+        "ventidós": 22,
+        "ventitrés": 23,
+        "cuarenta": 40,
+        "quaranta": 40,
+        "quarenta": 40,
+        "cinquanta": 50,
+        "sisanta": 60,
+        "sesenta": 60,
+        "setenta": 70,
+        "noranta": 90,
+        "cien": 100,
+        "cent": 100,
+        "ciento": 100
+    },
+    ORDINAL_UNITS={
+        1: 'primero',
+        2: 'segundo',
+        3: 'tercero',
+        4: 'cuatreno',
+        5: 'cinqueno',
+        6: 'seiseno',
+        7: 'seteno',
+        8: 'uiteno',
+        9: 'noveno'
+    },
+    ORDINAL_TENS={
+        10: 'deceno',
+        11: 'onceno',
+        12: 'doceno',
+        13: 'treceno',
+        14: 'catorzeno',
+        15: 'quinceno',
+        16: 'deciseiseno',
+        17: 'decisieteno',
+        18: 'deciueiteno',
+        19: 'decinoveno',
+        20: 'venteno',
+        30: 'trenteno',
+        40: 'cuaranteno',
+        50: 'cincuanteno',
+        60: 'sixanteno',
+        70: 'setanteno',
+        80: 'uitanteno',
+        90: 'novanteno'
+    },
+    ORDINAL_HUNDREDS={
+        100: 'centeno'
+    },
+    ORDINAL_SHORT_SCALE={
+        10 ** 3: "mileno"
+    },
+    ORDINAL_LONG_SCALE={
+        10 ** 3: "mileno"
+    }
+)
+
+AN = RomanceNumberExtractor(_AN)
+
+if __name__ == '__main__':
+    print('--- Aragonese number tests ---')
+    print('16 ->', AN.pronounce_number(16))
+    print('21 ->', AN.pronounce_number(21))
+    print('35 ->', AN.pronounce_number(35))
+    print('101 ->', AN.pronounce_number(101))
+    print('1,234 ->', AN.pronounce_number(1234))
+    print('1,000,000 ->', AN.pronounce_number(1_000_000))
+
+    print('\n--- Ordinals ---')
+    print('1st (m):', AN.pronounce_ordinal(1))
+    print('1st (f):', AN.pronounce_ordinal(1, GrammaticalGender.FEMININE))
+    print('4th (m):', AN.pronounce_ordinal(4))
+    print('11th:', AN.pronounce_ordinal(11))
+
+    print('\n--- Extraction ---')
+    print("'un millón' ->", AN.extract_number('un millón'))
+    print("'trenta y cinco' ->", AN.extract_number('trenta y cinco'))
+    print("'vintiún' ->", AN.extract_number('vintiún'))
+
+    print('\n--- numbers_to_digits ---')
+    print(AN.numbers_to_digits('bi ha docientos cincuanta personas'))

--- a/ovos_number_parser/numbers_fy.py
+++ b/ovos_number_parser/numbers_fy.py
@@ -1,0 +1,867 @@
+from collections import OrderedDict
+from math import floor
+
+from ovos_number_parser.util import convert_to_mixed_fraction, is_numeric, look_for_fractions, Token, \
+    ReplaceableNumber, tokenize, partition_list, invert_dict
+
+_ARTICLES_FY = {'de', 'it'}
+
+_NUM_STRING_FY = {
+    0: 'nul',
+    1: 'ien',
+    2: 'twa',
+    3: 'trije',
+    4: 'fjouwer',
+    5: 'fiif',
+    6: 'seis',
+    7: 'sân',
+    8: 'acht',
+    9: 'njoggen',
+    10: 'tsien',
+    11: 'alve',
+    12: 'tolve',
+    13: 'trettjin',
+    14: 'fjirtjin',
+    15: 'fyftjin',
+    16: 'sechstjin',
+    17: 'santjin',
+    18: 'achttjin',
+    19: 'njoggentjin',
+    20: 'tweintich',
+    30: 'tritich',
+    40: 'fjirtich',
+    50: 'fyftich',
+    60: 'sechstich',
+    70: 'santich',
+    80: 'tachtich',
+    90: 'njoggentich',
+    100: 'hûndert'
+}
+
+_FRACTION_STRING_FY = {
+    2: 'heal',
+    3: 'tredde',
+    4: 'fjirde',
+    5: 'fyfte',
+    6: 'sechste',
+    7: 'sânde',
+    8: 'achtste',
+    9: 'njoggende',
+    10: 'tsiende',
+    11: 'alfde',
+    12: 'tolfde',
+    13: 'trettjinde',
+    14: 'fjirtjinde',
+    15: 'fyftjinde',
+    16: 'sechstjinde',
+    17: 'santjinde',
+    18: 'achttjinde',
+    19: 'njoggentjinde',
+    20: 'tweintichste'
+}
+
+# West Frisian uses the long scale, alternating -joen and -jard suffixes
+_LONG_SCALE_FY = OrderedDict([
+    (100, 'hûndert'),
+    (1000, 'tûzen'),
+    (1000000, 'miljoen'),
+    (1e12, 'biljoen'),
+    (1e18, 'triljoen'),
+])
+
+_SHORT_SCALE_FY = OrderedDict([
+    (100, 'hûndert'),
+    (1000, 'tûzen'),
+    (1000000, 'miljoen'),
+    (1e9, 'miljard'),
+    (1e12, 'biljoen'),
+    (1e15, 'biljard'),
+    (1e18, 'triljoen'),
+    (1e21, 'triljard'),
+])
+
+_ORDINAL_STRING_BASE_FY = {
+    1: 'earste',
+    2: 'twadde',
+    3: 'tredde',
+    4: 'fjirde',
+    5: 'fyfte',
+    6: 'sechste',
+    7: 'sânde',
+    8: 'achtste',
+    9: 'njoggende',
+    10: 'tsiende',
+    11: 'alfde',
+    12: 'tolfde',
+    13: 'trettjinde',
+    14: 'fjirtjinde',
+    15: 'fyftjinde',
+    16: 'sechstjinde',
+    17: 'santjinde',
+    18: 'achttjinde',
+    19: 'njoggentjinde',
+    20: 'tweintichste',
+    30: 'tritichste',
+    40: 'fjirtichste',
+    50: 'fyftichste',
+    60: 'sechstichste',
+    70: 'santichste',
+    80: 'tachtichste',
+    90: 'njoggentichste',
+    1e2: 'hûndertste',
+    1e3: 'tûzenste'
+}
+
+_SHORT_ORDINAL_STRING_FY = {
+    1e6: 'miljoenste',
+    1e9: 'miljardste',
+    1e12: 'biljoenste',
+    1e15: 'biljardste',
+    1e18: 'triljoenste',
+    1e21: 'triljardste'
+}
+_SHORT_ORDINAL_STRING_FY.update(_ORDINAL_STRING_BASE_FY)
+
+_LONG_ORDINAL_STRING_FY = {
+    1e6: 'miljoenste',
+    1e12: 'biljoenste',
+    1e18: 'triljoenste'
+}
+_LONG_ORDINAL_STRING_FY.update(_ORDINAL_STRING_BASE_FY)
+
+# negate next number (-2 = 0 - 2)
+_NEGATIVES_FY = {"min", "minus"}
+
+# sum the next number (twenty two = 20 + 2)
+_SUMS_FY = {'tweintich', '20', 'tritich', '30', 'fjirtich', '40',
+            'fyftich', '50', 'sechstich', '60', 'santich', '70',
+            'tachtich', '80', 'njoggentich', '90'}
+
+_MULTIPLIES_LONG_SCALE_FY = set(_LONG_SCALE_FY.values())
+
+_MULTIPLIES_SHORT_SCALE_FY = set(_SHORT_SCALE_FY.values())
+
+# split sentence parse separately and sum ( 2 and a half = 2 + 0.5 )
+_FRACTION_MARKER_FY = {"en"}
+
+# decimal marker ( 1 komma 5 = 1 + 0.5)
+_DECIMAL_MARKER_FY = {"komma", "punt"}
+
+_STRING_NUM_FY = invert_dict(_NUM_STRING_FY)
+_STRING_NUM_FY.update({
+    # spellings without diacritics, common in ASR output
+    "san": 7,
+    "hundert": 100,
+    "tuzen": 1000,
+    # variant teen/ten spellings without the etymological -s-
+    "sechtjin": 16,
+    "sechtich": 60,
+    "heal": 0.5,
+})
+
+_STRING_SHORT_ORDINAL_FY = invert_dict(_SHORT_ORDINAL_STRING_FY)
+_STRING_LONG_ORDINAL_FY = invert_dict(_LONG_ORDINAL_STRING_FY)
+
+# Numbers below 1 million are written in one word in West Frisian, just as
+# in Dutch: units come before the tens, joined with "en" (ienentweintich)
+
+_NUM_POWERS_OF_TEN_FY = [
+    '', 'tûzen', 'miljoen', 'miljard', 'biljoen', 'biljard', 'triljoen',
+    'triljard'
+]
+
+_EXTRA_SPACE_FY = ""
+
+
+def nice_number_fy(number, speech=True, denominators=range(1, 21)):
+    """ West Frisian helper for nice_number
+
+    This function formats a float to a human understandable string. Like
+    4.5 becomes "4 en in heal" for speech and "4 1/2" for text
+
+    Args:
+        number (int or float): the float to format
+        speech (bool): format for speech (True) or display (False)
+        denominators (iter of ints): denominators to use, default [1 .. 20]
+    Returns:
+        (str): The formatted string.
+    """
+    result = convert_to_mixed_fraction(number, denominators)
+    if not result:
+        # Give up, just represent as a 3 decimal number
+        return str(round(number, 3)).replace(".", ",")
+    whole, num, den = result
+    if not speech:
+        if num == 0:
+            return str(whole)
+        else:
+            return '{} {}/{}'.format(whole, num, den)
+    if num == 0:
+        return str(whole)
+    den_str = _FRACTION_STRING_FY[den]
+    if whole == 0:
+        if num == 1:
+            return_string = 'ien {}'.format(den_str)
+        else:
+            return_string = '{} {}'.format(num, den_str)
+    elif num == 1:
+        return_string = '{} en ien {}'.format(whole, den_str)
+    else:
+        return_string = '{} en {} {}'.format(whole, num, den_str)
+
+    return return_string
+
+
+def pronounce_number_fy(number, places=2, short_scale=True, scientific=False,
+                        ordinals=False):
+    """
+    Convert a number to its spoken West Frisian equivalent
+
+    For example, '5.2' would return 'fiif komma twa'
+
+    Args:
+        number(float or int): the number to pronounce
+        places(int): maximum decimal places to speak
+        short_scale (bool) : use short (True) or long scale (False)
+            https://en.wikipedia.org/wiki/Names_of_large_numbers
+        scientific (bool): pronounce in scientific notation
+        ordinals (bool): pronounce in ordinal form "first" instead of "one"
+    Returns:
+        (str): The pronounced number
+    """
+    if ordinals:
+        return pronounce_ordinal_fy(number)
+
+    def pronounce_triplet_fy(num):
+        result = ""
+        num = floor(num)
+        if num > 99:
+            hundreds = floor(num / 100)
+            if hundreds > 0:
+                result += _NUM_STRING_FY[hundreds] + _EXTRA_SPACE_FY + 'hûndert' + _EXTRA_SPACE_FY
+                num -= hundreds * 100
+        if num == 0:
+            result += ''  # do nothing
+        elif num <= 20:
+            result += _NUM_STRING_FY[num]
+        elif num > 20:
+            ones = num % 10
+            tens = num - ones
+            if ones > 0:
+                result += _NUM_STRING_FY[ones] + _EXTRA_SPACE_FY
+                if tens > 0:
+                    result += 'en' + _EXTRA_SPACE_FY
+            if tens > 0:
+                result += _NUM_STRING_FY[tens] + _EXTRA_SPACE_FY
+        return result
+
+    def pronounce_fractional_fy(num, places):
+        # fixed number of places even with trailing zeros
+        result = ""
+        num = round(num, places)
+        place = 10
+        while places > 0:
+            result += " " + _NUM_STRING_FY[int(num * place) % 10]
+            place *= 10
+            places -= 1
+        return result
+
+    def pronounce_whole_number_fy(num, scale_level=0):
+        if num == 0:
+            return ''
+
+        num = floor(num)
+        result = ''
+        last_triplet = num % 1000
+
+        if last_triplet == 1:
+            if scale_level == 0:
+                result += "ien"
+            elif scale_level == 1:
+                result += 'ien' + _EXTRA_SPACE_FY + 'tûzen' + _EXTRA_SPACE_FY
+            else:
+                result += "ien " + _NUM_POWERS_OF_TEN_FY[scale_level] + ' '
+        elif last_triplet > 1:
+            result += pronounce_triplet_fy(last_triplet)
+            if scale_level == 1:
+                result += 'tûzen' + _EXTRA_SPACE_FY
+            if scale_level >= 2:
+                result += " " + _NUM_POWERS_OF_TEN_FY[scale_level] + ' '
+
+        num = floor(num / 1000)
+        scale_level += 1
+        return pronounce_whole_number_fy(num, scale_level) + result
+
+    result = ""
+    if abs(number) >= 1000000000000000000000000:  # cannot do more than this
+        return str(number)
+    elif number == 0:
+        return str(_NUM_STRING_FY[0])
+    elif number < 0:
+        return "min " + pronounce_number_fy(abs(number), places)
+    else:
+        if number == int(number):
+            return pronounce_whole_number_fy(number)
+        else:
+            whole_number_part = floor(number)
+            fractional_part = number - whole_number_part
+            result += pronounce_whole_number_fy(whole_number_part) or \
+                _NUM_STRING_FY[0]
+            if places > 0:
+                result += " komma"
+                result += pronounce_fractional_fy(fractional_part, places)
+            return result
+
+
+def pronounce_ordinal_fy(number):
+    """
+    This function pronounces a West Frisian number as an ordinal
+
+    1 -> earste
+    2 -> twadde
+
+    Args:
+        number (int): the number to format
+    Returns:
+        (str): The pronounced number string.
+    """
+    # only for whole positive numbers including zero
+    if number < 0 or number != int(number):
+        return number
+    number = int(number)
+    if number in _ORDINAL_STRING_BASE_FY:
+        return _ORDINAL_STRING_BASE_FY[number]
+    if number in _SHORT_ORDINAL_STRING_FY:
+        return _SHORT_ORDINAL_STRING_FY[number]
+    # compounds: cardinal + table-driven last element, mirroring the
+    # cardinal compounding ("ienentweintich" -> "ienentweintichste")
+    if number < 100:
+        ones = number % 10
+        tens = number - ones
+        return _NUM_STRING_FY[ones] + "en" + _ORDINAL_STRING_BASE_FY[tens]
+    return pronounce_number_fy(number) + "ste"
+
+
+def numbers_to_digits_fy(text, short_scale=True, ordinals=False):
+    """Convert words in a string into their equivalent numbers.
+    Args:
+        text str:
+        short_scale boolean: True if short scale numbers should be used.
+        ordinals boolean: True if ordinals (e.g. first, second, third) should
+                          be parsed to their number values (1, 2, 3...)
+
+    Returns:
+        str
+        The original text, with numbers subbed in where appropriate.
+    """
+    text = text.lower().replace("û", "u").replace("â", "a") \
+        .replace("ú", "u").replace("á", "a").replace("ê", "e") \
+        .replace("ô", "o").replace("é", "e")
+    text = _expand_compound_numbers_fy(text, short_scale)
+    tokens = tokenize(text)
+    numbers_to_replace = \
+        _extract_numbers_with_text_fy(tokens, short_scale, ordinals)
+    numbers_to_replace.sort(key=lambda number: number.start_index)
+
+    results = []
+    for token in tokens:
+        if not numbers_to_replace or \
+                token.index < numbers_to_replace[0].start_index:
+            results.append(token.word)
+        else:
+            if numbers_to_replace and \
+                    token.index == numbers_to_replace[0].start_index:
+                results.append(str(numbers_to_replace[0].value))
+            if numbers_to_replace and \
+                    token.index == numbers_to_replace[0].end_index:
+                numbers_to_replace.pop(0)
+
+    return ' '.join(results)
+
+
+def _extract_numbers_with_text_fy(tokens, short_scale=True,
+                                  ordinals=False, fractional_numbers=True):
+    """Extract all numbers from a list of Tokens, with the representing words.
+
+    Args:
+        [Token]: The tokens to parse.
+        short_scale bool: True if short scale numbers should be used, False for
+                          long scale. True by default.
+        ordinals bool: True if ordinal words (first, second, third, etc) should
+                       be parsed.
+        fractional_numbers bool: True if we should look for fractions and
+                                 decimals.
+
+    Returns:
+        [ReplaceableNumber]: A list of tuples, each containing a number and a
+                         string.
+    """
+    placeholder = "<placeholder>"  # inserted to maintain correct indices
+    results = []
+    while True:
+        to_replace = \
+            _extract_number_with_text_fy(tokens, short_scale,
+                                         ordinals, fractional_numbers)
+
+        if not to_replace:
+            break
+
+        results.append(to_replace)
+
+        tokens = [
+            t if not
+            to_replace.start_index <= t.index <= to_replace.end_index
+            else
+            Token(placeholder, t.index) for t in tokens
+        ]
+    results.sort(key=lambda n: n.start_index)
+    return results
+
+
+def _extract_number_with_text_fy(tokens, short_scale=True,
+                                 ordinals=False, fractional_numbers=True):
+    """This function extracts a number from a list of Tokens.
+
+    Args:
+        tokens str: the string to normalize
+        short_scale (bool): use short scale if True, long scale if False
+        ordinals (bool): consider ordinal numbers, third=3 instead of 1/3
+        fractional_numbers (bool): True if we should look for fractions and
+                                   decimals.
+    Returns:
+        ReplaceableNumber
+    """
+    number, tokens = \
+        _extract_number_with_text_fy_helper(tokens, short_scale,
+                                            ordinals, fractional_numbers)
+    while tokens and tokens[0].word in _ARTICLES_FY:
+        tokens.pop(0)
+    return ReplaceableNumber(number, tokens)
+
+
+def _extract_number_with_text_fy_helper(tokens,
+                                        short_scale=True, ordinals=False,
+                                        fractional_numbers=True):
+    """Helper for _extract_number_with_text_fy.
+
+    This contains the real logic for parsing, but produces
+    a result that needs a little cleaning (specific, it may
+    contain leading articles that can be trimmed off).
+
+    Args:
+        tokens [Token]:
+        short_scale boolean:
+        ordinals boolean:
+        fractional_numbers boolean:
+
+    Returns:
+        int or float, [Tokens]
+    """
+    if fractional_numbers:
+        fraction, fraction_text = \
+            _extract_fraction_with_text_fy(tokens, short_scale, ordinals)
+        if fraction:
+            return fraction, fraction_text
+
+        decimal, decimal_text = \
+            _extract_decimal_with_text_fy(tokens, short_scale, ordinals)
+        if decimal:
+            return decimal, decimal_text
+
+    return _extract_whole_number_with_text_fy(tokens, short_scale, ordinals)
+
+
+def _extract_fraction_with_text_fy(tokens, short_scale, ordinals):
+    """Extract fraction numbers from a string.
+
+    This function handles text such as '2 en 3/4'. Note that "ien heal" or
+    similar will be parsed by the whole number function.
+
+    Args:
+        tokens [Token]: words and their indexes in the original string.
+        short_scale boolean:
+        ordinals boolean:
+
+    Returns:
+        (int or float, [Token])
+        The value found, and the list of relevant tokens.
+        (None, None) if no fraction value is found.
+    """
+    for c in _FRACTION_MARKER_FY:
+        partitions = partition_list(tokens, lambda t: t.word == c)
+
+        if len(partitions) == 3:
+            numbers1 = \
+                _extract_numbers_with_text_fy(partitions[0], short_scale,
+                                              ordinals, fractional_numbers=False)
+            numbers2 = \
+                _extract_numbers_with_text_fy(partitions[2], short_scale,
+                                              ordinals, fractional_numbers=True)
+
+            if not numbers1 or not numbers2:
+                return None, None
+
+            # ensure first is not a fraction and second is a fraction
+            num1 = numbers1[-1]
+            num2 = numbers2[0]
+            if num1.value >= 1 and 0 < num2.value < 1:
+                return num1.value + num2.value, \
+                       num1.tokens + partitions[1] + num2.tokens
+
+    return None, None
+
+
+def _extract_decimal_with_text_fy(tokens, short_scale, ordinals):
+    """Extract decimal numbers from a string.
+
+    This function handles text such as '2 komma 5'.
+
+    Notes:
+        While this is a helper for extract_number_fy, it also depends on
+        extract_number_fy, to parse out the components of the decimal.
+
+        This does not currently handle things like:
+            number dot number number number
+
+    Args:
+        tokens [Token]: The text to parse.
+        short_scale boolean:
+        ordinals boolean:
+
+    Returns:
+        (float, [Token])
+        The value found and relevant tokens.
+        (None, None) if no decimal value is found.
+    """
+    for c in _DECIMAL_MARKER_FY:
+        partitions = partition_list(tokens, lambda t: t.word == c)
+
+        if len(partitions) == 3:
+            numbers1 = \
+                _extract_numbers_with_text_fy(partitions[0], short_scale,
+                                              ordinals, fractional_numbers=False)
+            numbers2 = \
+                _extract_numbers_with_text_fy(partitions[2], short_scale,
+                                              ordinals, fractional_numbers=False)
+
+            if not numbers1 or not numbers2:
+                return None, None
+
+            number = numbers1[-1]
+            decimal = numbers2[0]
+            # concatenate consecutive single digits after the marker
+            # ("komma ien fjouwer" -> .14)
+            _digits = ""
+            _digit_tokens = []
+            _prev_end = None
+            for _num in numbers2:
+                _v = _num.value
+                if _v is None or _v is False or float(_v) != int(_v) \
+                        or not 0 <= _v <= 9:
+                    break
+                if _prev_end is not None and _num.start_index != _prev_end + 1:
+                    break
+                _digits += str(int(_v))
+                _digit_tokens.extend(_num.tokens)
+                _prev_end = _num.end_index
+            if len(_digits) > 1:
+                _frac = float("0." + _digits)
+                return (number.value - _frac if number.value < 0
+                        else number.value + _frac), \
+                    number.tokens + partitions[1] + _digit_tokens
+
+            if "." not in str(decimal.text):
+                _frac2 = float('0.' + str(decimal.value))
+                return (number.value - _frac2 if number.value < 0
+                        else number.value + _frac2), \
+                       number.tokens + partitions[1] + decimal.tokens
+    return None, None
+
+
+def _extract_whole_number_with_text_fy(tokens, short_scale, ordinals):
+    """Handle numbers not handled by the decimal or fraction functions.
+
+    This is generally whole numbers. Note that phrases such as "ien heal" will
+    be handled by this function, while "ien en in heal" is handled by the
+    fraction function.
+
+    Args:
+        tokens [Token]:
+        short_scale boolean:
+        ordinals boolean:
+
+    Returns:
+        int or float, [Tokens]
+        The value parsed, and tokens that it corresponds to.
+    """
+    multiplies, string_num_ordinal, string_num_scale = \
+        _initialize_number_data_fy(short_scale)
+
+    number_words = []  # type: [Token]
+    val = False
+    prev_val = None
+    next_val = None
+    to_sum = []
+    for idx, token in enumerate(tokens):
+        current_val = None
+        if next_val:
+            next_val = None
+            continue
+
+        word = token.word
+        if word in _ARTICLES_FY or word in _NEGATIVES_FY:
+            number_words.append(token)
+            continue
+
+        prev_word = tokens[idx - 1].word if idx > 0 else ""
+        next_word = tokens[idx + 1].word if idx + 1 < len(tokens) else ""
+
+        if word not in string_num_scale and \
+                word not in _STRING_NUM_FY and \
+                word not in _SUMS_FY and \
+                word not in multiplies and \
+                not (ordinals and word in string_num_ordinal) and \
+                not is_numeric(word) and \
+                not is_fractional_fy(word, short_scale=short_scale) and \
+                not look_for_fractions(word.split('/')):
+            words_only = [token.word for token in number_words]
+            if number_words and not all([w in _ARTICLES_FY |
+                                         _NEGATIVES_FY for w in words_only]):
+                break
+            else:
+                number_words = []
+                continue
+        elif word not in multiplies \
+                and prev_word not in multiplies \
+                and prev_word not in _SUMS_FY \
+                and not (ordinals and prev_word in string_num_ordinal) \
+                and prev_word not in _NEGATIVES_FY \
+                and prev_word not in _ARTICLES_FY:
+            number_words = [token]
+        elif prev_word in _SUMS_FY and word in _SUMS_FY:
+            number_words = [token]
+        else:
+            number_words.append(token)
+
+        # is this word already a number ?
+        if is_numeric(word):
+            if word.isdigit():  # doesn't work with decimals
+                val = int(word)
+            else:
+                val = float(word)
+            current_val = val
+
+        # is this word the name of a number ?
+        if word in _STRING_NUM_FY:
+            val = _STRING_NUM_FY.get(word)
+            current_val = val
+        elif word in string_num_scale:
+            val = string_num_scale.get(word)
+            current_val = val
+        elif ordinals and word in string_num_ordinal:
+            val = string_num_ordinal[word]
+            current_val = val
+
+        # is the prev word an ordinal number and current word is one?
+        if ordinals and prev_word in string_num_ordinal and val == 1:
+            val = prev_val
+
+        # is the prev word a number and should we sum it?
+        if prev_word in _SUMS_FY and val and val < 10:
+            if prev_val < 0:
+                val = prev_val - val
+            else:
+                val = prev_val + val
+
+        # is the prev word a number and should we multiply it?
+        if word in multiplies:
+            if not prev_val:
+                prev_val = 1
+            val = prev_val * val
+
+        # is this a spoken fraction?
+        if val is False:
+            val = is_fractional_fy(word, short_scale=short_scale)
+            current_val = val
+
+        # 2 fifths
+        if not ordinals:
+            next_val = is_fractional_fy(next_word, short_scale=short_scale)
+            if next_val:
+                if not val:
+                    val = 1
+                val = val * next_val
+                number_words.append(tokens[idx + 1])
+
+        # is this a negative number?
+        if val and prev_word and prev_word in _NEGATIVES_FY:
+            val = 0 - val
+
+        # let's make sure it isn't a fraction
+        if not val:
+            # look for fractions like "2/3"
+            aPieces = word.split('/')
+            if look_for_fractions(aPieces):
+                val = float(aPieces[0]) / float(aPieces[1])
+                current_val = val
+
+        else:
+            if prev_word in _SUMS_FY and word not in _SUMS_FY and current_val >= 10:
+                # Backtrack - we've got numbers we can't sum.
+                number_words.pop()
+                val = prev_val
+                break
+            prev_val = val
+
+            # handle long numbers
+            if word in multiplies and next_word not in multiplies:
+                to_sum.append(val)
+                val = 0
+                prev_val = 0
+
+    if val is not None and to_sum:
+        val += sum(to_sum)
+
+    return val, number_words
+
+
+def _initialize_number_data_fy(short_scale):
+    """Generate dictionaries of words to numbers, based on scale.
+
+    This is a helper function for _extract_whole_number.
+
+    Args:
+        short_scale boolean:
+
+    Returns:
+        (set(str), dict(str, number), dict(str, number))
+        multiplies, string_num_ordinal, string_num_scale
+    """
+    multiplies = _MULTIPLIES_SHORT_SCALE_FY if short_scale \
+        else _MULTIPLIES_LONG_SCALE_FY
+
+    string_num_ordinal_fy = _STRING_SHORT_ORDINAL_FY if short_scale \
+        else _STRING_LONG_ORDINAL_FY
+
+    string_num_scale_fy = _SHORT_SCALE_FY if short_scale else _LONG_SCALE_FY
+    string_num_scale_fy = invert_dict(string_num_scale_fy)
+
+    return multiplies, string_num_ordinal_fy, string_num_scale_fy
+
+
+def _split_compound_number_fy(word):
+    """
+    Split a West Frisian compound number word into its component number words.
+
+    "ienentweintich" -> ["ien", "en", "tweintich"]
+    "twahûnderttrijeentweintich" -> ["twa", "hûndert", "trije", "en", "tweintich"]
+
+    Returns None if the word is not composed purely of known number words.
+    """
+    if word in _STRING_NUM_FY:
+        return None
+    keys = sorted(set(_STRING_NUM_FY) |
+                  set(_MULTIPLIES_LONG_SCALE_FY) |
+                  set(_MULTIPLIES_SHORT_SCALE_FY),
+                  key=len, reverse=True)
+    parts, rest = [], word
+    while rest:
+        if rest.startswith("en") and parts and rest != "en":
+            candidate = rest[2:]
+            if any(candidate.startswith(k) for k in keys):
+                parts.append("en")
+                rest = candidate
+                continue
+        for k in keys:
+            if rest.startswith(k):
+                parts.append(k)
+                rest = rest[len(k):]
+                break
+        else:
+            return None
+    return parts if len(parts) > 1 else None
+
+
+def _compound_value_fy(parts, short_scale=True):
+    """Evaluate the numeric value of a split compound number word."""
+    scale = _SHORT_SCALE_FY if short_scale else _LONG_SCALE_FY
+    string_scale = invert_dict(scale)
+    total = current = 0
+    for p in parts:
+        if p == "en":
+            continue
+        v = _STRING_NUM_FY.get(p)
+        if v is None:
+            v = string_scale.get(p)
+        if v is None:
+            return None
+        if v >= 1000:
+            total += max(current, 1) * v
+            current = 0
+        elif v == 100:
+            current = max(current, 1) * 100
+        else:
+            current += v
+    return total + current
+
+
+def _expand_compound_numbers_fy(text, short_scale=True):
+    """Rewrite compound number words as their digit value for parsing."""
+    out = []
+    for w in text.split():
+        parts = _split_compound_number_fy(w)
+        if parts:
+            value = _compound_value_fy(parts, short_scale)
+            out.append(str(value) if value is not None else w)
+        else:
+            out.append(w)
+    return " ".join(out)
+
+
+def extract_number_fy(text, short_scale=True, ordinals=False):
+    """Extract a number from a West Frisian text string
+
+    The function handles pronunciations in long scale and short scale
+
+    https://en.wikipedia.org/wiki/Names_of_large_numbers
+
+    Args:
+        text (str): the string to normalize
+        short_scale (bool): use short scale if True, long scale if False
+        ordinals (bool): consider ordinal numbers, third=3 instead of 1/3
+    Returns:
+        (int) or (float) or False: The extracted number or False if no number
+                                   was found
+    """
+    text = text.lower().replace("û", "u").replace("â", "a") \
+        .replace("ú", "u").replace("á", "a").replace("ê", "e") \
+        .replace("ô", "o").replace("é", "e")
+    # normalize the words carrying diacritics to their plain spellings so
+    # the compound splitter sees a single canonical form
+    text = _expand_compound_numbers_fy(text, short_scale)
+    return _extract_number_with_text_fy(tokenize(text),
+                                        short_scale, ordinals).value
+
+
+def is_fractional_fy(input_str, short_scale=True):
+    """This function takes the given text and checks if it is a fraction.
+
+    Args:
+        input_str (str): the string to check if fractional
+        short_scale (bool): use short scale if True, long scale if False
+    Returns:
+        (bool) or (float): False if not a fraction, otherwise the fraction
+    """
+    fracts = {"hiel": 1, "heal": 2, "healve": 2, "kwart": 4}
+    if short_scale:
+        for num in _SHORT_ORDINAL_STRING_FY:
+            if num > 2:
+                fracts[_SHORT_ORDINAL_STRING_FY[num]] = num
+    else:
+        for num in _LONG_ORDINAL_STRING_FY:
+            if num > 2:
+                fracts[_LONG_ORDINAL_STRING_FY[num]] = num
+
+    if input_str.lower() in fracts:
+        return 1.0 / fracts[input_str.lower()]
+    return False

--- a/tests/test_lang_parity.py
+++ b/tests/test_lang_parity.py
@@ -9,9 +9,9 @@ from ovos_number_parser import (extract_number, is_fractional, is_ordinal,
                                 numbers_to_digits, pronounce_fraction,
                                 pronounce_number, pronounce_ordinal)
 
-LANGS = ["ar", "az", "ast", "ca", "cs", "da", "de", "en", "es", "eu", "fa", "fr",
-         "gl", "hu", "it", "kab", "mwl", "nl", "oc", "pl", "pt", "ro", "ru",
-         "sl", "sv", "uk"]
+LANGS = ["an", "ar", "az", "ast", "ca", "cs", "da", "de", "en", "es", "eu", "fa",
+         "fr", "fy", "gl", "hu", "it", "kab", "mwl", "nl", "oc", "pl", "pt", "ro",
+         "ru", "sl", "sv", "uk"]
 
 
 class TestLanguageParity(unittest.TestCase):
@@ -100,6 +100,9 @@ class TestPronounceFractionAnchors(unittest.TestCase):
         "pt": [("1/2", "um meio"), ("2/3", "dois terços")],
         "ro": [("1/2", "o jumătate"), ("2/3", "două treimi"),
                ("3/4", "trei sferturi"), ("1/4", "un sfert")],
+        "an": [("1/2", "un meyo"), ("2/3", "dos tercios"),
+               ("3/4", "tres cuartos")],
+        "fy": [("1/2", "ien heal")],
     }
 
     def test_anchors(self):

--- a/tests/test_number_parser_an.py
+++ b/tests/test_number_parser_an.py
@@ -1,0 +1,141 @@
+import unittest
+
+from ovos_number_parser.util import GrammaticalGender
+from ovos_number_parser.numbers_an import AN
+
+
+# ============================================================
+# Pronunciation Tests
+# ============================================================
+
+class TestPronunciationAN(unittest.TestCase):
+
+    # --- Cardinal Pronunciation (up to 999) ---
+    def test_units(self):
+        self.assertEqual(AN.pronounce_number(0), "zero")
+        self.assertEqual(AN.pronounce_number(1), "un")
+        self.assertEqual(AN.pronounce_number(1, gender=GrammaticalGender.FEMININE), "una")
+        self.assertEqual(AN.pronounce_number(4), "cuatre")
+        self.assertEqual(AN.pronounce_number(7), "siet")
+        self.assertEqual(AN.pronounce_number(8), "ueito")
+        self.assertEqual(AN.pronounce_number(9), "nueu")
+
+    def test_teens(self):
+        self.assertEqual(AN.pronounce_number(12), "doce")
+        self.assertEqual(AN.pronounce_number(14), "catorze")
+        self.assertEqual(AN.pronounce_number(16), "deciséis")
+        self.assertEqual(AN.pronounce_number(18), "deciueito")
+        self.assertEqual(AN.pronounce_number(19), "decinueu")
+
+    def test_composite_numbers(self):
+        # 21-29 are written as one word
+        self.assertEqual(AN.pronounce_number(21), "vintiún")
+        self.assertEqual(AN.pronounce_number(25), "vinticinco")
+        # from 30 on, tens and units join with "y"
+        self.assertEqual(AN.pronounce_number(35), "trenta y cinco")
+        self.assertEqual(AN.pronounce_number(48), "cuaranta y ueito")
+        self.assertEqual(AN.pronounce_number(67), "sixanta y siet")
+        self.assertEqual(AN.pronounce_number(99), "novanta y nueu")
+
+    def test_hundreds(self):
+        self.assertEqual(AN.pronounce_number(100), "cient")
+        self.assertEqual(AN.pronounce_number(101), "ciento un")
+        self.assertEqual(AN.pronounce_number(200), "docientos")
+        self.assertEqual(AN.pronounce_number(500), "cincocientos")
+        self.assertEqual(AN.pronounce_number(900), "noucientos")
+
+    def test_thousands(self):
+        self.assertEqual(AN.pronounce_number(1000), "mil")
+        self.assertEqual(AN.pronounce_number(2000), "dos mil")
+
+    def test_millions(self):
+        self.assertEqual(AN.pronounce_number(1_000_000), "un millón")
+        self.assertEqual(AN.pronounce_number(2_000_000), "dos millones")
+
+    # --- Decimals and Negatives ---
+    def test_decimals(self):
+        self.assertEqual(AN.pronounce_number(10.05), "diez coma zero cinco")
+
+    def test_negative(self):
+        self.assertEqual(AN.pronounce_number(-7), "menos siet")
+
+    # --- Ordinal Pronunciation ---
+    def test_ordinals(self):
+        self.assertEqual(AN.pronounce_ordinal(1), "primero")
+        self.assertEqual(AN.pronounce_ordinal(1, GrammaticalGender.FEMININE), "primera")
+        self.assertEqual(AN.pronounce_ordinal(2), "segundo")
+        self.assertEqual(AN.pronounce_ordinal(3), "tercero")
+        self.assertEqual(AN.pronounce_ordinal(4), "cuatreno")
+        self.assertEqual(AN.pronounce_ordinal(5), "cinqueno")
+        self.assertEqual(AN.pronounce_ordinal(8), "uiteno")
+        self.assertEqual(AN.pronounce_ordinal(10), "deceno")
+
+    # --- Fractions ---
+    def test_fractions(self):
+        self.assertEqual(AN.pronounce_fraction('1/2'), "un meyo")
+        self.assertEqual(AN.pronounce_fraction('2/3'), "dos tercios")
+        self.assertEqual(AN.pronounce_fraction('3/4'), "tres cuartos")
+
+
+# ============================================================
+# Extraction and Conversion Tests
+# ============================================================
+
+class TestExtractionAN(unittest.TestCase):
+
+    def test_extraction_cardinal_gender(self):
+        self.assertEqual(AN.extract_number('un'), 1)
+        self.assertEqual(AN.extract_number('una'), 1)
+
+    def test_extraction_composite(self):
+        self.assertEqual(AN.extract_number('vintiún'), 21)
+        self.assertEqual(AN.extract_number('trenta y cinco'), 35)
+        self.assertEqual(AN.extract_number('novanta y nueu'), 99)
+
+    def test_extraction_variant_spellings(self):
+        # dialectal / variant spellings understood on extraction
+        self.assertEqual(AN.extract_number('quatre'), 4)
+        self.assertEqual(AN.extract_number('güeito'), 8)
+        self.assertEqual(AN.extract_number('nou'), 9)
+        self.assertEqual(AN.extract_number('vente'), 20)
+        self.assertEqual(AN.extract_number('setse'), 16)
+        self.assertEqual(AN.extract_number('noranta'), 90)
+
+    def test_extraction_large_numbers(self):
+        self.assertEqual(AN.extract_number('un millón'), 1_000_000)
+        self.assertEqual(AN.extract_number('dos millones cincocientos'), 2_000_500)
+        self.assertEqual(AN.extract_number('mil vinte y tres'), 1023)
+
+    def test_extraction_ordinals(self):
+        self.assertEqual(AN.extract_number('o segundo coche', ordinals=True), 2)
+        self.assertEqual(AN.extract_number('a primera vegada', ordinals=True), 1)
+        self.assertEqual(AN.extract_number('o cuatreno puesto', ordinals=True), 4)
+
+    def test_no_number(self):
+        self.assertFalse(AN.extract_number('xyzzy'))
+
+    # --- Text to Digits Conversion ---
+    def test_numbers_to_digits(self):
+        self.assertEqual(AN.numbers_to_digits('docientos cincuanta'), '250')
+        self.assertEqual(AN.numbers_to_digits('un millón'), '1000000')
+        self.assertEqual(
+            AN.numbers_to_digits('bi ha docientos cincuanta coches'),
+            'bi ha 250 coches')
+
+
+class TestRoundTripAN(unittest.TestCase):
+    """pronounce_number output must be understood by extract_number."""
+
+    def test_round_trip(self):
+        numbers = list(range(0, 200)) + [
+            201, 222, 300, 345, 400, 456, 500, 678, 700, 891, 900, 1000,
+            1001, 1234, 2000, 2023, 5000, 9999, 10000, 100000, 1000000,
+            2000000]
+        for number in numbers:
+            with self.subTest(number=number):
+                spoken = AN.pronounce_number(number)
+                self.assertEqual(AN.extract_number(spoken), number)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_number_parser_fy.py
+++ b/tests/test_number_parser_fy.py
@@ -1,0 +1,109 @@
+import unittest
+
+from ovos_number_parser import extract_number, pronounce_number, pronounce_ordinal, is_fractional
+
+
+class TestWestFrisianPronounce(unittest.TestCase):
+    """Anchors for spoken West Frisian numbers."""
+
+    def test_pronounce_number(self):
+        expected = {0: 'nul', 1: 'ien', 2: 'twa', 3: 'trije', 4: 'fjouwer',
+                    5: 'fiif', 6: 'seis', 7: 'sân', 8: 'acht', 9: 'njoggen',
+                    10: 'tsien', 11: 'alve', 12: 'tolve', 13: 'trettjin',
+                    14: 'fjirtjin', 15: 'fyftjin', 16: 'sechstjin',
+                    17: 'santjin', 18: 'achttjin', 19: 'njoggentjin',
+                    20: 'tweintich', 21: 'ienentweintich', 30: 'tritich',
+                    42: 'twaenfjirtich', 50: 'fyftich', 66: 'seisensechstich',
+                    70: 'santich', 80: 'tachtich', 90: 'njoggentich',
+                    99: 'njoggenennjoggentich', 100: 'ienhûndert',
+                    200: 'twahûndert', 500: 'fiifhûndert',
+                    999: 'njoggenhûndertnjoggenennjoggentich',
+                    1000: 'ientûzen', 2000: 'twatûzen',
+                    2023: 'twatûzentrijeentweintich',
+                    1000000: 'ien miljoen ', 2000000: 'twa miljoen '}
+        for number, spoken in expected.items():
+            with self.subTest(number=number):
+                self.assertEqual(pronounce_number(number, lang="fy"), spoken)
+
+    def test_pronounce_negative_and_decimal(self):
+        expected = {-7: 'min sân', -42: 'min twaenfjirtich',
+                    2.5: 'twa komma fiif nul nul',
+                    3.14: 'trije komma ien fjouwer nul',
+                    -3.5: 'min trije komma fiif nul nul',
+                    0.5: 'nul komma fiif nul nul'}
+        for number, spoken in expected.items():
+            with self.subTest(number=number):
+                self.assertEqual(pronounce_number(number, lang="fy"), spoken)
+
+    def test_pronounce_ordinal(self):
+        expected = {1: 'earste', 2: 'twadde', 3: 'tredde', 4: 'fjirde',
+                    5: 'fyfte', 6: 'sechste', 7: 'sânde', 8: 'achtste',
+                    9: 'njoggende', 10: 'tsiende', 11: 'alfde', 12: 'tolfde',
+                    13: 'trettjinde', 20: 'tweintichste',
+                    21: 'ienentweintichste'}
+        for number, spoken in expected.items():
+            with self.subTest(number=number):
+                self.assertEqual(pronounce_ordinal(number, lang="fy"), spoken)
+
+
+class TestWestFrisianExtract(unittest.TestCase):
+    """Anchors for extracting numbers from West Frisian text."""
+
+    def test_extract_number(self):
+        expected = {1: 'ien', 2: 'twa', 3: 'trije', 4: 'fjouwer', 5: 'fiif',
+                    6: 'seis', 7: 'sân', 8: 'acht', 9: 'njoggen', 10: 'tsien',
+                    11: 'alve', 12: 'tolve', 13: 'trettjin', 14: 'fjirtjin',
+                    15: 'fyftjin', 16: 'sechstjin', 17: 'santjin',
+                    18: 'achttjin', 19: 'njoggentjin', 20: 'tweintich',
+                    21: 'ienentweintich', 30: 'tritich', 42: 'twaenfjirtich',
+                    100: 'hûndert', 1000: 'tûzen',
+                    123: 'ienhûnderttrijeentweintich',
+                    1000000: 'ien miljoen'}
+        for number, spoken in expected.items():
+            with self.subTest(spoken=spoken):
+                self.assertEqual(extract_number(spoken, lang="fy"), number)
+
+    def test_extract_variant_spellings(self):
+        # non-etymological variants without -s- and plain-ASCII spellings
+        self.assertEqual(extract_number("sechtjin", lang="fy"), 16)
+        self.assertEqual(extract_number("sechtich", lang="fy"), 60)
+        self.assertEqual(extract_number("san", lang="fy"), 7)
+        self.assertEqual(extract_number("hundert", lang="fy"), 100)
+
+    def test_extract_from_sentence(self):
+        self.assertEqual(
+            extract_number('ik haw ienentweintich katten', lang="fy"), 21)
+
+    def test_is_fractional(self):
+        self.assertEqual(is_fractional("heal", lang="fy"), 0.5)
+        self.assertEqual(is_fractional("kwart", lang="fy"), 0.25)
+        self.assertEqual(is_fractional("tredde", lang="fy"), 1.0 / 3)
+        self.assertFalse(is_fractional("hynder", lang="fy"))
+
+    def test_no_number(self):
+        self.assertIn(extract_number("hoi hoe giet it", lang="fy"),
+                      (False, None))
+
+
+class TestWestFrisianRoundTrip(unittest.TestCase):
+    """pronounce_number output must be understood by extract_number."""
+
+    def test_round_trip(self):
+        numbers = list(range(0, 200)) + [
+            201, 222, 300, 345, 400, 456, 500, 678, 700, 891, 900, 1000,
+            1001, 1234, 2000, 2023, 5000, 9999, 10000, 100000, 1000000,
+            2000000]
+        for number in numbers:
+            with self.subTest(number=number):
+                spoken = pronounce_number(number, lang="fy")
+                self.assertEqual(extract_number(spoken, lang="fy"), number)
+
+    def test_round_trip_negative_and_decimal(self):
+        for number in [-7, -42, 2.5, 3.14, -3.5, 0.5]:
+            with self.subTest(number=number):
+                spoken = pronounce_number(number, lang="fy")
+                self.assertEqual(extract_number(spoken, lang="fy"), number)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds two new languages, both with full public-function parity (pronounce_number, pronounce_ordinal, pronounce_fraction, extract_number, is_fractional, is_ordinal, numbers_to_digits).

## West Frisian (`fy`)

`numbers_fy.py` follows the Dutch implementation, including the compound-number splitter: units come before the tens joined with *en* (`ienentweintich` = 21, `twahûnderttrijeentweintich` = 223), hundred/thousand fuse with their multiplier (`twahûndert`, `trijetûzen`), and the long scale alternates *-joen*/*-jard* (`miljoen`, `miljard`, `biljoen`). Diacritics (`sân`, `hûndert`, `tûzen`) are normalized before parsing, and the variant spellings without the etymological *-s-* (`sechtjin`, `sechtich`) are accepted alongside the standard `sechstjin`/`sechstich` (the form given by the Wurdboek fan de Fryske taal). Ordinals use the attested table for 1–20 (`earste`, `twadde`, `tredde`, ..., `alfde`, `tolfde`, `tweintichste`) and compound regularly above it (`ienentweintichste`).

Sources:
- https://www.languagesandnumbers.com/how-to-count-in-west-frisian/en/fry/ (cardinals, compounding rule, scale words)
- https://www.omniglot.com/language/numbers/westfrisian.htm (cardinals, ordinals)
- https://en.wiktionary.org/wiki/Category:West_Frisian_cardinal_numbers and https://en.wiktionary.org/wiki/Category:West_Frisian_ordinal_numbers (standard spellings, `sechstjin`/`sechstich`)
- https://en.wiktionary.org/wiki/heal#West_Frisian (fraction word *heal*)

## Aragonese (`an`)

`numbers_an.py` uses the declarative `NumberVocabulary` + `RomanceNumberExtractor` engine, per `docs/adding-a-language.md`.

Orthography decision: pronunciation uses the general forms as spelled on Biquipedia and consistent with the 2023 *Ortografía de l'aragonés* of the Academia Aragonesa de la Lengua (`cuatre`, `ueito`, `nueu`, `deciséis`, `vintiún`, `trenta y cinco`, `cuaranta`, `sixanta`, `novanta`, `cient`). Earlier EFA-style and dialectal spellings (`quatre`, `güeito`, `setse`, `vente`, `quaranta`, `sesenta`, `noranta`, `cent`) are accepted on extraction only.

Coverage boundaries (null beats wrong):
- Ordinals 1–11 are attested (`primero`...`noveno`, `deceno`, `onceno`); the remaining teens/tens ordinals use the same productive `-eno` suffix on the cardinal stem (`venteno`, `trenteno`, ...), and `centeno`/`mileno` follow the same pattern. These pattern-derived forms are noted in `docs/languages.md`.
- Fractions include only `meyo/meya`, `tercio`, `cuarto`; larger denominators fall back to the engine's cardinal + *avos* reading.
- Scale words stop at `millón`; larger scale words were not sourced and are omitted.

Sources:
- https://an.wikipedia.org/wiki/Cardinals_en_aragon%C3%A9s (cardinals, fused 21–29, *y* joiner from 30)
- https://an.wikipedia.org/wiki/Wikipedia:Normas_d'estilo/Ordinals_con_abreviadura (ordinals 1–11, masculine and feminine)
- https://www.omniglot.com/language/numbers/aragonese.htm and https://europeminoritylanguages.wordpress.com/2016/10/31/aragonese-os-numeros/ (variant spellings, hundreds)
- http://ocharraire.blogspot.com/2011/01/os-numerals.html (hundreds series, `ciento un` particle)
- https://academiaaragonesadelalengua.org/sites/default/files/ficheros-pdf/ortografia-aragones.pdf (current official orthography)

## Tests

- `an` and `fy` added to `tests/test_lang_parity.py` (with fraction anchors).
- New `tests/test_number_parser_fy.py` and `tests/test_number_parser_an.py` with pronounce anchors, extract anchors, variant-spelling checks and round-trip sweeps over 0–200 plus larger values.
- Full suite: 517 passed.

Asturian (`ast`) was gap-checked: already wired in every dispatcher, present in the parity suite, README and language notes — no changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)