### PR TITLE
feat: add Occitan (oc) number support

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ fractional and ordinal numbers, and more.
 | `pt` (Portuguese)       | ✅                | ✅                  | ✅              | ✅                |
 | `mwl` (Mirandese)       | ✅                | ✅                  | ✅              | ✅                |
 | `ast` (Asturian)        | ✅                | ✅                  | ✅              | ✅                |
+| `oc` (Occitan)          | ✅                | ✅                  | ✅              | ✅                |
 | `ro` (Romanian)         | ✅                | ✅                  | ✅              | ✅                |
 | `ru` (Russian)          | ✅                | 🚧                 | ✅              | ✅                 |
 | `sv` (Swedish)          | ✅                | ✅                 | ✅              | ❌                 |

--- a/ovos_number_parser/__init__.py
+++ b/ovos_number_parser/__init__.py
@@ -30,6 +30,7 @@ from ovos_number_parser.numbers_it import (extract_number_it, pronounce_number_i
 from ovos_number_parser.numbers_kab import (pronounce_number_kab, pronounce_ordinal_kab, extract_number_kab,
                                              is_fractional_kab, is_ordinal_kab)
 from ovos_number_parser.numbers_mwl import MWL
+from ovos_number_parser.numbers_oc import OC
 from ovos_number_parser.numbers_nl import numbers_to_digits_nl, pronounce_number_nl, pronounce_ordinal_nl, \
     extract_number_nl, is_fractional_nl
 from ovos_number_parser.numbers_pl import numbers_to_digits_pl, pronounce_number_pl, extract_number_pl, \
@@ -251,6 +252,8 @@ def numbers_to_digits(utterance: str, lang: str, scale: Optional[Scale] = None) 
     """
     if lang.startswith("ast"):
         return AST.numbers_to_digits(utterance)
+    if lang.startswith("oc"):
+        return OC.numbers_to_digits(utterance, scale=scale)
     if lang.startswith("gl"):
         return numbers_to_digits_gl(utterance)
     if lang.startswith("de"):
@@ -312,6 +315,8 @@ def pronounce_number(number: Union[int, float], lang: str,
         return pronounce_number_ca(number, places)
     if lang.startswith("ast"):
         return AST.pronounce_number(number, places, scale, ordinals, digits, gender)
+    if lang.startswith("oc"):
+        return OC.pronounce_number(number, places, scale, ordinals, digits, gender)
     if lang.startswith("cs"):
         return pronounce_number_cs(number, places, short_scale, scientific, ordinals)
     if lang.startswith("da"):
@@ -382,6 +387,8 @@ def pronounce_fraction(fraction_word: str, lang: str, scale: Optional[Scale] = N
             else PT_PT.pronounce_fraction(fraction_word, scale=scale)
     elif lang.startswith("ast"):
         return AST.pronounce_fraction(fraction_word, scale=scale)
+    elif lang.startswith("oc"):
+        return OC.pronounce_fraction(fraction_word, scale=scale)
     elif lang.startswith("mwl"):
         return MWL.pronounce_fraction(fraction_word, scale=scale)
     elif lang.startswith("gl"):
@@ -425,6 +432,8 @@ def pronounce_ordinal(number: Union[int, float], lang: str,
         return RO.pronounce_ordinal(number, scale=scale, gender=gender)
     if lang.startswith("ast"):
         return AST.pronounce_ordinal(number, scale=scale, gender=gender)
+    if lang.startswith("oc"):
+        return OC.pronounce_ordinal(number, scale=scale, gender=gender)
     if lang.startswith("ar"):
         return pronounce_ordinal_ar(number)
     if lang.startswith("da"):
@@ -529,6 +538,8 @@ def extract_number(text: str, lang: str,
         return RO.extract_number(text, scale=scale, ordinals=ordinals)
     if lang.startswith("ast"):
         return AST.extract_number(text, scale=scale, ordinals=ordinals)
+    if lang.startswith("oc"):
+        return OC.extract_number(text, scale=scale, ordinals=ordinals)
     if lang.startswith("ru"):
         return extract_number_ru(text, short_scale, ordinals)
     if lang.startswith("sv"):
@@ -603,6 +614,8 @@ def is_fractional(input_str: str, lang: str,
         return RO.is_fractional(input_str)
     if lang.startswith("ast"):
         return AST.is_fractional(input_str)
+    if lang.startswith("oc"):
+        return OC.is_fractional(input_str)
     if lang.startswith("ru"):
         return is_fractional_ru(input_str, short_scale)
     if lang.startswith("sv"):
@@ -638,6 +651,8 @@ def is_ordinal(input_str: str, lang: str) -> Union[bool, float]:
         return RO.is_ordinal(input_str)
     if lang.startswith("ast"):
         return AST.is_ordinal(input_str)
+    if lang.startswith("oc"):
+        return OC.is_ordinal(input_str)
     if lang.startswith("en"):
         return is_ordinal_en(input_str)
     if lang.startswith("ar"):

--- a/ovos_number_parser/numbers_oc.py
+++ b/ovos_number_parser/numbers_oc.py
@@ -1,0 +1,232 @@
+"""Occitan number vocabulary.
+
+Classical orthography (norma classica), Lengadocian referential variety.
+
+Sources:
+- Lo Congrès permanent de la lenga occitana, dicod'Òc (https://dicodoc.eu)
+- "How to count in Occitan", languagesandnumbers.com/how-to-count-in-occitan
+- Wiktionary Occitan numeral and ordinal entries
+  (en.wiktionary.org/wiki/Category:Occitan_numerals,
+   fr.wiktionary.org/wiki/Catégorie:Ordinaux_en_occitan)
+
+Notes on the grammar encoded below:
+- 17-19 and 21-29 join with "-e-" (dètz-e-sèt, vint-e-un); from 31 upward the
+  ten and the unit are simply juxtaposed (trenta dos, cinquanta sèt).
+- hundreds are analytic: dos cents, tres cents ... nòu cents.
+- "mila" (thousand) is invariable and never takes a preceding "un".
+- Occitan uses the long scale (milion, miliard).
+"""
+from ovos_number_parser.util import (Scale, GrammaticalGender, NumberVocabulary,
+                                     RomanceNumberExtractor)
+
+_FEM_SPECIAL = {"un": "una", "dos": "doas", "mièg": "mièja"}
+_MASC_SPECIAL = {v: k for k, v in _FEM_SPECIAL.items()}
+
+
+def swap_gender_oc(word: str, gender: GrammaticalGender) -> str:
+    """Swap an Occitan numeral/ordinal between grammatical genders.
+
+    Feminine forms of ordinals add -a to the consonant-final masculine
+    (primièr/primièra, segond/segonda, tresen/tresena).
+    """
+    if gender == GrammaticalGender.FEMININE:
+        if word in _FEM_SPECIAL:
+            return _FEM_SPECIAL[word]
+        if word.endswith("ièr") or word.endswith("en") \
+                or word in ("segond", "quart", "tèrç"):
+            return word + "a"
+    elif gender == GrammaticalGender.MASCULINE:
+        if word in _MASC_SPECIAL:
+            return _MASC_SPECIAL[word]
+        if word.endswith("ièra") or word.endswith("ena") or word.endswith("onda"):
+            return word[:-1]
+    return word
+
+
+def pluralize_oc(word: str) -> str:
+    """Pluralize an Occitan word (sibilant-final words take -es)."""
+    if word.endswith("ç"):
+        return word[:-1] + "ces"  # tèrç -> tèrces
+    if word.endswith("ch") or word.endswith("x"):
+        return word + "es"
+    if not word.endswith("s"):
+        return word + "s"
+    return word
+
+
+# compound ordinals keep the cardinal ten and put the -en suffix on the unit:
+# vint-e-unen (21st), trenta dosen (32nd); "unen"/"dosen" are the compound
+# unit ordinals (standalone 1st/2nd are primièr/segond)
+_ORDINAL_COMPOUND_UNITS = {1: 'unen', 2: 'dosen', 3: 'tresen', 4: 'quatren',
+                           5: 'cinquen', 6: 'seisen', 7: 'seten', 8: 'ochen',
+                           9: 'noven'}
+_CARDINAL_TENS = {20: 'vint', 30: 'trenta', 40: 'quaranta', 50: 'cinquanta',
+                  60: 'seissanta', 70: 'setanta', 80: 'ochanta', 90: 'nonanta'}
+_ORDINAL_COMPOUNDS = {
+    ten + unit: f"{_CARDINAL_TENS[ten]}{'-e-' if ten == 20 else ' '}{word}"
+    for ten in _CARDINAL_TENS
+    for unit, word in _ORDINAL_COMPOUND_UNITS.items()
+}
+
+
+_OC = NumberVocabulary(
+    LANG="oc-FR",
+    swap_gender=swap_gender_oc,
+    pluralize=pluralize_oc,
+
+    HUNDRED_PARTICLE="cent",  # 1XX reads "cent vint"
+    DENOMINATOR_PARTICLE="parts",
+    DIVIDED_BY_ZERO="dividit per zèro",
+    NO_PREV_UNIT=[100, 1000],  # "cent" / "mila", never "un cent" / "un mila"
+    NO_PLURAL=[1000],  # "mila" is invariable: "dos mila"
+
+    NUMBER_OVERFLOW="nombre tròp grand",
+    DEFAULT_SCALE=Scale.LONG,
+    JOIN_WORD=["e"],
+
+    JOINER_ON_TWENTYS=True,  # vint-e-un
+    JOINER_ONLY_ON_TWENTYS=True,  # but "trenta dos", "cinquanta sèt"
+    PREFER_EXPLICIT_ORDINALS=True,  # onzen, vint-e-unen
+    MULTIPLY_HUNDREDS=True,  # analytic hundreds: "dos cents" = 200
+    JOINER_ON_HUNDREDS=False,  # "dos cents trenta"
+    JOINER_ON_HUNDRED_PARTICLE=False,  # "cent vint"
+    JOINER_ON_THOUSANDS=False,  # "mila dos cents"
+
+    DECIMAL_MARKER=["virgula", "punt", ".", ","],
+    NEGATIVE_SIGN=["mens"],
+    UNITS={
+        0: 'zèro',
+        1: 'un',
+        2: 'dos',
+        3: 'tres',
+        4: 'quatre',
+        5: 'cinc',
+        6: 'sièis',
+        7: 'sèt',
+        8: 'uèch',
+        9: 'nòu',
+    },
+    TENS={
+        10: 'dètz',
+        11: 'onze',
+        12: 'dotze',
+        13: 'tretze',
+        14: 'catòrze',
+        15: 'quinze',
+        16: 'setze',
+        17: 'dètz-e-sèt',
+        18: 'dètz-e-uèch',
+        19: 'dètz-e-nòu',
+        20: 'vint',
+        30: 'trenta',
+        40: 'quaranta',
+        50: 'cinquanta',
+        60: 'seissanta',
+        70: 'setanta',
+        80: 'ochanta',
+        90: 'nonanta'
+    },
+    HUNDREDS={
+        100: 'cent',
+        200: 'dos cents',
+        300: 'tres cents',
+        400: 'quatre cents',
+        500: 'cinc cents',
+        600: 'sièis cents',
+        700: 'sèt cents',
+        800: 'uèch cents',
+        900: 'nòu cents'
+    },
+    FRACTION={
+        2: 'mièg',
+        3: 'tèrç',
+        4: 'quart',
+        5: 'cinquen',
+        6: 'seisen',
+        7: 'seten',
+        8: 'ochen',
+        9: 'noven',
+        10: 'desen',
+        11: 'onzen',
+        12: 'dotzen',
+        13: 'tretzen',
+        14: 'catorzen',
+        15: 'quinzen',
+        16: 'setzen',
+        20: 'vinten',
+        100: 'centen',
+        1000: 'milen'
+    },
+    FRACTION_FEMALE={
+        2: 'mièja'  # "una e mièja" -> 1.5
+    },
+    SHORT_SCALE={
+        1000: 'mila',
+        10 ** 6: 'milion',
+        10 ** 9: 'miliard',
+    },
+    LONG_SCALE={
+        1000: 'mila',
+        10 ** 6: 'milion',
+        10 ** 9: 'miliard',
+        10 ** 12: 'bilion',
+    },
+
+    GENDERED_SPELLINGS={
+        GrammaticalGender.FEMININE: {
+            1: 'una',
+            2: 'doas'
+        }
+    },
+    DIGIT_SPELLINGS={},
+    ALT_SPELLINGS={
+        'ueitanta': 80,  # attested alternative for ochanta
+    },
+    ORDINAL_UNITS={
+        1: 'primièr',
+        2: 'segond',
+        3: 'tresen',
+        4: 'quatren',
+        5: 'cinquen',
+        6: 'seisen',
+        7: 'seten',
+        8: 'ochen',
+        9: 'noven',
+    },
+    ORDINAL_TENS={
+        **_ORDINAL_COMPOUNDS,
+        1: 'unen',  # extraction alias for compound forms ("vint e unen")
+        2: 'dosen',
+        10: 'desen',
+        11: 'onzen',
+        12: 'dotzen',
+        13: 'tretzen',
+        14: 'catorzen',
+        15: 'quinzen',
+        16: 'setzen',
+        17: 'dètz-e-seten',
+        18: 'dètz-e-ochen',
+        19: 'dètz-e-noven',
+        20: 'vinten',
+        30: 'trenten',
+        40: 'quaranten',
+        50: 'cinquanten',
+        60: 'seissanten',
+        70: 'setanten',
+        80: 'ochanten',
+        90: 'nonanten'
+    },
+    ORDINAL_HUNDREDS={
+        100: 'centen',
+    },
+    ORDINAL_SHORT_SCALE={
+        10 ** 3: 'milen',
+        10 ** 6: 'milionen',
+    },
+    ORDINAL_LONG_SCALE={
+        10 ** 3: 'milen',
+        10 ** 6: 'milionen',
+    }
+)
+
+OC = RomanceNumberExtractor(_OC)

--- a/ovos_number_parser/util.py
+++ b/ovos_number_parser/util.py
@@ -305,6 +305,14 @@ class NumberVocabulary:
     pluralize: Callable[[str], str] = lambda word: word
     singularize: Callable[[str], str] = lambda word: word
 
+    # restrict the tens joiner to the twenties ("vint-e-un" but "trenta dos"),
+    # for languages that only join 21-29
+    JOINER_ONLY_ON_TWENTYS: bool = False
+
+    # prefer explicit ORDINAL_TENS entries ("onzen", "vint-e-unen") over
+    # composing tens + units ordinals
+    PREFER_EXPLICIT_ORDINALS: bool = False
+
     # join the "hundred" particle to its remainder ("cento e un") even when
     # JOINER_ON_HUNDREDS is off, but only for the top-level group of the number
     JOINER_ON_HUNDRED_PARTICLE: bool = False
@@ -521,8 +529,8 @@ class RomanceNumberExtractor:
                         current = 0
                 elif val == 100 and self.vocab.MULTIPLY_HUNDREDS:
                     # the hundreds word multiplies the preceding units
-                    # ("două sute" = 200), leaving higher groups untouched
-                    # ("două mii trei sute" -> 2000 + 3*100)
+                    # ("două sute" = 200, "dos cents" = 200), leaving higher
+                    # groups untouched ("două mii trei sute" -> 2000 + 3*100)
                     below = current % 100
                     current += (below or 1) * 100 - below
                 else:
@@ -1002,7 +1010,8 @@ class RomanceNumberExtractor:
                 unit = n % 10
                 parts.append(gendered(ten, tens_map[ten]))
                 if unit > 0:
-                    if self.vocab.JOINER_ON_TWENTYS and self.vocab.JOIN_WORD:
+                    if self.vocab.JOINER_ON_TWENTYS and self.vocab.JOIN_WORD \
+                            and (ten == 20 or not self.vocab.JOINER_ONLY_ON_TWENTYS):
                         parts.append(self.vocab.JOIN_WORD[0])
                     parts.append(gendered(unit, self.vocab.UNITS[unit]))
 
@@ -1061,6 +1070,9 @@ class RomanceNumberExtractor:
             elif n < 10:
                 units_word_masc = self.vocab.ORDINAL_UNITS[n]
                 parts.append(self.vocab.swap_gender(units_word_masc, gender))
+            elif self.vocab.PREFER_EXPLICIT_ORDINALS and n in self.vocab.ORDINAL_TENS:
+                # explicit compound ordinal ("onzen", "vint-e-unen")
+                parts.append(self.vocab.swap_gender(self.vocab.ORDINAL_TENS[n], gender))
             elif n < 20:
                 tens_word_masc = self.vocab.ORDINAL_TENS[10]
                 units_word_masc = self.vocab.ORDINAL_UNITS[n - 10]

--- a/tests/test_lang_parity.py
+++ b/tests/test_lang_parity.py
@@ -10,8 +10,8 @@ from ovos_number_parser import (extract_number, is_fractional, is_ordinal,
                                 pronounce_number, pronounce_ordinal)
 
 LANGS = ["ar", "az", "ast", "ca", "cs", "da", "de", "en", "es", "eu", "fa", "fr",
-         "gl", "hu", "it", "kab", "mwl", "nl", "pl", "pt", "ro", "ru", "sl",
-         "sv", "uk"]
+         "gl", "hu", "it", "kab", "mwl", "nl", "oc", "pl", "pt", "ro", "ru",
+         "sl", "sv", "uk"]
 
 
 class TestLanguageParity(unittest.TestCase):

--- a/tests/test_number_parser_oc.py
+++ b/tests/test_number_parser_oc.py
@@ -1,0 +1,233 @@
+"""Occitan number parser tests.
+
+Anchor forms use the classical orthography (norma classica), Lengadocian
+referential variety, verified against Lo Congrès resources, Wiktionary
+Occitan numeral/ordinal entries and languagesandnumbers.com.
+"""
+import unittest
+
+from ovos_number_parser.numbers_oc import OC
+from ovos_number_parser.util import GrammaticalGender, Scale
+
+
+# hand-verified pronounce anchors (Lengadocian, classical norm)
+PRONOUNCE_ANCHORS = {
+    0: "zèro",
+    1: "un",
+    2: "dos",
+    3: "tres",
+    4: "quatre",
+    5: "cinc",
+    6: "sièis",
+    7: "sèt",
+    8: "uèch",
+    9: "nòu",
+    10: "dètz",
+    11: "onze",
+    12: "dotze",
+    13: "tretze",
+    14: "catòrze",
+    15: "quinze",
+    16: "setze",
+    17: "dètz-e-sèt",
+    18: "dètz-e-uèch",
+    19: "dètz-e-nòu",
+    20: "vint",
+    21: "vint e un",
+    22: "vint e dos",
+    29: "vint e nòu",
+    30: "trenta",
+    32: "trenta dos",
+    40: "quaranta",
+    50: "cinquanta",
+    57: "cinquanta sèt",
+    60: "seissanta",
+    70: "setanta",
+    80: "ochanta",
+    90: "nonanta",
+    99: "nonanta nòu",
+    100: "cent",
+    101: "cent un",
+    120: "cent vint",
+    200: "dos cents",
+    234: "dos cents trenta quatre",
+    300: "tres cents",
+    900: "nòu cents",
+    999: "nòu cents nonanta nòu",
+    1000: "mila",
+    2000: "dos mila",
+    2300: "dos mila tres cents",
+    1000000: "un milion",
+    2000000: "dos milions",
+    1000000000: "un miliard",
+}
+
+
+class TestPronounceOC(unittest.TestCase):
+    def test_anchors(self):
+        for n, spoken in PRONOUNCE_ANCHORS.items():
+            self.assertEqual(OC.pronounce_number(n), spoken, n)
+
+    def test_feminine(self):
+        self.assertEqual(OC.pronounce_number(1, gender=GrammaticalGender.FEMININE), "una")
+        self.assertEqual(OC.pronounce_number(2, gender=GrammaticalGender.FEMININE), "doas")
+        self.assertEqual(OC.pronounce_number(21, gender=GrammaticalGender.FEMININE), "vint e una")
+
+    def test_negative(self):
+        self.assertEqual(OC.pronounce_number(-7), "mens sèt")
+
+    def test_decimal(self):
+        self.assertEqual(OC.pronounce_number(3.14, places=2), "tres virgula catòrze")
+        self.assertEqual(OC.pronounce_number(0.5), "zèro virgula cinc")
+
+
+class TestOrdinalsOC(unittest.TestCase):
+    def test_units(self):
+        self.assertEqual(OC.pronounce_ordinal(1), "primièr")
+        self.assertEqual(OC.pronounce_ordinal(1, gender=GrammaticalGender.FEMININE), "primièra")
+        self.assertEqual(OC.pronounce_ordinal(2), "segond")
+        self.assertEqual(OC.pronounce_ordinal(2, gender=GrammaticalGender.FEMININE), "segonda")
+        self.assertEqual(OC.pronounce_ordinal(3), "tresen")
+        self.assertEqual(OC.pronounce_ordinal(3, gender=GrammaticalGender.FEMININE), "tresena")
+        self.assertEqual(OC.pronounce_ordinal(4), "quatren")
+        self.assertEqual(OC.pronounce_ordinal(5), "cinquen")
+        self.assertEqual(OC.pronounce_ordinal(9), "noven")
+
+    def test_teens(self):
+        self.assertEqual(OC.pronounce_ordinal(10), "desen")
+        self.assertEqual(OC.pronounce_ordinal(11), "onzen")
+        self.assertEqual(OC.pronounce_ordinal(16), "setzen")
+        self.assertEqual(OC.pronounce_ordinal(17), "dètz-e-seten")
+
+    def test_tens_and_compounds(self):
+        self.assertEqual(OC.pronounce_ordinal(20), "vinten")
+        self.assertEqual(OC.pronounce_ordinal(21), "vint-e-unen")
+        self.assertEqual(OC.pronounce_ordinal(30), "trenten")
+        self.assertEqual(OC.pronounce_ordinal(90), "nonanten")
+
+    def test_large(self):
+        self.assertEqual(OC.pronounce_ordinal(100), "centen")
+        self.assertEqual(OC.pronounce_ordinal(1000), "milen")
+        self.assertEqual(OC.pronounce_ordinal(1000000), "milionen")
+
+    def test_is_ordinal(self):
+        self.assertEqual(OC.is_ordinal("primièr"), 1)
+        self.assertEqual(OC.is_ordinal("tresen"), 3)
+        self.assertEqual(OC.is_ordinal("vinten"), 20)
+        self.assertFalse(OC.is_ordinal("ostal"))
+
+
+class TestFractionsOC(unittest.TestCase):
+    def test_pronounce_fraction(self):
+        self.assertEqual(OC.pronounce_fraction("1/2"), "un mièg")
+        self.assertEqual(OC.pronounce_fraction("2/3"), "dos tèrces")
+        self.assertEqual(OC.pronounce_fraction("3/4"), "tres quarts")
+        self.assertEqual(OC.pronounce_fraction("1/4"), "un quart")
+        self.assertEqual(OC.pronounce_fraction("1/5"), "un cinquen")
+
+    def test_is_fractional(self):
+        self.assertEqual(OC.is_fractional("mièg"), 0.5)
+        self.assertEqual(OC.is_fractional("mièja"), 0.5)
+        self.assertEqual(OC.is_fractional("tèrç"), 1 / 3)
+        self.assertEqual(OC.is_fractional("quart"), 0.25)
+        self.assertFalse(OC.is_fractional("ostal"))
+
+
+class TestExtractOC(unittest.TestCase):
+    def test_units_and_teens(self):
+        self.assertEqual(OC.extract_number("un"), 1)
+        self.assertEqual(OC.extract_number("una"), 1)
+        self.assertEqual(OC.extract_number("doas"), 2)
+        self.assertEqual(OC.extract_number("setze"), 16)
+        self.assertEqual(OC.extract_number("dètz-e-sèt"), 17)
+
+    def test_hyphenated_compounds(self):
+        self.assertEqual(OC.extract_number("vint-e-un"), 21)
+        self.assertEqual(OC.extract_number("vint-e-una"), 21)
+        self.assertEqual(OC.extract_number("vint-e-nòu"), 29)
+        self.assertEqual(OC.extract_number("dètz-e-uèch"), 18)
+
+    def test_juxtaposed_tens(self):
+        self.assertEqual(OC.extract_number("trenta dos"), 32)
+        self.assertEqual(OC.extract_number("cinquanta sèt"), 57)
+        self.assertEqual(OC.extract_number("nonanta nòu"), 99)
+
+    def test_alt_spellings(self):
+        self.assertEqual(OC.extract_number("ueitanta"), 80)
+
+    def test_analytic_hundreds(self):
+        self.assertEqual(OC.extract_number("cent"), 100)
+        self.assertEqual(OC.extract_number("cent vint"), 120)
+        self.assertEqual(OC.extract_number("dos cents"), 200)
+        self.assertEqual(OC.extract_number("dos cents trenta quatre"), 234)
+        self.assertEqual(OC.extract_number("nòu cents nonanta nòu"), 999)
+
+    def test_thousands(self):
+        self.assertEqual(OC.extract_number("mila"), 1000)
+        self.assertEqual(OC.extract_number("dos mila"), 2000)
+        self.assertEqual(OC.extract_number("dos mila tres cents"), 2300)
+        self.assertEqual(OC.extract_number("un milion"), 1000000)
+        self.assertEqual(OC.extract_number("dos milions"), 2000000)
+        self.assertEqual(OC.extract_number("un miliard"), 1000000000)
+
+    def test_decimals(self):
+        self.assertEqual(OC.extract_number("tres virgula catòrze"), 3.14)
+        self.assertEqual(OC.extract_number("trenta cinc virgula quatre"), 35.4)
+
+    def test_negative(self):
+        self.assertEqual(OC.extract_number("mens sèt"), -7)
+        self.assertEqual(OC.extract_number("mens vint e un"), -21)
+
+    def test_fraction_words(self):
+        self.assertEqual(OC.extract_number("un e mièg"), 1.5)
+        self.assertEqual(OC.extract_number("tres quarts"), 0.75)
+
+    def test_ordinal_extraction(self):
+        self.assertEqual(OC.extract_number("lo tresen còp", ordinals=True), 3)
+        self.assertEqual(OC.extract_number("la primièra vegada", ordinals=True), 1)
+        self.assertEqual(OC.extract_number("vint-e-unen", ordinals=True), 21)
+
+    def test_in_sentence(self):
+        self.assertEqual(OC.extract_number("i a vint e un gats"), 21)
+        self.assertEqual(OC.extract_number("son dos cents trenta quilòmetres"), 230)
+
+    def test_no_number(self):
+        self.assertFalse(OC.extract_number("bon jorn"))
+
+
+class TestNumbersToDigitsOC(unittest.TestCase):
+    def test_replace(self):
+        self.assertEqual(OC.numbers_to_digits("i a vint e un gats"), "i a 21 gats")
+        self.assertEqual(OC.numbers_to_digits("dos cents trenta quatre ostals"),
+                         "234 ostals")
+
+    def test_passthrough(self):
+        self.assertEqual(OC.numbers_to_digits("bon jorn amics"), "bon jorn amics")
+
+
+class TestRoundTripOC(unittest.TestCase):
+    def test_sweep(self):
+        for n in range(0, 1101):
+            spoken = OC.pronounce_number(n)
+            self.assertEqual(OC.extract_number(spoken), n, f"{n}: {spoken!r}")
+
+    def test_sweep_large(self):
+        for n in (2023, 9999, 12345, 100000, 654321, 1000000, 2500000,
+                  1000000000, 2000000001):
+            spoken = OC.pronounce_number(n)
+            self.assertEqual(OC.extract_number(spoken), n, f"{n}: {spoken!r}")
+
+    def test_sweep_feminine(self):
+        for n in (1, 2, 21, 22, 31, 42, 101, 202):
+            spoken = OC.pronounce_number(n, gender=GrammaticalGender.FEMININE)
+            self.assertEqual(OC.extract_number(spoken), n, f"{n}: {spoken!r}")
+
+    def test_sweep_ordinals(self):
+        for n in (1, 2, 3, 9, 10, 11, 16, 20, 30, 90, 100, 1000):
+            spoken = OC.pronounce_ordinal(n)
+            self.assertEqual(OC.extract_number(spoken, ordinals=True), n,
+                             f"{n}: {spoken!r}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds Occitan to the declarative NumberVocabulary + RomanceNumberExtractor engine, wired through every public dispatcher function and the language parity suite.

## Language choices
- **Orthography: classical (norma classica)** — the institutional standard maintained by Lo Congrès permanent de la lenga occitana.
- **Variety: Lengadocian**, the referential standard for normalized Occitan. Well-attested alternatives are accepted in extraction where verifiable (`ueitanta` for 80); pronunciation is always Lengadocian (`ochanta`).

## Grammar encoded
- 17–19 and 21–29 join with `-e-` (`dètz-e-sèt`, `vint-e-un`); from 31 upward ten and unit are juxtaposed (`trenta dos`, `cinquanta sèt`)
- analytic hundreds: `dos cents`, `nòu cents`
- invariable `mila` (never `un mila`, never pluralized); long scale (`milion`, `miliard`)
- gender pairs `un/una`, `dos/doas`; ordinals `primièr/primièra`, `segond`, `tresen`…, compounds `vint-e-unen`
- fractions `mièg/mièja`, `tèrç` (pl. `tèrces`), `quart`, then ordinal forms; decimals with `virgula`; negatives with `mens`

## Engine changes (all opt-in, defaults keep existing behavior)
- extraction of analytic hundreds: a unit directly before a 100-valued word multiplies (`dos cents` → 200, `dos mila tres cents` → 2300)
- `JOINER_ONLY_ON_TWENTYS`: restrict the tens joiner to 21–29
- `PREFER_EXPLICIT_ORDINALS`: honor explicit compound ordinal entries instead of composing tens + units

## Sources
- Lo Congrès permanent de la lenga occitana (dicod'Òc, dicodoc.eu)
- languagesandnumbers.com/how-to-count-in-occitan
- Wiktionary: Category:Occitan numerals (en), Catégorie:Ordinaux en occitan (fr)

## Tests
- `tests/test_number_parser_oc.py`: hand-verified pronounce/extract anchors, gender variants, hyphenated compound extraction, decimals, negatives, fractions, ordinals, `numbers_to_digits`, and round-trip sweeps (0–1100 plus large values, feminine, ordinals)
- `oc` added to `tests/test_lang_parity.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
