### PR TITLE
feat: finnish and estonian number support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ fractional and ordinal numbers, and more.
 | `de` (German)           | ✅                | ✅                 | ✅              | ✅                 |
 | `es` (Spanish)          | ✅                | 🚧                 | ✅              | 🚧                 |
 | `eu` (Euskara / Basque) | ✅                | ❌                 | ✅              | ❌                 |
+| `et` (Estonian)         | ✅                | ✅                 | ✅              | ✅                 |
 | `fa` (Farsi / Persian)  | ✅                | 🚧                 | ✅              | ❌                 |
+| `fi` (Finnish)          | ✅                | ✅                 | ✅              | ✅                 |
 | `fr` (French)           | ✅                | 🚧                 | ✅              | ❌                 |
 | `hu` (Hungarian)        | ✅                | ✅                 | ❌              | ❌                 |
 | `it` (Italian)          | ✅                | 🚧                | ✅              | ❌                 |

--- a/ovos_number_parser/__init__.py
+++ b/ovos_number_parser/__init__.py
@@ -20,8 +20,12 @@ from ovos_number_parser.numbers_en import numbers_to_digits_en, is_ordinal_en, p
 from ovos_number_parser.numbers_es import numbers_to_digits_es, pronounce_number_es, extract_number_es, is_fractional_es
 from ovos_number_parser.numbers_eu import pronounce_number_eu, extract_number_eu, is_fractional_eu, \
     pronounce_ordinal_eu
+from ovos_number_parser.numbers_et import pronounce_number_et, pronounce_ordinal_et, extract_number_et, \
+    is_fractional_et, is_ordinal_et, nice_number_et
 from ovos_number_parser.numbers_fa import pronounce_number_fa, extract_number_fa, is_fractional_fa, \
     pronounce_ordinal_fa
+from ovos_number_parser.numbers_fi import pronounce_number_fi, pronounce_ordinal_fi, extract_number_fi, \
+    is_fractional_fi, is_ordinal_fi, nice_number_fi
 from ovos_number_parser.numbers_fr import (pronounce_number_fr, extract_number_fr, is_fractional_fr)
 from ovos_number_parser.numbers_fy import numbers_to_digits_fy, pronounce_number_fy, pronounce_ordinal_fy, \
     extract_number_fy, is_fractional_fy, nice_number_fy
@@ -72,7 +76,8 @@ from ovos_number_parser.util import Scale, GrammaticalGender, DigitPronunciation
 _NICE_NUMBER_FNS = {
     "ar": nice_number_ar, "az": nice_number_az, "ca": nice_number_ca, "cs": nice_number_cs,
     "da": nice_number_da, "de": nice_number_de, "es": nice_number_es,
-    "eu": nice_number_eu, "fa": nice_number_fa, "fr": nice_number_fr, "fy": nice_number_fy,
+    "et": nice_number_et, "eu": nice_number_eu, "fa": nice_number_fa,
+    "fi": nice_number_fi, "fr": nice_number_fr, "fy": nice_number_fy,
     "hu": nice_number_hu, "it": nice_number_it, "nl": nice_number_nl,
     "pl": nice_number_pl, "ru": nice_number_ru, "sl": nice_number_sl,
     "sv": nice_number_sv, "uk": nice_number_uk,
@@ -92,7 +97,8 @@ _FRACTION_NUMERATOR_OVERRIDES = {
 _NUMBER_CONNECTORS = {
     "ar": {"و"}, "ca": {"i"}, "da": {"og"}, "en": {"and"}, "es": {"y"}, "eu": {"eta"},
     "fr": {"et"}, "fy": {"en"}, "it": {"e"}, "nl": {"en"}, "sv": {"och"},
-    "fa": {"و"}, "sl": {"in"}, "hu": set(), "kab": {"u", "d", "ed"},
+    "fa": {"و"}, "sl": {"in"}, "hu": set(), "fi": set(), "et": set(),
+    "kab": {"u", "d", "ed"},
 }
 
 
@@ -338,8 +344,12 @@ def pronounce_number(number: Union[int, float], lang: str,
         return pronounce_number_es(number, places)
     if lang.startswith("eu"):
         return pronounce_number_eu(number, places)
+    if lang.startswith("et"):
+        return pronounce_number_et(number, places, short_scale, scientific, ordinals)
     if lang.startswith("fa"):
         return pronounce_number_fa(number, places, scientific, ordinals)
+    if lang.startswith("fi"):
+        return pronounce_number_fi(number, places, short_scale, scientific, ordinals)
     if lang.startswith("fr"):
         return pronounce_number_fr(number, places)
     if lang.startswith("hu"):
@@ -455,6 +465,10 @@ def pronounce_ordinal(number: Union[int, float], lang: str,
         return pronounce_ordinal_da(number)
     if lang.startswith("de"):
         return pronounce_ordinal_de(number)
+    if lang.startswith("et"):
+        return pronounce_ordinal_et(number)
+    if lang.startswith("fi"):
+        return pronounce_ordinal_fi(number)
     if lang.startswith("hu"):
         return pronounce_ordinal_hu(number)
     if lang.startswith("fy"):
@@ -534,8 +548,12 @@ def extract_number(text: str, lang: str,
         return extract_number_gl(text, short_scale, ordinals)
     if lang.startswith("eu"):
         return extract_number_eu(text, short_scale, ordinals)
+    if lang.startswith("et"):
+        return extract_number_et(text, short_scale, ordinals)
     if lang.startswith("fa"):
         return extract_number_fa(text, ordinals)
+    if lang.startswith("fi"):
+        return extract_number_fi(text, short_scale, ordinals)
     if lang.startswith("fr"):
         return extract_number_fr(text, short_scale, ordinals)
     if lang.startswith("it"):
@@ -617,6 +635,10 @@ def is_fractional(input_str: str, lang: str,
         return is_fractional_gl(input_str)
     if lang.startswith("eu"):
         return is_fractional_eu(input_str)
+    if lang.startswith("et"):
+        return is_fractional_et(input_str, short_scale)
+    if lang.startswith("fi"):
+        return is_fractional_fi(input_str, short_scale)
     if lang.startswith("fr"):
         return is_fractional_fr(input_str)
     if lang.startswith("it"):
@@ -693,6 +715,10 @@ def is_ordinal(input_str: str, lang: str) -> Union[bool, float]:
         return is_ordinal_da(input_str)
     if lang.startswith("gl"):
         return is_ordinal_gl(input_str)
+    if lang.startswith("et"):
+        return is_ordinal_et(input_str)
+    if lang.startswith("fi"):
+        return is_ordinal_fi(input_str)
     if lang.startswith("hu"):
         return is_ordinal_hu(input_str)
     if lang.startswith("kab"):

--- a/ovos_number_parser/numbers_et.py
+++ b/ovos_number_parser/numbers_et.py
@@ -1,0 +1,518 @@
+"""Estonian number parsing and pronunciation.
+
+Estonian agglutinates teens ("kaksteist" = 12), tens ("kakskümmend" = 20)
+and hundreds ("kakssada" = 200) into single words, but writes the remaining
+numeral words separately: 21 is "kakskümmend üks" (two words) and 2500 is
+"kaks tuhat viissada". The scale nouns "miljon" and "miljard" follow a
+numeral in the partitive ("kaks miljonit").
+
+References:
+    * Eesti Keele Instituut (EKI), Eesti keele käsiraamat, "Arvsõnad"
+      (õigekiri: põhiarvsõnad kirjutatakse kokku ainult -teist(kümmend),
+      -kümmend ja -sada liitumites, muidu lahku)
+    * https://et.wikipedia.org/wiki/Arvs%C3%B5na
+    * https://en.wiktionary.org/wiki/Appendix:Estonian_numbers
+"""
+from math import floor
+
+from ovos_number_parser.util import convert_to_mixed_fraction
+
+_NUM_STRING_ET = {
+    0: 'null',
+    1: 'üks',
+    2: 'kaks',
+    3: 'kolm',
+    4: 'neli',
+    5: 'viis',
+    6: 'kuus',
+    7: 'seitse',
+    8: 'kaheksa',
+    9: 'üheksa',
+    10: 'kümme',
+}
+
+# genitive stems used inside ordinals ("kahekümnes" = 20th)
+_GENITIVE_UNITS_ET = {
+    1: 'ühe',
+    2: 'kahe',
+    3: 'kolme',
+    4: 'nelja',
+    5: 'viie',
+    6: 'kuue',
+    7: 'seitsme',
+    8: 'kaheksa',
+    9: 'üheksa',
+}
+
+_ORDINAL_UNITS_ET = {
+    1: 'esimene',
+    2: 'teine',
+    3: 'kolmas',
+    4: 'neljas',
+    5: 'viies',
+    6: 'kuues',
+    7: 'seitsmes',
+    8: 'kaheksas',
+    9: 'üheksas',
+    10: 'kümnes',
+}
+
+_FRACTION_STRING_ET = {
+    2: 'pool',
+    3: 'kolmandik',
+    4: 'neljandik',
+    5: 'viiendik',
+    6: 'kuuendik',
+    7: 'seitsmendik',
+    8: 'kaheksandik',
+    9: 'üheksandik',
+    10: 'kümnendik',
+    11: 'üheteistkümnendik',
+    12: 'kaheteistkümnendik',
+    13: 'kolmeteistkümnendik',
+    14: 'neljateistkümnendik',
+    15: 'viieteistkümnendik',
+    16: 'kuueteistkümnendik',
+    17: 'seitsmeteistkümnendik',
+    18: 'kaheksateistkümnendik',
+    19: 'üheksateistkümnendik',
+    20: 'kahekümnendik',
+}
+
+_MINUS_ET = ("miinus",)
+_DECIMAL_MARKER_ET = ("koma",)
+
+
+def _pronounce_below_1000_et(num):
+    """Pronounce 1..999; -sada, -kümmend and -teist join into one word,
+    everything else is a separate word."""
+    words = []
+    hundreds = num // 100
+    if hundreds:
+        words.append('sada' if hundreds == 1 else
+                     _NUM_STRING_ET[hundreds] + 'sada')
+        num -= hundreds * 100
+    if num == 0:
+        pass
+    elif num <= 10:
+        words.append(_NUM_STRING_ET[num])
+    elif num < 20:
+        words.append(_NUM_STRING_ET[num - 10] + 'teist')
+    else:
+        tens, ones = divmod(num, 10)
+        word = _NUM_STRING_ET[tens] + 'kümmend'
+        words.append(word)
+        if ones:
+            words.append(_NUM_STRING_ET[ones])
+    return ' '.join(words)
+
+
+def _pronounce_int_et(num):
+    """Pronounce a non-negative integer."""
+    if num == 0:
+        return _NUM_STRING_ET[0]
+    words = []
+    for value, name, partitive in ((10 ** 9, 'miljard', 'miljardit'),
+                                   (10 ** 6, 'miljon', 'miljonit')):
+        count = num // value
+        if count:
+            if count == 1:
+                words.append(name)
+            else:
+                words.append(_pronounce_int_et(count) + ' ' + partitive)
+            num -= count * value
+    thousands = num // 1000
+    if thousands:
+        if thousands == 1:
+            words.append('tuhat')
+        else:
+            words.append(_pronounce_below_1000_et(thousands) + ' tuhat')
+        num -= thousands * 1000
+    if num:
+        words.append(_pronounce_below_1000_et(num))
+    return ' '.join(words)
+
+
+def pronounce_number_et(number, places=2, short_scale=True, scientific=False,
+                        ordinals=False):
+    """
+    Convert a number to its spoken Estonian equivalent.
+
+    For example, 5.2 becomes "viis koma kaks".
+
+    Args:
+        number(float or int): the number to pronounce
+        places(int): maximum decimal places to speak
+        short_scale (bool): ignored, Estonian uses its own scale words
+        scientific (bool): ignored
+        ordinals (bool): pronounce as an ordinal ("esimene")
+    Returns:
+        (str): The pronounced number
+    """
+    if ordinals:
+        return pronounce_ordinal_et(number)
+    if abs(number) >= 10 ** 12:  # beyond the supported scale words
+        return str(number)
+    if number < 0:
+        return "miinus " + pronounce_number_et(abs(number), places)
+    if number == int(number):
+        return _pronounce_int_et(int(number))
+    result = _pronounce_int_et(floor(number))
+    if places > 0:
+        # decimals are read digit by digit after "koma"
+        fraction = str(round(number - floor(number), places))[2:]
+        digits = [_NUM_STRING_ET[int(d)] for d in fraction[:places]]
+        result += " koma " + " ".join(digits)
+    return result
+
+
+def pronounce_ordinal_et(number):
+    """
+    Pronounce a number as an Estonian ordinal.
+
+    1 -> "esimene", 2 -> "teine", 21 -> "kahekümne esimene"
+
+    Args:
+        number (int): the number to format
+    Returns:
+        (str): The pronounced ordinal string.
+    """
+    # only for whole positive numbers
+    if number < 1 or number != int(number):
+        return number
+    number = int(number)
+    if number in _ORDINAL_UNITS_ET:
+        return _ORDINAL_UNITS_ET[number]
+    if number < 20:
+        return _GENITIVE_UNITS_ET[number - 10] + 'teistkümnes'
+    if number < 100:
+        tens, ones = divmod(number, 10)
+        tens_ordinal = _GENITIVE_UNITS_ET[tens] + 'kümnes'
+        if not ones:
+            return tens_ordinal
+        # the leading part goes to the genitive: "kahekümne esimene"
+        return _GENITIVE_UNITS_ET[tens] + 'kümne ' + _ORDINAL_UNITS_ET[ones]
+    if number < 1000 and number % 100 == 0:
+        hundreds = number // 100
+        return 'sajas' if hundreds == 1 else \
+            _GENITIVE_UNITS_ET[hundreds] + 'sajas'
+    if number < 10 ** 6 and number % 1000 == 0 and number // 1000 <= 10:
+        thousands = number // 1000
+        return 'tuhandes' if thousands == 1 else \
+            _GENITIVE_UNITS_ET[thousands] + 'tuhandes'
+    if number == 10 ** 6:
+        return 'miljones'
+    # compose: genitive round part + ordinal remainder ("saja esimene")
+    if 100 < number < 1000:
+        hundreds = number // 100
+        head = 'saja' if hundreds == 1 else \
+            _GENITIVE_UNITS_ET[hundreds] + 'saja'
+        return head + ' ' + pronounce_ordinal_et(number % 100)
+    if 1000 < number < 10 ** 6:
+        thousands = number // 1000
+        head = 'tuhande' if thousands == 1 else \
+            _pronounce_int_et(thousands) + ' tuhande'
+        return head + ' ' + pronounce_ordinal_et(number % 1000)
+    return str(number)
+
+
+def nice_number_et(number, speech=True, denominators=range(1, 21)):
+    """Estonian helper for nice_number
+
+    This function formats a float to a human understandable string. Like
+    4.5 becomes "4 ja pool" for speech and "4 1/2" for text
+
+    Args:
+        number (int or float): the float to format
+        speech (bool): format for speech (True) or display (False)
+        denominators (iter of ints): denominators to use, default [1 .. 20]
+    Returns:
+        (str): The formatted string.
+    """
+    result = convert_to_mixed_fraction(number, denominators)
+    if not result:
+        # Give up, just represent as a 3 decimal number
+        return str(round(number, 3)).replace(".", ",")
+
+    whole, num, den = result
+
+    if not speech:
+        if num == 0:
+            return str(whole)
+        return '{} {}/{}'.format(whole, num, den)
+
+    if num == 0:
+        return str(whole)
+    den_str = _FRACTION_STRING_ET[den]
+    if num > 1:
+        # numerals govern the partitive: "kaks kolmandikku"
+        den_str = 'poolt' if den == 2 else den_str + 'ku'
+        frac = '{} {}'.format(pronounce_number_et(num), den_str)
+    else:
+        frac = den_str
+    if whole == 0:
+        return frac
+    return '{} ja {}'.format(whole, frac)
+
+
+# word → value map used to split compound numbers, including the suffixes
+# that only appear inside compounds ("teist", "kümmend", "sada")
+_STRING_NUM_ET = {word: val for val, word in _NUM_STRING_ET.items()}
+
+_COMPOUND_MULTIPLIERS_ET = {
+    'kümmend': 10,
+    'sada': 100,
+}
+
+_SCALE_WORDS_ET = {
+    'tuhat': 1000,
+    'tuhande': 1000,
+    'miljon': 10 ** 6,
+    'miljonit': 10 ** 6,
+    'miljard': 10 ** 9,
+    'miljardit': 10 ** 9,
+}
+
+
+def _split_compound_number_et(word):
+    """Split an agglutinated Estonian numeral ("kakskümmend", "viissada")
+    into its vocabulary parts.
+
+    Returns the list of matched (word, value) parts, or None if the word is
+    not entirely composed of number vocabulary.
+    """
+    vocab = dict(_STRING_NUM_ET)
+    vocab.update(_COMPOUND_MULTIPLIERS_ET)
+    vocab['teist'] = 'teen'
+    keys = sorted(vocab, key=len, reverse=True)
+    parts = []
+    rest = word
+    while rest:
+        for key in keys:
+            if rest.startswith(key):
+                parts.append((key, vocab[key]))
+                rest = rest[len(key):]
+                break
+        else:
+            return None
+    return parts
+
+
+def _compound_value_et(parts):
+    """Evaluate the value of a split Estonian compound numeral."""
+    current = 0
+    last_unit = 0
+    for word, val in parts:
+        if val == 'teen':  # "teist" turns the preceding unit into a teen
+            current += 10
+            last_unit = 0
+        elif word in _COMPOUND_MULTIPLIERS_ET:
+            mult = _COMPOUND_MULTIPLIERS_ET[word]
+            if last_unit:
+                current += last_unit * (mult - 1)
+            else:
+                current += mult
+            last_unit = 0
+        else:
+            current += val
+            last_unit = val
+    return current
+
+
+def _parse_number_word_et(word):
+    """Parse a single Estonian numeral word (possibly compound) into its
+    value, or None."""
+    word = word.lower().strip().replace('-', '')
+    if not word:
+        return None
+    if word in _STRING_NUM_ET:
+        return _STRING_NUM_ET[word]
+    if word in _COMPOUND_MULTIPLIERS_ET:
+        return _COMPOUND_MULTIPLIERS_ET[word]
+    if word in _SCALE_WORDS_ET:
+        return _SCALE_WORDS_ET[word]
+    parts = _split_compound_number_et(word)
+    if parts:
+        return _compound_value_et(parts)
+    return None
+
+
+_ORDINAL_REVERSE_ET = {}
+
+
+def is_ordinal_et(input_str):
+    """
+    Check if the given word is an Estonian ordinal number.
+
+    Args:
+        input_str (str): the string to check if ordinal
+    Returns:
+        (bool) or (int): False if not an ordinal, otherwise the number
+    """
+    if not _ORDINAL_REVERSE_ET:
+        candidates = list(range(1, 101)) + \
+            [n * 100 for n in range(1, 11)] + [1000, 10 ** 6]
+        for n in candidates:
+            _ORDINAL_REVERSE_ET[pronounce_ordinal_et(n)] = n
+    return _ORDINAL_REVERSE_ET.get(input_str.lower().strip(), False)
+
+
+def is_fractional_et(input_str, short_scale=True):
+    """
+    Check if the given word is an Estonian fraction.
+
+    Accepts the -ndik nouns ("kolmandik"), their partitive forms that
+    follow numerals ("kaks kolmandikku"), plus "pool" (1/2) and
+    "veerand" (1/4).
+
+    Args:
+        input_str (str): the string to check if fractional
+        short_scale (bool): ignored, present for API compatibility
+    Returns:
+        (bool) or (float): False if not a fraction, otherwise the fraction
+    """
+    word = input_str.lower().strip()
+    if word in ('pool', 'poolt'):
+        return 0.5
+    if word in ('veerand', 'veerandit'):
+        return 0.25
+    for den, den_str in _FRACTION_STRING_ET.items():
+        if word in (den_str, den_str + 'ku'):
+            return 1.0 / den
+    return False
+
+
+def _extract_span_et(tokens, idx):
+    """Parse the number starting at tokens[idx].
+
+    Returns (value, next_index) or None. Numerals above the hundreds are
+    written as separate words in Estonian, so consecutive number tokens are
+    accumulated: "kakskümmend üks" = 21, "kaks tuhat viissada" = 2500.
+    """
+    token = tokens[idx]
+
+    if token == 'poolteist':
+        return 1.5, idx + 1
+
+    # digits, including comma decimals
+    cleaned = token.replace(',', '.')
+    try:
+        val = float(cleaned)
+        if val == int(val) and '.' not in cleaned:
+            val = int(val)
+        return val, idx + 1
+    except ValueError:
+        pass
+
+    frac = is_fractional_et(token)
+    if frac:
+        return frac, idx + 1
+
+    if _parse_number_word_et(token) is None:
+        return None
+
+    # accumulate the separately written numeral words
+    total = 0
+    current = 0
+    prev = None
+    end = idx
+    while end < len(tokens):
+        word = tokens[end]
+        if word in _SCALE_WORDS_ET:
+            total += (current or 1) * _SCALE_WORDS_ET[word]
+            current = 0
+            prev = None
+            end += 1
+            continue
+        val = _parse_number_word_et(word)
+        if val is None:
+            break
+        # a number word only continues the span while values descend
+        # ("kakskümmend üks"); otherwise it starts a new number
+        if prev is not None and val >= prev:
+            break
+        current += val
+        prev = val
+        end += 1
+    val = total + current
+
+    # "kaks kolmandikku" → 2/3
+    if end < len(tokens):
+        frac = is_fractional_et(tokens[end])
+        if frac:
+            return val * frac, end + 1
+
+    # decimals: "viis koma kaks kolm" → 5.23
+    if end + 1 < len(tokens) and tokens[end] in _DECIMAL_MARKER_ET:
+        digits = []
+        j = end + 1
+        while j < len(tokens):
+            d = _parse_number_word_et(tokens[j])
+            if d is None or d > 9:
+                break
+            digits.append(str(d))
+            j += 1
+        if digits:
+            return float(str(val) + '.' + ''.join(digits)), j
+    return val, end
+
+
+def extract_number_et(text, short_scale=True, ordinals=False):
+    """
+    Extract the first number from Estonian text.
+
+    Args:
+        text (str): the string to normalize
+        short_scale (bool): ignored, Estonian uses its own scale words
+        ordinals (bool): consider ordinal numbers ("teine" → 2)
+    Returns:
+        (int, float or False): the extracted number or False if no number
+                               was found
+    """
+    tokens = [t.strip('.,!?;:').lower() for t in text.split()]
+    tokens = [t for t in tokens if t]
+    for idx in range(len(tokens)):
+        negative = idx > 0 and tokens[idx - 1] in _MINUS_ET
+        if ordinals:
+            val = is_ordinal_et(tokens[idx])
+            if val is not False:
+                return -val if negative else val
+        span = _extract_span_et(tokens, idx)
+        if span is None:
+            continue
+        val = span[0]
+        return -val if negative else val
+    return False
+
+
+def extract_numbers_et(text, short_scale=True, ordinals=False):
+    """
+    Extract all numbers from Estonian text.
+
+    Args:
+        text (str): the string to extract numbers from
+        short_scale (bool): ignored, Estonian uses its own scale words
+        ordinals (bool): consider ordinal numbers
+    Returns:
+        list: list of extracted numbers
+    """
+    tokens = [t.strip('.,!?;:').lower() for t in text.split()]
+    tokens = [t for t in tokens if t]
+    results = []
+    idx = 0
+    while idx < len(tokens):
+        negative = tokens[idx] in _MINUS_ET and idx + 1 < len(tokens)
+        start = idx + 1 if negative else idx
+        if ordinals and start < len(tokens):
+            val = is_ordinal_et(tokens[start])
+            if val is not False:
+                results.append(-val if negative else val)
+                idx = start + 1
+                continue
+        span = _extract_span_et(tokens, start) if start < len(tokens) else None
+        if span is None:
+            idx += 1
+            continue
+        val, idx = span
+        results.append(-val if negative else val)
+    return results

--- a/ovos_number_parser/numbers_fi.py
+++ b/ovos_number_parser/numbers_fi.py
@@ -1,0 +1,530 @@
+"""Finnish number parsing and pronunciation.
+
+Finnish writes numerals below a million as a single agglutinated word:
+21 is "kaksikymmentäyksi" and 345 is "kolmesataaneljäkymmentäviisi".
+Inside those compounds the ten, hundred and thousand words appear in the
+partitive singular ("kymmentä", "sataa", "tuhatta") whenever the multiplier
+is greater than one, while the bare forms "kymmenen", "sata" and "tuhat"
+stand alone. "miljoona" and "miljardi" are independent nouns written as
+separate words and take the partitive ("kaksi miljoonaa").
+
+References:
+    * Kotimaisten kielten keskus (Kotus), Kielitoimiston ohjepankki,
+      "Numeraalit" / "Lukusanat"
+    * https://fi.wikipedia.org/wiki/Numeraali
+    * https://en.wiktionary.org/wiki/Appendix:Finnish_numbers
+"""
+from math import floor
+
+from ovos_number_parser.util import convert_to_mixed_fraction
+
+_NUM_STRING_FI = {
+    0: 'nolla',
+    1: 'yksi',
+    2: 'kaksi',
+    3: 'kolme',
+    4: 'neljä',
+    5: 'viisi',
+    6: 'kuusi',
+    7: 'seitsemän',
+    8: 'kahdeksan',
+    9: 'yhdeksän',
+    10: 'kymmenen',
+}
+
+# ordinal units; the *_COMPOUND forms are the allomorphs used inside larger
+# ordinals (11. "yhdestoista", 12. "kahdestoista")
+_ORDINAL_UNITS_FI = {
+    1: 'ensimmäinen',
+    2: 'toinen',
+    3: 'kolmas',
+    4: 'neljäs',
+    5: 'viides',
+    6: 'kuudes',
+    7: 'seitsemäs',
+    8: 'kahdeksas',
+    9: 'yhdeksäs',
+    10: 'kymmenes',
+}
+_ORDINAL_UNITS_COMPOUND_FI = dict(_ORDINAL_UNITS_FI)
+_ORDINAL_UNITS_COMPOUND_FI[1] = 'yhdes'
+_ORDINAL_UNITS_COMPOUND_FI[2] = 'kahdes'
+
+# fraction denominators: ordinal stem + "osa" is fully productive
+# ("kolmasosa"); 3..9 also have the synonymous -nnes nouns ("kolmannes")
+_FRACTION_STRING_FI = {
+    2: 'puoli',
+    3: 'kolmasosa',
+    4: 'neljäsosa',
+    5: 'viidesosa',
+    6: 'kuudesosa',
+    7: 'seitsemäsosa',
+    8: 'kahdeksasosa',
+    9: 'yhdeksäsosa',
+    10: 'kymmenesosa',
+    11: 'yhdestoistaosa',
+    12: 'kahdestoistaosa',
+    13: 'kolmastoistaosa',
+    14: 'neljästoistaosa',
+    15: 'viidestoistaosa',
+    16: 'kuudestoistaosa',
+    17: 'seitsemästoistaosa',
+    18: 'kahdeksastoistaosa',
+    19: 'yhdeksästoistaosa',
+    20: 'kahdeskymmenesosa',
+}
+
+_NNES_FRACTIONS_FI = {
+    'kolmannes': 3,
+    'neljännes': 4,
+    'viidennes': 5,
+    'kuudennes': 6,
+    'seitsemännes': 7,
+    'kahdeksannes': 8,
+    'yhdeksännes': 9,
+}
+
+_MINUS_FI = ("miinus",)
+_DECIMAL_MARKER_FI = ("pilkku",)
+
+# well-attested colloquial short forms (accepted on extraction only)
+_COLLOQUIAL_NUM_FI = {
+    'yks': 1,
+    'kaks': 2,
+    'viis': 5,
+    'kuus': 6,
+    'seittemän': 7,
+}
+
+
+def _pronounce_below_1000_fi(num):
+    """Pronounce 1..999 as a single compound word."""
+    result = ""
+    hundreds = num // 100
+    if hundreds:
+        result += 'sata' if hundreds == 1 else \
+            _NUM_STRING_FI[hundreds] + 'sataa'
+        num -= hundreds * 100
+    if num == 0:
+        pass
+    elif num <= 10:
+        result += _NUM_STRING_FI[num]
+    elif num < 20:
+        result += _NUM_STRING_FI[num - 10] + 'toista'
+    else:
+        tens, ones = divmod(num, 10)
+        result += _NUM_STRING_FI[tens] + 'kymmentä'
+        if ones:
+            result += _NUM_STRING_FI[ones]
+    return result
+
+
+def _pronounce_int_fi(num):
+    """Pronounce a non-negative integer."""
+    if num == 0:
+        return _NUM_STRING_FI[0]
+    words = []
+    for value, name in ((10 ** 9, 'miljardi'), (10 ** 6, 'miljoona')):
+        count = num // value
+        if count:
+            if count == 1:
+                words.append(name)
+            else:
+                # miljoona/miljardi are separate nouns in the partitive
+                words.append(_pronounce_int_fi(count) + ' ' + name + 'a')
+            num -= count * value
+    compound = ""
+    thousands = num // 1000
+    if thousands:
+        compound += 'tuhat' if thousands == 1 else \
+            _pronounce_below_1000_fi(thousands) + 'tuhatta'
+        num -= thousands * 1000
+    if num:
+        compound += _pronounce_below_1000_fi(num)
+    if compound:
+        words.append(compound)
+    return ' '.join(words)
+
+
+def pronounce_number_fi(number, places=2, short_scale=True, scientific=False,
+                        ordinals=False):
+    """
+    Convert a number to its spoken Finnish equivalent.
+
+    For example, 5.2 becomes "viisi pilkku kaksi".
+
+    Args:
+        number(float or int): the number to pronounce
+        places(int): maximum decimal places to speak
+        short_scale (bool): ignored, Finnish uses its own scale words
+        scientific (bool): ignored
+        ordinals (bool): pronounce as an ordinal ("ensimmäinen")
+    Returns:
+        (str): The pronounced number
+    """
+    if ordinals:
+        return pronounce_ordinal_fi(number)
+    if abs(number) >= 10 ** 12:  # beyond the supported scale words
+        return str(number)
+    if number < 0:
+        return "miinus " + pronounce_number_fi(abs(number), places)
+    if number == int(number):
+        return _pronounce_int_fi(int(number))
+    result = _pronounce_int_fi(floor(number))
+    if places > 0:
+        # decimals are read digit by digit after "pilkku"
+        fraction = str(round(number - floor(number), places))[2:]
+        digits = [_NUM_STRING_FI[int(d)] for d in fraction[:places]]
+        result += " pilkku " + " ".join(digits)
+    return result
+
+
+def pronounce_ordinal_fi(number):
+    """
+    Pronounce a number as a Finnish ordinal.
+
+    1 -> "ensimmäinen", 2 -> "toinen", 21 -> "kahdeskymmenesensimmäinen"
+
+    Args:
+        number (int): the number to format
+    Returns:
+        (str): The pronounced ordinal string.
+    """
+    # only for whole positive numbers including zero
+    if number < 0 or number != int(number):
+        return number
+    number = int(number)
+    if number == 0:
+        return 'nollas'
+    if number in _ORDINAL_UNITS_FI:
+        return _ORDINAL_UNITS_FI[number]
+    if number < 20:
+        return _ORDINAL_UNITS_COMPOUND_FI[number - 10] + 'toista'
+    if number < 100:
+        tens, ones = divmod(number, 10)
+        result = _ORDINAL_UNITS_COMPOUND_FI[tens] + 'kymmenes'
+        if ones:
+            result += _ORDINAL_UNITS_FI[ones]
+        return result
+    if number < 1000 and number % 100 == 0:
+        hundreds = number // 100
+        return 'sadas' if hundreds == 1 else \
+            _ORDINAL_UNITS_COMPOUND_FI[hundreds] + 'sadas'
+    if number < 10 ** 6 and number % 1000 == 0:
+        thousands = number // 1000
+        return 'tuhannes' if thousands == 1 else \
+            pronounce_ordinal_fi(thousands) + 'tuhannes'
+    if number == 10 ** 6:
+        return 'miljoonas'
+    # compose: ordinal prefix from the largest round part + remainder
+    for base in (10 ** 6, 1000, 100):
+        if number > base:
+            head = (number // base) * base
+            return pronounce_ordinal_fi(head) + \
+                pronounce_ordinal_fi(number - head)
+    return str(number)
+
+
+def nice_number_fi(number, speech=True, denominators=range(1, 21)):
+    """Finnish helper for nice_number
+
+    This function formats a float to a human understandable string. Like
+    4.5 becomes "4 ja puoli" for speech and "4 1/2" for text
+
+    Args:
+        number (int or float): the float to format
+        speech (bool): format for speech (True) or display (False)
+        denominators (iter of ints): denominators to use, default [1 .. 20]
+    Returns:
+        (str): The formatted string.
+    """
+    result = convert_to_mixed_fraction(number, denominators)
+    if not result:
+        # Give up, just represent as a 3 decimal number
+        return str(round(number, 3)).replace(".", ",")
+
+    whole, num, den = result
+
+    if not speech:
+        if num == 0:
+            return str(whole)
+        return '{} {}/{}'.format(whole, num, den)
+
+    if num == 0:
+        return str(whole)
+    den_str = _FRACTION_STRING_FI[den]
+    if num > 1:
+        # numerals govern the partitive: "kolme neljäsosaa"
+        den_str = 'puolta' if den == 2 else den_str + 'a'
+        frac = '{} {}'.format(pronounce_number_fi(num), den_str)
+    else:
+        frac = den_str
+    if whole == 0:
+        return frac
+    return '{} ja {}'.format(whole, frac)
+
+
+# word → value map used to split compound numbers, including the partitive
+# allomorphs that only appear inside compounds ("kymmentä", "sataa",
+# "tuhatta") and the teen suffix "toista"
+_STRING_NUM_FI = {word: val for val, word in _NUM_STRING_FI.items()}
+
+_COMPOUND_MULTIPLIERS_FI = {
+    'kymmentä': 10,
+    'sataa': 100,
+    'sata': 100,
+    'tuhatta': 1000,
+    'tuhat': 1000,
+}
+
+_SCALE_WORDS_FI = {
+    'miljoona': 10 ** 6,
+    'miljoonaa': 10 ** 6,
+    'miljardi': 10 ** 9,
+    'miljardia': 10 ** 9,
+}
+
+
+def _split_compound_number_fi(word):
+    """Split an agglutinated Finnish numeral into its vocabulary parts.
+
+    Returns the list of matched (word, value) parts, or None if the word is
+    not entirely composed of number vocabulary.
+    """
+    vocab = dict(_STRING_NUM_FI)
+    vocab.update(_COMPOUND_MULTIPLIERS_FI)
+    vocab['toista'] = 'teen'
+    keys = sorted(vocab, key=len, reverse=True)
+    parts = []
+    rest = word
+    while rest:
+        for key in keys:
+            if rest.startswith(key):
+                parts.append((key, vocab[key]))
+                rest = rest[len(key):]
+                break
+        else:
+            return None
+    return parts
+
+
+def _compound_value_fi(parts):
+    """Evaluate the value of a split Finnish compound numeral."""
+    total = 0
+    current = 0
+    last_unit = 0
+    for word, val in parts:
+        if val == 'teen':  # "toista" turns the preceding unit into a teen
+            current += 10
+            last_unit = 0
+        elif word in ('tuhatta', 'tuhat'):
+            total += (current or 1) * 1000
+            current = 0
+            last_unit = 0
+        elif word in ('sataa', 'sata', 'kymmentä'):
+            mult = _COMPOUND_MULTIPLIERS_FI[word]
+            if last_unit:
+                current += last_unit * (mult - 1)
+            else:
+                current += mult
+            last_unit = 0
+        else:
+            current += val
+            last_unit = val
+    return total + current
+
+
+def _parse_number_word_fi(word):
+    """Parse a single Finnish numeral word (possibly compound) into its
+    value, or None."""
+    word = word.lower().strip().replace('-', '')
+    if not word:
+        return None
+    if word in _STRING_NUM_FI:
+        return _STRING_NUM_FI[word]
+    if word in _COLLOQUIAL_NUM_FI:
+        return _COLLOQUIAL_NUM_FI[word]
+    if word in _COMPOUND_MULTIPLIERS_FI:
+        return _COMPOUND_MULTIPLIERS_FI[word]
+    if word in _SCALE_WORDS_FI:
+        return _SCALE_WORDS_FI[word]
+    parts = _split_compound_number_fi(word)
+    if parts:
+        return _compound_value_fi(parts)
+    return None
+
+
+_ORDINAL_REVERSE_FI = {}
+
+
+def is_ordinal_fi(input_str):
+    """
+    Check if the given word is a Finnish ordinal number.
+
+    Args:
+        input_str (str): the string to check if ordinal
+    Returns:
+        (bool) or (int): False if not an ordinal, otherwise the number
+    """
+    if not _ORDINAL_REVERSE_FI:
+        candidates = list(range(0, 101)) + \
+            [n * 100 for n in range(1, 11)] + [1000, 10 ** 6]
+        for n in candidates:
+            _ORDINAL_REVERSE_FI[pronounce_ordinal_fi(n)] = n
+    return _ORDINAL_REVERSE_FI.get(input_str.lower().strip(), False)
+
+
+def is_fractional_fi(input_str, short_scale=True):
+    """
+    Check if the given word is a Finnish fraction.
+
+    Accepts both the productive ordinal + "osa" pattern ("kolmasosa") and
+    the -nnes nouns ("kolmannes", "neljännes"), plus the partitive forms
+    that follow numerals ("kolme neljäsosaa").
+
+    Args:
+        input_str (str): the string to check if fractional
+        short_scale (bool): ignored, present for API compatibility
+    Returns:
+        (bool) or (float): False if not a fraction, otherwise the fraction
+    """
+    word = input_str.lower().strip()
+    if word in ('puoli', 'puolta'):
+        return 0.5
+    for den, den_str in _FRACTION_STRING_FI.items():
+        if word in (den_str, den_str + 'a'):
+            return 1.0 / den
+    if word in _NNES_FRACTIONS_FI:
+        return 1.0 / _NNES_FRACTIONS_FI[word]
+    return False
+
+
+def _extract_span_fi(tokens, idx):
+    """Parse the number starting at tokens[idx].
+
+    Returns (value, next_index) or None. Consumes multi-token constructs:
+    "kaksi miljoonaa", "viisi pilkku kaksi", "kaksi kolmasosaa".
+    """
+    token = tokens[idx]
+
+    if token == 'puolitoista':
+        return 1.5, idx + 1
+
+    # digits, including comma decimals
+    cleaned = token.replace(',', '.')
+    try:
+        val = float(cleaned)
+        if val == int(val) and '.' not in cleaned:
+            val = int(val)
+        return val, idx + 1
+    except ValueError:
+        pass
+
+    frac = is_fractional_fi(token)
+    if frac:
+        return frac, idx + 1
+
+    val = _parse_number_word_fi(token)
+    if val is None:
+        return None
+    end = idx + 1
+
+    # separate scale nouns: "kaksi miljoonaa"
+    total = 0
+    while end < len(tokens) and tokens[end] in _SCALE_WORDS_FI:
+        total += val * _SCALE_WORDS_FI[tokens[end]]
+        end += 1
+        val = 0
+        # a following smaller group continues the same number
+        # ("kaksi miljoonaa kolmesataatuhatta")
+        if end < len(tokens):
+            nxt = _parse_number_word_fi(tokens[end])
+            if nxt is not None and (end + 1 >= len(tokens)
+                                    or tokens[end + 1] in _SCALE_WORDS_FI
+                                    or nxt < 10 ** 6):
+                val = nxt
+                end += 1
+                if end >= len(tokens) or tokens[end] not in _SCALE_WORDS_FI:
+                    break
+    val += total
+
+    # "kaksi kolmasosaa" → 2/3
+    if end < len(tokens):
+        frac = is_fractional_fi(tokens[end])
+        if frac:
+            return val * frac, end + 1
+
+    # decimals: "viisi pilkku kaksi kolme" → 5.23
+    if end + 1 < len(tokens) and tokens[end] in _DECIMAL_MARKER_FI:
+        digits = []
+        j = end + 1
+        while j < len(tokens):
+            d = _parse_number_word_fi(tokens[j])
+            if d is None or d > 9:
+                break
+            digits.append(str(d))
+            j += 1
+        if digits:
+            return float(str(val) + '.' + ''.join(digits)), j
+    return val, end
+
+
+def extract_number_fi(text, short_scale=True, ordinals=False):
+    """
+    Extract the first number from Finnish text.
+
+    Args:
+        text (str): the string to normalize
+        short_scale (bool): ignored, Finnish uses its own scale words
+        ordinals (bool): consider ordinal numbers ("toinen" → 2)
+    Returns:
+        (int, float or False): the extracted number or False if no number
+                               was found
+    """
+    tokens = [t.strip('.,!?;:').lower() for t in text.split()]
+    tokens = [t for t in tokens if t]
+    for idx in range(len(tokens)):
+        negative = idx > 0 and tokens[idx - 1] in _MINUS_FI
+        if ordinals:
+            val = is_ordinal_fi(tokens[idx])
+            if val is not False:
+                return -val if negative else val
+        span = _extract_span_fi(tokens, idx)
+        if span is None:
+            continue
+        val = span[0]
+        return -val if negative else val
+    return False
+
+
+def extract_numbers_fi(text, short_scale=True, ordinals=False):
+    """
+    Extract all numbers from Finnish text.
+
+    Args:
+        text (str): the string to extract numbers from
+        short_scale (bool): ignored, Finnish uses its own scale words
+        ordinals (bool): consider ordinal numbers
+    Returns:
+        list: list of extracted numbers
+    """
+    tokens = [t.strip('.,!?;:').lower() for t in text.split()]
+    tokens = [t for t in tokens if t]
+    results = []
+    idx = 0
+    while idx < len(tokens):
+        negative = tokens[idx] in _MINUS_FI and idx + 1 < len(tokens)
+        start = idx + 1 if negative else idx
+        if ordinals and start < len(tokens):
+            val = is_ordinal_fi(tokens[start])
+            if val is not False:
+                results.append(-val if negative else val)
+                idx = start + 1
+                continue
+        span = _extract_span_fi(tokens, start) if start < len(tokens) else None
+        if span is None:
+            idx += 1
+            continue
+        val, idx = span
+        results.append(-val if negative else val)
+    return results

--- a/tests/test_lang_parity.py
+++ b/tests/test_lang_parity.py
@@ -10,7 +10,7 @@ from ovos_number_parser import (extract_number, is_fractional, is_ordinal,
                                 pronounce_number, pronounce_ordinal)
 
 LANGS = ["an", "ar", "az", "ast", "ca", "cs", "da", "de", "en", "es", "eu", "fa",
-         "fr", "fy", "gl", "hu", "it", "kab", "mwl", "nl", "oc", "pl", "pt", "ro",
+         "fi", "et", "fr", "fy", "gl", "hu", "it", "kab", "mwl", "nl", "oc", "pl", "pt", "ro",
          "ru", "sl", "sv", "uk"]
 
 

--- a/tests/test_number_parser_et.py
+++ b/tests/test_number_parser_et.py
@@ -1,0 +1,138 @@
+import unittest
+
+from ovos_number_parser import (extract_number, is_fractional, is_ordinal,
+                                numbers_to_digits, pronounce_number,
+                                pronounce_ordinal)
+from ovos_number_parser.numbers_et import extract_numbers_et, nice_number_et
+
+
+class TestPronounceNumberEt(unittest.TestCase):
+    def test_anchors(self):
+        # tens and hundreds agglutinate ("kakskümmend", "kakssada") but the
+        # following units are separate words per EKI orthography
+        cases = [(0, "null"), (1, "üks"), (2, "kaks"), (7, "seitse"),
+                 (10, "kümme"), (11, "üksteist"), (12, "kaksteist"),
+                 (16, "kuusteist"), (20, "kakskümmend"),
+                 (21, "kakskümmend üks"), (25, "kakskümmend viis"),
+                 (30, "kolmkümmend"), (99, "üheksakümmend üheksa"),
+                 (100, "sada"), (101, "sada üks"), (200, "kakssada"),
+                 (222, "kakssada kakskümmend kaks"),
+                 (345, "kolmsada nelikümmend viis"),
+                 (1000, "tuhat"), (1001, "tuhat üks"),
+                 (2500, "kaks tuhat viissada"),
+                 (12345, "kaksteist tuhat kolmsada nelikümmend viis"),
+                 (1000000, "miljon"), (2000000, "kaks miljonit"),
+                 (1000000000, "miljard")]
+        for n, expected in cases:
+            self.assertEqual(pronounce_number(n, "et"), expected, n)
+
+    def test_negative(self):
+        self.assertEqual(pronounce_number(-5, "et"), "miinus viis")
+
+    def test_decimals(self):
+        self.assertEqual(pronounce_number(5.2, "et"), "viis koma kaks")
+        self.assertEqual(pronounce_number(3.14, "et"),
+                         "kolm koma üks neli")
+
+    def test_ordinals(self):
+        cases = [(1, "esimene"), (2, "teine"), (3, "kolmas"), (4, "neljas"),
+                 (5, "viies"), (6, "kuues"), (7, "seitsmes"),
+                 (8, "kaheksas"), (9, "üheksas"), (10, "kümnes"),
+                 (11, "üheteistkümnes"), (12, "kaheteistkümnes"),
+                 (20, "kahekümnes"), (21, "kahekümne esimene"),
+                 (30, "kolmekümnes"), (100, "sajas"), (200, "kahesajas"),
+                 (1000, "tuhandes"), (1000000, "miljones")]
+        for n, expected in cases:
+            self.assertEqual(pronounce_ordinal(n, "et"), expected, n)
+
+
+class TestExtractNumberEt(unittest.TestCase):
+    def test_anchors(self):
+        cases = [("null", 0), ("üks", 1), ("kaks", 2), ("kümme", 10),
+                 ("üksteist", 11), ("kakskümmend", 20),
+                 ("kakskümmend üks", 21), ("üheksakümmend üheksa", 99),
+                 ("sada", 100), ("sada üks", 101), ("kakssada", 200),
+                 ("kakssada kakskümmend kaks", 222), ("tuhat", 1000),
+                 ("tuhat üks", 1001), ("kaks tuhat viissada", 2500),
+                 ("kaksteist tuhat kolmsada nelikümmend viis", 12345),
+                 ("miljon", 1000000), ("kaks miljonit", 2000000)]
+        for spoken, expected in cases:
+            self.assertEqual(extract_number(spoken, "et"), expected, spoken)
+
+    def test_in_sentence(self):
+        self.assertEqual(extract_number("mul on kolm õuna", "et"), 3)
+        self.assertEqual(
+            extract_number("oota kakskümmend viis minutit", "et"), 25)
+
+    def test_digits(self):
+        self.assertEqual(extract_number("5 kassi", "et"), 5)
+        self.assertEqual(extract_number("5,2 kilo", "et"), 5.2)
+
+    def test_negative(self):
+        self.assertEqual(extract_number("miinus viis", "et"), -5)
+        self.assertEqual(
+            extract_number("miinus kakskümmend kraadi", "et"), -20)
+
+    def test_decimals(self):
+        self.assertEqual(extract_number("viis koma kaks", "et"), 5.2)
+        self.assertEqual(extract_number("kolm koma üks neli", "et"), 3.14)
+
+    def test_fractions(self):
+        self.assertEqual(extract_number("pool", "et"), 0.5)
+        self.assertEqual(extract_number("poolteist", "et"), 1.5)
+        self.assertEqual(extract_number("veerand", "et"), 0.25)
+        self.assertAlmostEqual(
+            extract_number("kaks kolmandikku", "et"), 2 / 3)
+        self.assertEqual(extract_number("kolm neljandikku", "et"), 0.75)
+
+    def test_ordinals(self):
+        self.assertEqual(
+            extract_number("teine korrus", "et", ordinals=True), 2)
+        self.assertEqual(
+            extract_number("kolmas koht", "et", ordinals=True), 3)
+
+    def test_no_number(self):
+        self.assertFalse(extract_number("siin pole midagi", "et"))
+
+    def test_roundtrip_sweep(self):
+        for n in list(range(0, 1000)) + [1234, 9999, 12345, 100000,
+                                         999999, 1000000, 2000000]:
+            spoken = pronounce_number(n, "et")
+            self.assertEqual(extract_number(spoken, "et"), n, spoken)
+
+    def test_ordinal_roundtrip_sweep(self):
+        for n in list(range(1, 101)) + [200, 1000, 1000000]:
+            spoken = pronounce_ordinal(n, "et")
+            self.assertEqual(is_ordinal(spoken, "et"), n, spoken)
+
+
+class TestExtractNumbersEt(unittest.TestCase):
+    def test_multiple(self):
+        self.assertEqual(
+            extract_numbers_et("kaks kassi ja kolm koera"), [2, 3])
+        self.assertEqual(
+            extract_numbers_et("miinus viis ja kakskümmend"), [-5, 20])
+
+
+class TestMiscEt(unittest.TestCase):
+    def test_is_fractional(self):
+        self.assertEqual(is_fractional("pool", "et"), 0.5)
+        self.assertAlmostEqual(is_fractional("kolmandik", "et"), 1 / 3)
+        self.assertEqual(is_fractional("neljandik", "et"), 0.25)
+        self.assertEqual(is_fractional("veerand", "et"), 0.25)
+        self.assertFalse(is_fractional("kass", "et"))
+
+    def test_nice_number(self):
+        self.assertEqual(nice_number_et(4.5), "4 ja pool")
+        self.assertEqual(nice_number_et(2 / 3), "kaks kolmandikku")
+        self.assertEqual(nice_number_et(1 / 3), "kolmandik")
+        self.assertEqual(nice_number_et(4.5, speech=False), "4 1/2")
+
+    def test_numbers_to_digits(self):
+        self.assertEqual(
+            numbers_to_digits("oota kakskümmend üks minutit", "et"),
+            "oota 21 minutit")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_number_parser_fi.py
+++ b/tests/test_number_parser_fi.py
@@ -1,0 +1,150 @@
+import unittest
+
+from ovos_number_parser import (extract_number, is_fractional, is_ordinal,
+                                numbers_to_digits, pronounce_number,
+                                pronounce_ordinal)
+from ovos_number_parser.numbers_fi import extract_numbers_fi, nice_number_fi
+
+
+class TestPronounceNumberFi(unittest.TestCase):
+    def test_anchors(self):
+        cases = [(0, "nolla"), (1, "yksi"), (2, "kaksi"), (7, "seitsemän"),
+                 (10, "kymmenen"), (11, "yksitoista"), (12, "kaksitoista"),
+                 (16, "kuusitoista"), (20, "kaksikymmentä"),
+                 (21, "kaksikymmentäyksi"), (25, "kaksikymmentäviisi"),
+                 (30, "kolmekymmentä"), (99, "yhdeksänkymmentäyhdeksän"),
+                 (100, "sata"), (101, "satayksi"), (200, "kaksisataa"),
+                 (222, "kaksisataakaksikymmentäkaksi"),
+                 (345, "kolmesataaneljäkymmentäviisi"),
+                 (1000, "tuhat"), (1001, "tuhatyksi"),
+                 (2500, "kaksituhattaviisisataa"),
+                 (12345, "kaksitoistatuhattakolmesataaneljäkymmentäviisi"),
+                 (1000000, "miljoona"), (2000000, "kaksi miljoonaa"),
+                 (2300000, "kaksi miljoonaa kolmesataatuhatta"),
+                 (1000000000, "miljardi")]
+        for n, expected in cases:
+            self.assertEqual(pronounce_number(n, "fi"), expected, n)
+
+    def test_negative(self):
+        self.assertEqual(pronounce_number(-5, "fi"), "miinus viisi")
+
+    def test_decimals(self):
+        self.assertEqual(pronounce_number(5.2, "fi"), "viisi pilkku kaksi")
+        self.assertEqual(pronounce_number(3.14, "fi"),
+                         "kolme pilkku yksi neljä")
+
+    def test_ordinals(self):
+        cases = [(1, "ensimmäinen"), (2, "toinen"), (3, "kolmas"),
+                 (4, "neljäs"), (5, "viides"), (6, "kuudes"),
+                 (7, "seitsemäs"), (8, "kahdeksas"), (9, "yhdeksäs"),
+                 (10, "kymmenes"), (11, "yhdestoista"), (12, "kahdestoista"),
+                 (20, "kahdeskymmenes"), (21, "kahdeskymmenesensimmäinen"),
+                 (30, "kolmaskymmenes"), (100, "sadas"), (200, "kahdessadas"),
+                 (1000, "tuhannes"), (1000000, "miljoonas")]
+        for n, expected in cases:
+            self.assertEqual(pronounce_ordinal(n, "fi"), expected, n)
+
+
+class TestExtractNumberFi(unittest.TestCase):
+    def test_anchors(self):
+        cases = [("nolla", 0), ("yksi", 1), ("kaksi", 2), ("kymmenen", 10),
+                 ("yksitoista", 11), ("kaksikymmentä", 20),
+                 ("kaksikymmentäyksi", 21),
+                 ("yhdeksänkymmentäyhdeksän", 99), ("sata", 100),
+                 ("satayksi", 101), ("kaksisataa", 200),
+                 ("kaksisataakaksikymmentäkaksi", 222), ("tuhat", 1000),
+                 ("tuhatyksi", 1001), ("kaksituhattaviisisataa", 2500),
+                 ("kaksitoistatuhattakolmesataaneljäkymmentäviisi", 12345),
+                 ("miljoona", 1000000), ("kaksi miljoonaa", 2000000),
+                 ("kaksi miljoonaa kolmesataatuhatta", 2300000)]
+        for spoken, expected in cases:
+            self.assertEqual(extract_number(spoken, "fi"), expected, spoken)
+
+    def test_in_sentence(self):
+        self.assertEqual(
+            extract_number("minulla on kolme omenaa", "fi"), 3)
+        self.assertEqual(
+            extract_number("odota kaksikymmentäviisi minuuttia", "fi"), 25)
+
+    def test_colloquial(self):
+        cases = [("yks", 1), ("kaks", 2), ("viis", 5), ("kuus", 6),
+                 ("seittemän", 7)]
+        for spoken, expected in cases:
+            self.assertEqual(extract_number(spoken, "fi"), expected, spoken)
+
+    def test_digits(self):
+        self.assertEqual(extract_number("5 kissaa", "fi"), 5)
+        self.assertEqual(extract_number("5,2 kiloa", "fi"), 5.2)
+
+    def test_negative(self):
+        self.assertEqual(extract_number("miinus viisi", "fi"), -5)
+        self.assertEqual(
+            extract_number("miinus kaksikymmentä astetta", "fi"), -20)
+
+    def test_decimals(self):
+        self.assertEqual(extract_number("viisi pilkku kaksi", "fi"), 5.2)
+        self.assertEqual(
+            extract_number("kolme pilkku yksi neljä", "fi"), 3.14)
+
+    def test_fractions(self):
+        self.assertEqual(extract_number("puoli", "fi"), 0.5)
+        self.assertEqual(extract_number("puolitoista", "fi"), 1.5)
+        self.assertAlmostEqual(
+            extract_number("kaksi kolmasosaa", "fi"), 2 / 3)
+        self.assertEqual(extract_number("kolme neljäsosaa", "fi"), 0.75)
+        self.assertAlmostEqual(extract_number("kolmannes", "fi"), 1 / 3)
+        self.assertEqual(extract_number("neljännes", "fi"), 0.25)
+
+    def test_ordinals(self):
+        self.assertEqual(
+            extract_number("toinen kerros", "fi", ordinals=True), 2)
+        self.assertEqual(
+            extract_number("kahdeskymmenesensimmäinen", "fi",
+                           ordinals=True), 21)
+
+    def test_no_number(self):
+        self.assertFalse(extract_number("ei mitään täällä", "fi"))
+
+    def test_roundtrip_sweep(self):
+        for n in list(range(0, 1000)) + [1234, 9999, 12345, 100000,
+                                         999999, 1000000, 2000000]:
+            spoken = pronounce_number(n, "fi")
+            self.assertEqual(extract_number(spoken, "fi"), n, spoken)
+
+    def test_ordinal_roundtrip_sweep(self):
+        for n in list(range(1, 101)) + [200, 1000, 1000000]:
+            spoken = pronounce_ordinal(n, "fi")
+            self.assertEqual(is_ordinal(spoken, "fi"), n, spoken)
+
+
+class TestExtractNumbersFi(unittest.TestCase):
+    def test_multiple(self):
+        self.assertEqual(
+            extract_numbers_fi("kaksi kissaa ja kolme koiraa"), [2, 3])
+        self.assertEqual(
+            extract_numbers_fi("miinus viisi ja kaksikymmentä"), [-5, 20])
+
+
+class TestMiscFi(unittest.TestCase):
+    def test_is_fractional(self):
+        self.assertEqual(is_fractional("puoli", "fi"), 0.5)
+        self.assertAlmostEqual(is_fractional("kolmasosa", "fi"), 1 / 3)
+        self.assertAlmostEqual(is_fractional("kolmannes", "fi"), 1 / 3)
+        self.assertEqual(is_fractional("neljäsosa", "fi"), 0.25)
+        self.assertEqual(is_fractional("neljännes", "fi"), 0.25)
+        self.assertFalse(is_fractional("kissa", "fi"))
+
+    def test_nice_number(self):
+        self.assertEqual(nice_number_fi(4.5), "4 ja puoli")
+        self.assertEqual(nice_number_fi(0.75), "kolme neljäsosaa")
+        self.assertEqual(nice_number_fi(1 / 3), "kolmasosa")
+        self.assertEqual(nice_number_fi(4.5, speech=False), "4 1/2")
+
+    def test_numbers_to_digits(self):
+        self.assertEqual(
+            numbers_to_digits("odota kaksikymmentäyksi minuuttia", "fi"),
+            "odota 21 minuuttia")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Finnish and Estonian join the parsers, both built on the greedy longest-prefix compound splitter (the pattern the Hungarian module established).

**Finnish** — numerals are written as one compound word, and the pieces appear in partitive forms that never occur standalone: `kaksikymmentäyksi` (21), `kaksituhattaviisisataa` (2500) need `kymmentä`/`sataa`/`tuhatta` in the splitter vocabulary alongside the citation forms. Extraction additionally accepts the colloquial short forms (yks, kaks, viis…).

**Estonian** — same family, different orthography: standard Estonian keeps tens and units apart (`kakskümmend üks`), so the module composes them as separate tokens while still splitting the tens compounds themselves (`kakskümmend`).

Both wire every public function (the generic fraction/ordinal/digit-substitution fallbacks engage) and join the parity suite; per-language suites include pronounce→extract round-trip sweeps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)