### PR TITLE
feat: hebrew number support

### DIFF
--- a/ovos_number_parser/__init__.py
+++ b/ovos_number_parser/__init__.py
@@ -35,6 +35,8 @@ from ovos_number_parser.numbers_gl import pronounce_number_gl, extract_number_gl
     numbers_to_digits_gl, pronounce_ordinal_gl, is_ordinal_gl, pronounce_fraction_gl
 from ovos_number_parser.numbers_hr import pronounce_number_hr, pronounce_ordinal_hr, extract_number_hr, \
     is_fractional_hr, nice_number_hr, numbers_to_digits_hr
+from ovos_number_parser.numbers_he import pronounce_number_he, pronounce_ordinal_he, \
+    extract_number_he, is_fractional_he, is_ordinal_he, nice_number_he
 from ovos_number_parser.numbers_hu import pronounce_number_hu, pronounce_ordinal_hu, extract_number_hu, \
     is_fractional_hu, is_ordinal_hu, nice_number_hu
 from ovos_number_parser.numbers_it import (extract_number_it, pronounce_number_it, is_fractional_it)
@@ -85,7 +87,7 @@ _NICE_NUMBER_FNS = {
     "da": nice_number_da, "de": nice_number_de, "es": nice_number_es,
     "et": nice_number_et, "eu": nice_number_eu, "fa": nice_number_fa,
     "fi": nice_number_fi, "fr": nice_number_fr, "fy": nice_number_fy,
-    "hr": nice_number_hr,
+    "he": nice_number_he, "hr": nice_number_hr,
     "hu": nice_number_hu, "it": nice_number_it, "nl": nice_number_nl,
     "pl": nice_number_pl, "ru": nice_number_ru, "sk": nice_number_sk, "sl": nice_number_sl,
     "sv": nice_number_sv, "uk": nice_number_uk,
@@ -371,6 +373,8 @@ def pronounce_number(number: Union[int, float], lang: str,
         return pronounce_number_fi(number, places, short_scale, scientific, ordinals)
     if lang.startswith("fr"):
         return pronounce_number_fr(number, places)
+    if lang.startswith("he"):
+        return pronounce_number_he(number, places, scientific, ordinals)
     if lang.startswith("hr"):
         return pronounce_number_hr(number, places, short_scale, scientific, ordinals)
     if lang.startswith("hu"):
@@ -494,6 +498,8 @@ def pronounce_ordinal(number: Union[int, float], lang: str,
         return pronounce_ordinal_fi(number)
     if lang.startswith("hr"):
         return pronounce_ordinal_hr(number)
+    if lang.startswith("he"):
+        return pronounce_ordinal_he(number)
     if lang.startswith("hu"):
         return pronounce_ordinal_hu(number)
     if lang.startswith("fy"):
@@ -620,6 +626,8 @@ def extract_number(text: str, lang: str,
         return extract_number_uk(text, short_scale, ordinals)
     if lang.startswith("hr"):
         return extract_number_hr(text, short_scale, ordinals)
+    if lang.startswith("he"):
+        return extract_number_he(text, ordinals)
     if lang.startswith("hu"):
         return extract_number_hu(text, short_scale, ordinals)
     if lang.startswith("sl"):
@@ -710,6 +718,8 @@ def is_fractional(input_str: str, lang: str,
         return is_fractional_fa(input_str, short_scale)
     if lang.startswith("hr"):
         return is_fractional_hr(input_str, short_scale)
+    if lang.startswith("he"):
+        return is_fractional_he(input_str, short_scale)
     if lang.startswith("hu"):
         return is_fractional_hu(input_str, short_scale)
     if lang.startswith("sl"):
@@ -760,6 +770,8 @@ def is_ordinal(input_str: str, lang: str) -> Union[bool, float]:
         return is_ordinal_et(input_str)
     if lang.startswith("fi"):
         return is_ordinal_fi(input_str)
+    if lang.startswith("he"):
+        return is_ordinal_he(input_str)
     if lang.startswith("hu"):
         return is_ordinal_hu(input_str)
     if lang.startswith("kab"):

--- a/ovos_number_parser/numbers_he.py
+++ b/ovos_number_parser/numbers_he.py
@@ -1,0 +1,576 @@
+"""Number tools for Hebrew.
+
+Pronunciation defaults to the masculine citation forms. Extraction accepts
+both genders (numbers 1-19 and the fraction nouns differ by gender), the
+construct-state forms used before counted nouns (``שני``/``שתי``, and
+``שלושת`` .. ``עשרת`` before ``אלפים``), and the dual forms that encode
+value times two (``מאתיים`` = 200, ``אלפיים`` = 2000). Niqqud (vowel
+points and cantillation marks) is stripped before matching.
+"""
+
+from ovos_number_parser.util import convert_to_mixed_fraction
+
+# niqqud and cantillation marks are stripped so vocalized text matches
+_NORM_TABLE = {c: None for c in range(0x0591, 0x05C8)}
+_NORM_TABLE[0x05BE] = ord("-")  # maqaf joins words like a hyphen
+
+
+def _normalize_he(text: str) -> str:
+    return text.translate(_NORM_TABLE)
+
+
+# masculine citation forms used for pronunciation
+_ONES_HE = ["אפס", "אחד", "שניים", "שלושה", "ארבעה", "חמישה",
+            "שישה", "שבעה", "שמונה", "תשעה", "עשרה"]
+# feminine forms, accepted in extraction
+_ONES_FEM_HE = ["", "אחת", "שתיים", "שלוש", "ארבע", "חמש",
+                "שש", "שבע", "שמונה", "תשע", "עשר"]
+# construct-state forms: שני/שתי before nouns, שלושת..עשרת before אלפים
+_ONES_CONSTRUCT_HE = {2: "שני", 3: "שלושת", 4: "ארבעת", 5: "חמשת",
+                      6: "ששת", 7: "שבעת", 8: "שמונת", 9: "תשעת",
+                      10: "עשרת"}
+
+# 12 uses the reduced forms שנים/שתים in the teen compounds
+_TEEN_UNIT_HE = {1: "אחד", 2: "שנים", 3: "שלושה", 4: "ארבעה", 5: "חמישה",
+                 6: "שישה", 7: "שבעה", 8: "שמונה", 9: "תשעה"}
+_TEEN_UNIT_FEM_HE = {1: "אחת", 2: "שתים", 3: "שלוש", 4: "ארבע", 5: "חמש",
+                     6: "שש", 7: "שבע", 8: "שמונה", 9: "תשע"}
+
+_TENS_HE = {20: "עשרים", 30: "שלושים", 40: "ארבעים", 50: "חמישים",
+            60: "שישים", 70: "שבעים", 80: "שמונים", 90: "תשעים"}
+
+_HUNDRED_HE = "מאה"
+_HUNDRED_DUAL_HE = "מאתיים"  # 200
+_HUNDREDS_PLURAL_HE = "מאות"  # 300-900: feminine unit + מאות
+
+_THOUSAND_HE = "אלף"
+_THOUSAND_DUAL_HE = "אלפיים"  # 2000
+_THOUSANDS_PLURAL_HE = "אלפים"  # 3000-10000: construct unit + אלפים
+
+# scale words above the thousands
+_SCALES_HE = [
+    (1000000, "מיליון", "מיליונים"),
+    (1000000000, "מיליארד", "מיליארדים"),
+    (1000000000000, "טריליון", "טריליונים"),
+]
+
+_MINUS_HE = "מינוס"
+_DECIMAL_HE = "נקודה"
+_INFINITY_HE = "אינסוף"
+
+# fraction nouns: denominator -> (singular, plural, numerator gender)
+# שליש and רבע are masculine, the ordinal-derived fifth..tenth are feminine
+_FRACTIONS_HE = {
+    2: ("חצי", "חצאים", "m"),
+    3: ("שליש", "שלישים", "m"),
+    4: ("רבע", "רבעים", "m"),
+    5: ("חמישית", "חמישיות", "f"),
+    6: ("שישית", "שישיות", "f"),
+    7: ("שביעית", "שביעיות", "f"),
+    8: ("שמינית", "שמיניות", "f"),
+    9: ("תשיעית", "תשיעיות", "f"),
+    10: ("עשירית", "עשיריות", "f"),
+}
+
+# ordinal forms exist for 1-10; larger ordinals use the definite cardinal
+_ORDINALS_HE = {1: "ראשון", 2: "שני", 3: "שלישי", 4: "רביעי", 5: "חמישי",
+                6: "שישי", 7: "שביעי", 8: "שמיני", 9: "תשיעי", 10: "עשירי"}
+_ORDINALS_FEM_HE = {1: "ראשונה", 2: "שנייה", 3: "שלישית", 4: "רביעית",
+                    5: "חמישית", 6: "שישית", 7: "שביעית", 8: "שמינית",
+                    9: "תשיעית", 10: "עשירית"}
+
+
+# ---------------------------------------------------------------------------
+# pronunciation
+# ---------------------------------------------------------------------------
+
+def _join_he(parts):
+    """Space-join, prefixing the conjunction ו to the final component."""
+    if len(parts) > 1:
+        parts = parts[:-1] + ["ו" + parts[-1]]
+    return " ".join(parts)
+
+
+def _two_digit_parts_he(number, feminine=False):
+    """0-99 as a list of components (units last, so ו lands on them)."""
+    ones = _ONES_FEM_HE if feminine else _ONES_HE
+    if number <= 10:
+        return [ones[number]]
+    if number < 20:
+        teen = _TEEN_UNIT_FEM_HE if feminine else _TEEN_UNIT_HE
+        suffix = " עשרה" if feminine else " עשר"
+        return [teen[number - 10] + suffix]
+    tens, unit = divmod(number, 10)
+    parts = [_TENS_HE[tens * 10]]
+    if unit:
+        parts.append(ones[unit])
+    return parts
+
+
+def _three_digit_parts_he(number, feminine=False):
+    """0-999 as a list of components."""
+    if number < 100:
+        return _two_digit_parts_he(number, feminine)
+    hundreds, rest = divmod(number, 100)
+    if hundreds == 1:
+        parts = [_HUNDRED_HE]
+    elif hundreds == 2:
+        parts = [_HUNDRED_DUAL_HE]
+    else:
+        parts = [_ONES_FEM_HE[hundreds] + " " + _HUNDREDS_PLURAL_HE]
+    if rest:
+        parts += _two_digit_parts_he(rest, feminine)
+    return parts
+
+
+def _thousands_component_he(count):
+    """The thousands block as a single component."""
+    if count == 1:
+        return _THOUSAND_HE
+    if count == 2:
+        return _THOUSAND_DUAL_HE
+    if 3 <= count <= 10:
+        return _ONES_CONSTRUCT_HE[count] + " " + _THOUSANDS_PLURAL_HE
+    return _cardinal_he(count) + " " + _THOUSAND_HE
+
+
+def _cardinal_he(number, feminine=False):
+    if number < 1000:
+        return _join_he(_three_digit_parts_he(number, feminine))
+    parts = []
+    remainder = number
+    for value, singular, _plural in reversed(_SCALES_HE):
+        count, remainder = divmod(remainder, value)
+        if not count:
+            continue
+        if count == 1:
+            parts.append(singular)
+        elif count == 2:
+            parts.append(_ONES_CONSTRUCT_HE[2] + " " + singular)
+        else:
+            parts.append(_cardinal_he(count) + " " + singular)
+    thousands, remainder = divmod(remainder, 1000)
+    if thousands:
+        parts.append(_thousands_component_he(thousands))
+    if remainder:
+        parts += _three_digit_parts_he(remainder, feminine)
+    return _join_he(parts)
+
+
+def pronounce_number_he(number, places=2, scientific=False, ordinals=False):
+    """
+    Convert a number to its spoken Hebrew equivalent.
+
+    Uses masculine citation forms; the decimal part is read digit by digit
+    after "נקודה" (e.g. 5.2 -> "חמישה נקודה שניים").
+
+    Args:
+        number (float or int): the number to pronounce
+        places (int): maximum decimal places to speak
+        scientific (bool): pronounce in scientific notation
+        ordinals (bool): pronounce in ordinal form "ראשון" instead of "אחד"
+    Returns:
+        (str): The pronounced number
+    """
+    if number == float("inf"):
+        return _INFINITY_HE
+    if number == float("-inf"):
+        return _MINUS_HE + " " + _INFINITY_HE
+    if scientific:
+        if number == 0:
+            return _ONES_HE[0]
+        n, power = ('%E' % number).replace("+", "").split("E")
+        power = int(power)
+        if power != 0:
+            mantissa = pronounce_number_he(abs(float(n)), places)
+            exponent = pronounce_number_he(abs(power), places)
+            return "{}{} כפול עשר בחזקת {}{}".format(
+                _MINUS_HE + " " if float(n) < 0 else "", mantissa,
+                _MINUS_HE + " " if power < 0 else "", exponent)
+    if ordinals:
+        return pronounce_ordinal_he(number)
+    if number < 0:
+        return _MINUS_HE + " " + pronounce_number_he(abs(number), places)
+
+    whole = int(number)
+    result = _cardinal_he(whole)
+    if isinstance(number, float) and number != whole and places > 0:
+        digits = ("%." + str(places) + "f") % (number - whole)
+        digits = digits.split(".")[1].rstrip("0")
+        if digits:
+            result += " " + _DECIMAL_HE + " " + \
+                " ".join(_ONES_HE[int(d)] for d in digits)
+    return result
+
+
+def pronounce_ordinal_he(number):
+    """
+    Pronounce a number as a Hebrew ordinal (masculine, with the definite
+    article for 11+), e.g. 1 -> "ראשון", 25 -> "העשרים וחמישה".
+
+    Ordinal forms exist for 1-10 only; larger ordinals use the definite
+    cardinal, which is the standard Hebrew pattern.
+
+    Args:
+        number (int): the number to pronounce
+    Returns:
+        (str): the ordinal in Hebrew
+    """
+    number = int(number)
+    if number <= 0:
+        raise ValueError("Hebrew ordinals start at 1")
+    if number <= 10:
+        return _ORDINALS_HE[number]
+    return "ה" + _cardinal_he(number)
+
+
+def nice_number_he(number, speech=True, denominators=range(1, 11)):
+    """Hebrew helper for nice_number
+
+    Formats a float as a whole number plus a Hebrew fraction noun, e.g.
+    4.5 becomes "4 וחצי" for speech and "4 1/2" for text. Fraction nouns
+    exist for denominators 2-10 (חצי, שליש, רבע, חמישית...); numerators
+    2+ take the plural with construct-state agreement ("שני שלישים",
+    "שלוש חמישיות").
+
+    Args:
+        number (int or float): the float to format
+        speech (bool): format for speech (True) or display (False)
+        denominators (iter of ints): denominators to use, default [1 .. 10]
+    Returns:
+        (str): The formatted string.
+    """
+    result = convert_to_mixed_fraction(number, denominators)
+    if not result:
+        return str(round(number, 3))
+    whole, num, den = result
+    if not speech:
+        if num == 0:
+            return str(whole)
+        return '{} {}/{}'.format(whole, num, den)
+    if num == 0:
+        return str(whole)
+    if den in _FRACTIONS_HE:
+        singular, plural, gender = _FRACTIONS_HE[den]
+        if num == 1:
+            frac = singular
+        elif num == 2:
+            two = "שתי" if gender == "f" else "שני"
+            frac = '{} {}'.format(two, plural)
+        else:
+            count = _cardinal_he(num, feminine=gender == "f")
+            frac = '{} {}'.format(count, plural)
+    elif num == 1:
+        frac = 'חלק אחד מתוך {}'.format(_cardinal_he(den))
+    else:
+        frac = '{} חלקים מתוך {}'.format(_cardinal_he(num), _cardinal_he(den))
+    if whole == 0:
+        return frac
+    return '{} ו{}'.format(whole, frac)
+
+
+# ---------------------------------------------------------------------------
+# extraction
+# ---------------------------------------------------------------------------
+
+def _build_lookup():
+    units = {}
+    for i, w in enumerate(_ONES_HE):
+        units[w] = i
+    for i, w in enumerate(_ONES_FEM_HE):
+        if w:
+            units[w] = i
+    for value, word in _ONES_CONSTRUCT_HE.items():
+        units[word] = value
+    units["שתי"] = 2
+    units["שנים"] = 2  # reduced form used in שנים עשר
+    units["שתים"] = 2  # reduced form used in שתים עשרה
+    tens = dict((w, v) for v, w in _TENS_HE.items())
+    scales = {_THOUSAND_HE: 1000, _THOUSANDS_PLURAL_HE: 1000}
+    scale_duals = {_THOUSAND_DUAL_HE: 2000, _HUNDRED_DUAL_HE: 200}
+    for value, singular, plural in _SCALES_HE:
+        scales[singular] = value
+        scales[plural] = value
+    # unambiguous fraction words usable inside a number ("חמישה וחצי")
+    fractions = {"חצי": 0.5, "שליש": 1 / 3, "רבע": 0.25}
+    return units, tens, scales, scale_duals, fractions
+
+
+(_UNITS_LOOKUP, _TENS_LOOKUP, _SCALES_LOOKUP, _SCALE_DUALS_LOOKUP,
+ _FRACTIONS_LOOKUP) = _build_lookup()
+
+_TEEN_SECOND_LOOKUP = {"עשר", "עשרה"}
+_MINUS_LOOKUP = {"מינוס", "פחות"}
+_DECIMAL_LOOKUP = {"נקודה"}
+_HUNDRED_WORDS = {_HUNDRED_HE: 100}
+_HUNDRED_MULT_LOOKUP = {_HUNDREDS_PLURAL_HE}
+
+_ORDINAL_UNITS_LOOKUP = {w: v for v, w in _ORDINALS_HE.items()}
+_ORDINAL_UNITS_LOOKUP.update({w: v for v, w in _ORDINALS_FEM_HE.items()})
+
+
+def _is_number(s):
+    try:
+        float(s)
+        return True
+    except ValueError:
+        return False
+
+
+def _in_vocab(token):
+    return (token in _UNITS_LOOKUP or token in _TENS_LOOKUP or
+            token in _SCALES_LOOKUP or token in _SCALE_DUALS_LOOKUP or
+            token in _FRACTIONS_LOOKUP or token in _TEEN_SECOND_LOOKUP or
+            token in _HUNDRED_WORDS or token in _HUNDRED_MULT_LOOKUP or
+            token in _ORDINAL_UNITS_LOOKUP)
+
+
+def _tokenize_he(text):
+    """Normalize and split, detaching the attached conjunction ו.
+
+    Final-letter forms (ם/ן/ץ/ף/ך) are inherent to Hebrew spelling, so no
+    folding is applied; only the prefixes ו (and ה before number words)
+    are detached when what remains is number vocabulary.
+    """
+    tokens = []
+    for token in _normalize_he(text).split():
+        token = token.strip(".,!?;:״׳\"'")
+        if not token:
+            continue
+        if not _in_vocab(token) and len(token) > 1 and token[0] == "ו" and (
+                _in_vocab(token[1:]) or
+                (token[1] == "ה" and _in_vocab(token[2:]))):
+            tokens.append("ו")
+            token = token[1:]
+        tokens.append(token)
+    return tokens
+
+
+def _strip_article(token):
+    if len(token) > 1 and token[0] == "ה" and _in_vocab(token[1:]):
+        return token[1:]
+    return token
+
+
+def _parse_ordinal_span(tokens, i):
+    """Try to read an ordinal starting at tokens[i].
+
+    Returns (value, next_index) or (None, i)."""
+    tok = _strip_article(tokens[i])
+    if tok in _ORDINAL_UNITS_LOOKUP:
+        return _ORDINAL_UNITS_LOOKUP[tok], i + 1
+    # definite cardinal used as an ordinal: "האחד עשר", "העשרים ואחד"
+    if tokens[i].startswith("ה") and tok != tokens[i]:
+        stripped = [tok] + tokens[i + 1:]
+        value, j = _parse_number_span(stripped, 0)
+        if value is not None and float(value).is_integer():
+            return int(value), i + (j - 0)
+    return None, i
+
+
+def extract_numbers_he(text, short_scale=True, ordinals=False):
+    """
+    Takes in a string and extracts a list of numbers.
+
+    Accepts both genders of the numerals, the construct-state forms and
+    the dual forms מאתיים/אלפיים.
+
+    Args:
+        text (str): the string to extract numbers from
+        short_scale (bool): ignored, Hebrew scale words are unambiguous
+        ordinals (bool): consider ordinal numbers ("שלישי" = 3)
+    Returns:
+        list: list of extracted numbers as floats
+    """
+    tokens = _tokenize_he(text)
+    results = []
+    i = 0
+    n = len(tokens)
+    while i < n:
+        tok = tokens[i]
+        negative = False
+        if tok in _MINUS_LOOKUP and i + 1 < n:
+            negative = True
+            i += 1
+            tok = tokens[i]
+        if ordinals:
+            value, j = _parse_ordinal_span(tokens, i)
+            if value is not None:
+                results.append(-value if negative else value)
+                i = j
+                continue
+        value, j = _parse_number_span(tokens, i)
+        if value is None:
+            i += 1
+            continue
+        # decimal part: "נקודה" + digit words
+        if j < n and tokens[j] in _DECIMAL_LOOKUP:
+            frac, j2 = _parse_decimal_part(tokens, j + 1)
+            if frac is not None:
+                value += frac
+                j = j2
+        results.append(-value if negative else value)
+        i = j
+    return results
+
+
+def _parse_number_span(tokens, i):
+    """Parse one number starting at tokens[i].
+
+    Returns (value, next_index); value is None if no number starts here."""
+    total = 0
+    current = 0
+    started = False
+    n = len(tokens)
+    j = i
+    while j < n:
+        tok = tokens[j]
+        if tok == "ו" and started and j + 1 < n:
+            # the conjunction only continues the number if a number word
+            # follows and forms part of the same number
+            nxt = tokens[j + 1]
+            if (nxt in _UNITS_LOOKUP or nxt in _TENS_LOOKUP or
+                    nxt in _SCALES_LOOKUP or nxt in _SCALE_DUALS_LOOKUP or
+                    nxt in _HUNDRED_WORDS or nxt in _FRACTIONS_LOOKUP):
+                j += 1
+                continue
+            break
+        if _is_number(tok):
+            if started:
+                break
+            value = float(tok)
+            if value.is_integer():
+                value = int(value)
+            return value, j + 1
+        # teens: unit word followed by עשר/עשרה
+        if tok in _UNITS_LOOKUP and 1 <= _UNITS_LOOKUP[tok] <= 9 and \
+                j + 1 < n and tokens[j + 1] in _TEEN_SECOND_LOOKUP:
+            current += 10 + _UNITS_LOOKUP[tok]
+            started = True
+            j += 2
+            continue
+        if tok in _UNITS_LOOKUP:
+            # feminine unit followed by מאות multiplies: "שלוש מאות" = 300
+            if j + 1 < n and tokens[j + 1] in _HUNDRED_MULT_LOOKUP and \
+                    3 <= _UNITS_LOOKUP[tok] <= 9:
+                current += _UNITS_LOOKUP[tok] * 100
+                started = True
+                j += 2
+                continue
+            current += _UNITS_LOOKUP[tok]
+            started = True
+            j += 1
+            continue
+        if tok in _TENS_LOOKUP:
+            current += _TENS_LOOKUP[tok]
+            started = True
+            j += 1
+            continue
+        if tok in _HUNDRED_WORDS:
+            current += _HUNDRED_WORDS[tok]
+            started = True
+            j += 1
+            continue
+        if tok in _SCALES_LOOKUP:
+            total += (current if current else 1) * _SCALES_LOOKUP[tok]
+            current = 0
+            started = True
+            j += 1
+            continue
+        if tok in _SCALE_DUALS_LOOKUP:
+            value = _SCALE_DUALS_LOOKUP[tok]
+            if value == 200:
+                current += 200
+            else:
+                total += value
+                current = 0
+            started = True
+            j += 1
+            continue
+        if tok in _FRACTIONS_LOOKUP:
+            current += _FRACTIONS_LOOKUP[tok]
+            started = True
+            j += 1
+            break  # a fraction noun ends the number
+        break
+    if not started:
+        return None, i
+    return total + current, j
+
+
+def _parse_decimal_part(tokens, i):
+    """Parse the digit words following "נקודה".
+
+    Returns (fraction, next_index) or (None, i)."""
+    n = len(tokens)
+    digits = []
+    j = i
+    while j < n and tokens[j] in _UNITS_LOOKUP and \
+            _UNITS_LOOKUP[tokens[j]] <= 9 and \
+            not (j + 1 < n and tokens[j + 1] in _TEEN_SECOND_LOOKUP) and \
+            not (j + 1 < n and tokens[j + 1] in _HUNDRED_MULT_LOOKUP):
+        digits.append(_UNITS_LOOKUP[tokens[j]])
+        j += 1
+    if digits:
+        return sum(d / 10 ** (k + 1) for k, d in enumerate(digits)), j
+    return None, i
+
+
+def extract_number_he(text, ordinals=False):
+    """
+    Extract the first number found in Hebrew text.
+
+    Args:
+        text (str): the string to extract a number from
+        ordinals (bool): consider ordinal numbers ("שלישי" = 3)
+    Returns:
+        (int, float or False): the extracted number, or False if the text
+                               contains no number
+    """
+    numbers = extract_numbers_he(text, ordinals=ordinals)
+    if not numbers:
+        return False
+    value = numbers[0]
+    if isinstance(value, float) and value.is_integer():
+        return int(value)
+    return value
+
+
+def is_fractional_he(input_str, short_scale=True):
+    """
+    Check if the given word is a Hebrew fraction noun.
+
+    Recognizes the fraction nouns for 1/2 .. 1/10 (חצי, שליש, רבע,
+    חמישית...), with or without the definite article.
+
+    Args:
+        input_str (str): the string to check if fractional
+        short_scale (bool): ignored, present for API compatibility
+    Returns:
+        (bool) or (float): False if not a fraction, otherwise the fraction
+    """
+    word = _normalize_he(input_str.strip())
+    if len(word) > 1 and word[0] == "ה":
+        word = word[1:]
+    for den, (singular, _plural, _gender) in _FRACTIONS_HE.items():
+        if word == singular:
+            return 1.0 / den
+    return False
+
+
+def is_ordinal_he(input_str):
+    """
+    Check if the given text is a Hebrew ordinal number.
+
+    Args:
+        input_str (str): the string to check if ordinal
+    Returns:
+        (bool) or (int): False if not an ordinal, otherwise the number
+    """
+    tokens = _tokenize_he(input_str)
+    if not tokens:
+        return False
+    value, j = _parse_ordinal_span(tokens, 0)
+    if value is not None and j == len(tokens):
+        return value
+    return False

--- a/tests/test_lang_parity.py
+++ b/tests/test_lang_parity.py
@@ -10,7 +10,7 @@ from ovos_number_parser import (extract_number, is_fractional, is_ordinal,
                                 pronounce_number, pronounce_ordinal)
 
 LANGS = ["an", "ar", "ast", "az", "bg", "ca", "cs", "da", "de", "en", "es",
-         "et", "eu", "fa", "fi", "fr", "fy", "gl", "hr", "hu", "it", "kab",
+         "et", "eu", "fa", "fi", "fr", "fy", "gl", "he", "hr", "hu", "it", "kab",
          "mwl", "nl", "oc", "pl", "pt", "ro", "ru", "sk", "sl", "sv", "uk"]
 
 

--- a/tests/test_number_parser_he.py
+++ b/tests/test_number_parser_he.py
@@ -1,0 +1,192 @@
+import unittest
+
+from ovos_number_parser import (extract_number, pronounce_number,
+                                pronounce_ordinal, pronounce_fraction,
+                                is_fractional, is_ordinal, numbers_to_digits)
+
+
+class TestHebrewPronounce(unittest.TestCase):
+    """Anchors for spoken Hebrew numbers (masculine citation forms)."""
+
+    def test_pronounce_number(self):
+        expected = {
+            0: 'אפס', 1: 'אחד', 2: 'שניים', 3: 'שלושה', 4: 'ארבעה',
+            5: 'חמישה', 6: 'שישה', 7: 'שבעה', 8: 'שמונה', 9: 'תשעה',
+            10: 'עשרה', 11: 'אחד עשר', 12: 'שנים עשר', 13: 'שלושה עשר',
+            14: 'ארבעה עשר', 15: 'חמישה עשר', 16: 'שישה עשר',
+            17: 'שבעה עשר', 18: 'שמונה עשר', 19: 'תשעה עשר', 20: 'עשרים',
+            # the conjunction ו attaches to the final component
+            21: 'עשרים ואחד', 25: 'עשרים וחמישה', 30: 'שלושים',
+            42: 'ארבעים ושניים', 50: 'חמישים', 66: 'שישים ושישה',
+            70: 'שבעים', 80: 'שמונים', 90: 'תשעים', 99: 'תשעים ותשעה',
+            100: 'מאה', 101: 'מאה ואחד', 110: 'מאה ועשרה',
+            123: 'מאה עשרים ושלושה',
+            # dual forms encode value times two
+            200: 'מאתיים', 2000: 'אלפיים',
+            # 300-900 use the feminine unit + מאות
+            300: 'שלוש מאות', 500: 'חמש מאות',
+            999: 'תשע מאות תשעים ותשעה',
+            1000: 'אלף', 1985: 'אלף תשע מאות שמונים וחמישה',
+            2023: 'אלפיים עשרים ושלושה',
+            # 3000-10000 use the construct-state unit + אלפים
+            3000: 'שלושת אלפים', 10000: 'עשרת אלפים', 11000: 'אחד עשר אלף',
+            100000: 'מאה אלף', 1000000: 'מיליון', 2000000: 'שני מיליון',
+            3000000: 'שלושה מיליון', 1000000000: 'מיליארד',
+        }
+        for number, spoken in expected.items():
+            with self.subTest(number=number):
+                self.assertEqual(pronounce_number(number, lang="he"), spoken)
+
+    def test_pronounce_negative_and_decimal(self):
+        expected = {-7: 'מינוס שבעה', -42: 'מינוס ארבעים ושניים',
+                    5.2: 'חמישה נקודה שניים',
+                    5.25: 'חמישה נקודה שניים חמישה',
+                    0.5: 'אפס נקודה חמישה',
+                    -3.5: 'מינוס שלושה נקודה חמישה'}
+        for number, spoken in expected.items():
+            with self.subTest(number=number):
+                self.assertEqual(pronounce_number(number, lang="he"), spoken)
+
+    def test_pronounce_ordinal(self):
+        expected = {1: 'ראשון', 2: 'שני', 3: 'שלישי', 4: 'רביעי',
+                    5: 'חמישי', 6: 'שישי', 7: 'שביעי', 8: 'שמיני',
+                    9: 'תשיעי', 10: 'עשירי',
+                    # ordinals beyond 10 use the definite cardinal
+                    11: 'האחד עשר', 12: 'השנים עשר', 20: 'העשרים',
+                    21: 'העשרים ואחד', 25: 'העשרים וחמישה',
+                    30: 'השלושים', 100: 'המאה', 1000: 'האלף'}
+        for number, spoken in expected.items():
+            with self.subTest(number=number):
+                self.assertEqual(pronounce_ordinal(number, lang="he"), spoken)
+
+    def test_pronounce_fraction(self):
+        self.assertEqual(pronounce_fraction("1/2", lang="he"), 'חצי')
+        self.assertEqual(pronounce_fraction("1/3", lang="he"), 'שליש')
+        self.assertEqual(pronounce_fraction("1/4", lang="he"), 'רבע')
+        self.assertEqual(pronounce_fraction("2/3", lang="he"), 'שני שלישים')
+        self.assertEqual(pronounce_fraction("3/4", lang="he"),
+                         'שלושה רבעים')
+        # feminine agreement of the ordinal-derived fraction nouns
+        self.assertEqual(pronounce_fraction("2/5", lang="he"),
+                         'שתי חמישיות')
+        self.assertEqual(pronounce_fraction("3/10", lang="he"),
+                         'שלוש עשיריות')
+
+
+class TestHebrewExtract(unittest.TestCase):
+    """Anchors for extracting numbers from Hebrew text."""
+
+    def test_extract_number(self):
+        expected = {
+            0: 'אפס', 1: 'אחד', 2: 'שניים', 3: 'שלושה', 10: 'עשרה',
+            11: 'אחד עשר', 12: 'שנים עשר', 15: 'חמישה עשר', 20: 'עשרים',
+            25: 'עשרים וחמישה', 99: 'תשעים ותשעה', 100: 'מאה',
+            123: 'מאה עשרים ושלושה', 1000: 'אלף', 3000: 'שלושת אלפים',
+            1000000: 'מיליון',
+        }
+        for number, spoken in expected.items():
+            with self.subTest(spoken=spoken):
+                self.assertEqual(extract_number(spoken, lang="he"), number)
+
+    def test_extract_gender_and_construct_variants(self):
+        # feminine forms are accepted alongside the masculine ones
+        expected = {1: 'אחת', 2: 'שתיים', 3: 'שלוש', 4: 'ארבע',
+                    5: 'חמש', 6: 'שש', 7: 'שבע', 9: 'תשע', 10: 'עשר',
+                    # construct-state forms
+                    22: 'עשרים ושתיים', 32: 'שלושים ושתי',
+                    # feminine teens
+                    11: 'אחת עשרה', 12: 'שתים עשרה', 13: 'שלוש עשרה',
+                    18: 'שמונה עשרה',
+                    # duals
+                    200: 'מאתיים', 2000: 'אלפיים',
+                    # feminine compounds
+                    21: 'עשרים ואחת', 400: 'ארבע מאות'}
+        for number, spoken in expected.items():
+            with self.subTest(spoken=spoken):
+                self.assertEqual(extract_number(spoken, lang="he"), number)
+
+    def test_extract_negative_and_decimal(self):
+        expected = {-7: 'מינוס שבעה', -9: 'מינוס תשעה',
+                    -42: 'מינוס ארבעים ושניים',
+                    5.2: 'חמישה נקודה שניים',
+                    3.14: 'שלושה נקודה אחד ארבעה',
+                    5.5: 'חמישה וחצי', 2.25: 'שניים ורבע',
+                    0.5: 'חצי', 0.25: 'רבע'}
+        for number, spoken in expected.items():
+            with self.subTest(spoken=spoken):
+                self.assertAlmostEqual(extract_number(spoken, lang="he"),
+                                       number)
+
+    def test_extract_with_niqqud(self):
+        # vowel points are stripped before matching
+        self.assertEqual(extract_number("שְׁלוֹשָׁה", lang="he"), 3)
+        self.assertEqual(extract_number("אַרְבַּע", lang="he"), 4)
+
+    def test_extract_from_sentence(self):
+        self.assertEqual(extract_number("יש לי עשרים וחמישה ספרים",
+                                        lang="he"), 25)
+        self.assertEqual(extract_number("קניתי שלוש בננות", lang="he"), 3)
+        self.assertEqual(extract_number("זה היום השלישי", lang="he",
+                                        ordinals=True), 3)
+        self.assertEqual(extract_number("העשרים וחמישה", lang="he",
+                                        ordinals=True), 25)
+
+    def test_no_number(self):
+        self.assertIn(extract_number("שלום מה שלומך", lang="he"),
+                      (False, None))
+        self.assertIn(extract_number("", lang="he"), (False, None))
+
+    def test_is_fractional(self):
+        self.assertEqual(is_fractional("חצי", lang="he"), 0.5)
+        self.assertEqual(is_fractional("רבע", lang="he"), 0.25)
+        self.assertEqual(is_fractional("הרבע", lang="he"), 0.25)
+        self.assertAlmostEqual(is_fractional("שליש", lang="he"), 1 / 3)
+        self.assertAlmostEqual(is_fractional("חמישית", lang="he"), 0.2)
+        self.assertAlmostEqual(is_fractional("עשירית", lang="he"), 0.1)
+        self.assertFalse(is_fractional("ספר", lang="he"))
+
+    def test_is_ordinal(self):
+        self.assertEqual(is_ordinal("ראשון", lang="he"), 1)
+        self.assertEqual(is_ordinal("ראשונה", lang="he"), 1)
+        self.assertEqual(is_ordinal("שלישית", lang="he"), 3)
+        self.assertEqual(is_ordinal("האחד עשר", lang="he"), 11)
+        self.assertEqual(is_ordinal("העשרים וחמישה", lang="he"), 25)
+        self.assertFalse(is_ordinal("שלום", lang="he"))
+
+    def test_numbers_to_digits(self):
+        self.assertEqual(
+            numbers_to_digits("יש לי עשרים וחמישה חתולים", lang="he"),
+            "יש לי 25 חתולים")
+
+
+class TestHebrewRoundTrip(unittest.TestCase):
+    """pronounce_number output must be understood by extract_number."""
+
+    def test_round_trip(self):
+        numbers = list(range(0, 200)) + [
+            201, 222, 300, 345, 400, 456, 500, 678, 700, 891, 900, 999,
+            1000, 1001, 1234, 1985, 2000, 2023, 3000, 5000, 9999, 10000,
+            11000, 15000, 100000, 123456, 1000000, 2000000, 3000000,
+            1000000000, 2000000000]
+        for number in numbers:
+            with self.subTest(number=number):
+                spoken = pronounce_number(number, lang="he")
+                self.assertEqual(extract_number(spoken, lang="he"), number)
+
+    def test_round_trip_negative_and_decimal(self):
+        for number in [-7, -42, -100, 2.5, 3.14, 5.2, -3.5, 0.5, 5.25,
+                       0.75, 12.34]:
+            with self.subTest(number=number):
+                spoken = pronounce_number(number, lang="he")
+                self.assertAlmostEqual(extract_number(spoken, lang="he"),
+                                       number)
+
+    def test_round_trip_ordinals(self):
+        for number in range(1, 100):
+            with self.subTest(number=number):
+                spoken = pronounce_ordinal(number, lang="he")
+                self.assertEqual(is_ordinal(spoken, lang="he"), number)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Hebrew numerals, following the Arabic module's approach — the two languages share the same problem class (gender polarity, dual forms carrying their own value, script normalization).

- **gender**: pronunciation uses masculine citation forms; extraction accepts both genders (`שלושה`/`שלוש`) and the construct forms (`שני`/`שתי`)
- **duals encode value**: `מאתיים` = 200, `אלפיים` = 2000 — not "two hundred" as two words
- **agreement inside the number**: `אלפיים וחמש מאות` (2500) takes the feminine `חמש` because `מאות` is feminine
- construct-state thousands: `שלושת אלפים`, `עשרת אלפים`
- `ו` joiner, `נקודה` decimals read digit-by-digit, `מינוס` negatives, niqqud stripped before matching

All public functions work for `he` (`numbers_to_digits` and `pronounce_fraction` via the generic fallbacks) and `he` joins the parity suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)