### PR TITLE
test: guard indonesian and malay in the parity suite

### DIFF
--- a/tests/test_lang_parity.py
+++ b/tests/test_lang_parity.py
@@ -11,8 +11,8 @@ from ovos_number_parser import (extract_number, is_fractional, is_ordinal,
 
 LANGS = ["an", "ar", "ast", "az", "bg", "ca", "cs", "da", "de", "el", "en",
          "es", "et", "eu", "fa", "fi", "fr", "fy", "gl", "he", "hr", "hu",
-         "it", "kab",
-         "mwl", "nb", "nl", "nn", "oc", "pl", "pt", "ro", "ru", "sk", "sl", "sv", "tr", "uk"]
+         "id", "it", "kab", "ms", "mwl", "nb", "nl", "nn", "oc", "pl", "pt",
+         "ro", "ru", "sk", "sl", "sv", "tr", "uk"]
 
 
 class TestLanguageParity(unittest.TestCase):


### PR DESCRIPTION
`id` and `ms` are wired into every dispatcher but were absent from `LANGS`, so nothing asserted that every public function serves them. Adding them brings the parity suite to 40 languages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)