### PR TITLE
fix: hyphenate Hungarian thousand-group boundaries above 2000

### DIFF
--- a/ovos_number_parser/numbers_hu.py
+++ b/ovos_number_parser/numbers_hu.py
@@ -188,6 +188,8 @@ def pronounce_number_hu(number, places=2, short_scale=True, scientific=False,
         result = ''
         last_triplet = num % 1000
 
+        higher_groups = floor(num / 1000) > 0
+
         if last_triplet == 1:
             if scale_level == 0:
                 if result != '':
@@ -195,10 +197,16 @@ def pronounce_number_hu(number, places=2, short_scale=True, scientific=False,
                 else:
                     result += "egy"
             elif scale_level == 1:
-                result += _EXTRA_SPACE_HU + \
-                          _NUM_POWERS_OF_TEN[1] + _EXTRA_SPACE_HU
+                # a lone thousands group is "ezer" on its own, but "egyezer"
+                # once a higher (million+) group precedes it, and then the
+                # group boundary takes a hyphen like any other above 2000
+                if higher_groups:
+                    result += "egy" + _NUM_POWERS_OF_TEN[1] + '-'
+                else:
+                    result += _EXTRA_SPACE_HU + \
+                        _NUM_POWERS_OF_TEN[1] + _EXTRA_SPACE_HU
             else:
-                result += "egy" + _NUM_POWERS_OF_TEN[scale_level]
+                result += "egy" + _NUM_POWERS_OF_TEN[scale_level] + '-'
         elif last_triplet > 1:
             result += pronounce_triplet_hu(last_triplet)
             if scale_level != 0:

--- a/tests/test_hu_edges.py
+++ b/tests/test_hu_edges.py
@@ -36,6 +36,34 @@ class TestHungarianEdges(unittest.TestCase):
         self.assertEqual(pronounce_number_hu(5.2), "öt egész húsz század")
         self.assertEqual(pronounce_number_hu(5.2, places=1), "öt egész két tized")
 
+    def test_scale_group_of_one_is_hyphenated(self):
+        # above 2000 Hungarian hyphenates at every thousand-group boundary,
+        # including when a million/billion group is exactly one
+        cases = [
+            (1000001, "egymillió-egy"),
+            (1000100, "egymillió-száz"),
+            (1234567, "egymillió-kétszázharmincnégyezer-ötszázhatvanhét"),
+            (1001000, "egymillió-egyezer"),
+            (2001001, "kétmillió-egyezer-egy"),
+            (1000000001, "egymilliárd-egy"),
+            (1001000000, "egymilliárd-egymillió"),
+        ]
+        for n, expected in cases:
+            self.assertEqual(pronounce_number_hu(n), expected, n)
+
+    def test_scale_group_of_one_still_bare_when_standalone(self):
+        # a bare thousand/million group keeps no trailing hyphen or "egy"
+        self.assertEqual(pronounce_number_hu(1000), "ezer")
+        self.assertEqual(pronounce_number_hu(1500), "ezerötszáz")
+        self.assertEqual(pronounce_number_hu(1000000), "egymillió")
+        self.assertEqual(pronounce_number_hu(1000000000), "egymilliárd")
+
+    def test_large_number_round_trip(self):
+        from ovos_number_parser.numbers_hu import extract_number_hu
+        for n in (1000001, 1001000, 1234567, 2001001, 1000000001,
+                  1001000000):
+            self.assertEqual(extract_number_hu(pronounce_number_hu(n)), n, n)
+
     def test_pronounce_ordinal_large(self):
         from ovos_number_parser.numbers_hu import pronounce_ordinal_hu
         self.assertEqual(pronounce_ordinal_hu(1000), "ezredik")


### PR DESCRIPTION
Above 2000, Hungarian hyphenates the spelled-out number at every thousand-group boundary. Two cases dropped that separator when a group was exactly one:

- A million-or-higher group of one lost the following hyphen — `pronounce_number_hu(1234567)` returned `egymilliókétszázharmincnégyezer-ötszázhatvanhét` instead of `egymillió-kétszázharmincnégyezer-ötszázhatvanhét`.
- A leading thousands group of one, when a higher group preceded it, both lost the hyphen and the `egy` prefix — `pronounce_number_hu(1001000)` returned `egymillióezer` instead of `egymillió-egyezer`.

Standalone groups (`ezer`, `egymillió`, `ezerötszáz`) and all existing round-trips are unchanged; extraction already stripped hyphens so this was invisible to the round-trip sweep.

New tests cover the hyphenated boundaries, the standalone-group cases, and large-number round-trips.