### PR TITLE
fix: parse elided and accented Italian fused numerals

### DIFF
--- a/ovos_number_parser/numbers_it.py
+++ b/ovos_number_parser/numbers_it.py
@@ -371,6 +371,13 @@ def _extract_number_long_it(word):
                                    was found
     """
 
+    # accented endings are the standard spelling of fused units
+    # (ventitré, trentatré, ...) and must parse like their bare forms
+    word = word.replace('é', 'e').replace('è', 'e')
+    # restore the vowel elided before -uno / -otto in the hundreds
+    # (centotto -> cento otto, centuno -> cento uno)
+    word = word.replace('centotto', 'centootto').replace('centuno', 'centouno')
+
     units = {'zero': 0, 'uno': 1, 'due': 2, 'tre': 3, 'quattro': 4,
              'cinque': 5, 'sei': 6, 'sette': 7, 'otto': 8, 'nove': 9}
 

--- a/tests/test_number_parser_it.py
+++ b/tests/test_number_parser_it.py
@@ -58,5 +58,95 @@ class TestItalianRoundTrip(unittest.TestCase):
                 self.assertEqual(extract_number(spoken, lang="it"), number)
 
 
+class TestItalianFusedCompounds(unittest.TestCase):
+    """Vowel elision and accented endings in fused Italian numerals."""
+
+    def test_elided_units_in_tens(self):
+        # -uno and -otto drop the tens vowel
+        expected = {'ventuno': 21, 'ventotto': 28, 'trentuno': 31,
+                    'trentotto': 38, 'quarantuno': 41, 'quarantotto': 48,
+                    'cinquantuno': 51, 'cinquantotto': 58, 'sessantuno': 61,
+                    'sessantotto': 68, 'settantuno': 71, 'settantotto': 78,
+                    'ottantuno': 81, 'ottantotto': 88, 'novantuno': 91,
+                    'novantotto': 98}
+        for word, number in expected.items():
+            with self.subTest(word=word):
+                self.assertEqual(extract_number(word, lang="it"), number)
+
+    def test_accented_tre_endings(self):
+        # tré carries an accent in every fused form; both spellings are valid
+        expected = {'ventitré': 23, 'trentatré': 33, 'quarantatré': 43,
+                    'cinquantatré': 53, 'sessantatré': 63, 'settantatré': 73,
+                    'ottantatré': 83, 'novantatré': 93, 'centotré': 103,
+                    'duecentotré': 203}
+        for word, number in expected.items():
+            with self.subTest(word=word):
+                self.assertEqual(extract_number(word, lang="it"), number)
+
+    def test_accented_and_bare_agree(self):
+        for bare, accented in [('ventitre', 'ventitré'),
+                               ('trentatre', 'trentatré'),
+                               ('novantatre', 'novantatré')]:
+            with self.subTest(word=accented):
+                self.assertEqual(extract_number(accented, lang="it"),
+                                 extract_number(bare, lang="it"))
+
+    def test_elided_units_in_hundreds(self):
+        expected = {'centouno': 101, 'centuno': 101, 'centotto': 108,
+                    'centootto': 108, 'centosette': 107, 'centoventuno': 121,
+                    'duecentotto': 208, 'trecentotto': 308}
+        for word, number in expected.items():
+            with self.subTest(word=word):
+                self.assertEqual(extract_number(word, lang="it"), number)
+
+    def test_thousands_and_scale(self):
+        expected = {'milleuno': 1001, 'duemila': 2000,
+                    'duemilaventitre': 2023, 'duemilaventitré': 2023,
+                    'centomila': 100000, 'ventitremila': 23000,
+                    'tremiladuecentotrentotto': 3238,
+                    'un milione': 1000000, 'due milioni': 2000000}
+        for word, number in expected.items():
+            with self.subTest(word=word):
+                self.assertEqual(extract_number(word, lang="it"), number)
+
+
+class TestItalianFractions(unittest.TestCase):
+    """Spoken fractions and halves."""
+
+    def test_fractions(self):
+        expected = {'mezza': 0.5, 'mezzo': 0.5, 'un quarto': 0.25,
+                    'tre quarti': 0.75, 'due terzi': 2 / 3}
+        for word, number in expected.items():
+            with self.subTest(word=word):
+                self.assertAlmostEqual(extract_number(word, lang="it"), number)
+
+
+class TestItalianAdversarial(unittest.TestCase):
+    """Malformed, empty and junk input must not raise."""
+
+    def test_empty_and_junk(self):
+        for junk in ["", "   ", "ciao come stai", "!!!", "xyz",
+                     "gattopardo", "trentini"]:
+            with self.subTest(junk=junk):
+                self.assertIn(extract_number(junk, lang="it"), (False, None))
+
+    def test_number_in_noise(self):
+        self.assertEqual(extract_number("allora ventotto mele", lang="it"), 28)
+        self.assertEqual(extract_number("ne voglio quarantotto", lang="it"), 48)
+
+    def test_zero(self):
+        self.assertEqual(extract_number("zero", lang="it"), 0)
+
+
+class TestItalianFusedRoundTrip(unittest.TestCase):
+    """Sweep fused compounds that stress elision through a full round trip."""
+
+    def test_sweep_all_tens(self):
+        for number in range(0, 1001):
+            with self.subTest(number=number):
+                spoken = pronounce_number(number, lang="it")
+                self.assertEqual(extract_number(spoken, lang="it"), number)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Italian fused numerals with vowel elision and accented endings failed to extract.

## Fixes
- Accented `-tré` endings (`ventitré`, `trentatré`, … `novantatré`, `centotré`) now extract, matching their bare `-tre` forms. Some previously raised on internal integer conversion.
- Vowel elision in the hundreds is handled: `centotto` -> 108, `centuno` -> 101, and their multiples (`duecentotto` -> 208).

## Tests
- New tests for elided units in tens and hundreds, accented endings, thousands/scale, spoken fractions, and adversarial/empty/junk input.
- Full-range 0..1000 pronounce/extract round-trip sweep.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Italian number recognition for accented endings and fused forms involving hundreds and thousands.
  * Enhanced extraction of Italian fractions, halves, and numbers embedded in surrounding text.
  * Improved handling of empty or invalid input without errors.

* **Tests**
  * Expanded coverage for fused compounds, fractions, malformed input, and number conversion round trips across a broad range.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->