### PR TITLE
fix(sl): correct compound Slovene ordinals above one hundred

### DIFF
--- a/ovos_number_parser/numbers_sl.py
+++ b/ovos_number_parser/numbers_sl.py
@@ -351,9 +351,9 @@ def pronounce_number_sl(num, places=2, short_scale=True, scientific=False,
 
                 if z == 1 and i == 1:
                     number = ""
-                elif z > 100 and z % 100 == 2:
+                elif z > 100 and z % 100 == 2 and not ordi:
                     number = _sub_thousand(z, not i and ordi, is_male=True)
-                elif z > 100 and z % 100 == 3:
+                elif z > 100 and z % 100 == 3 and not ordi:
                     number = _sub_thousand(z, not i and ordi) + "je"
                 elif z > 1 or i == 0 or ordi:
                     number = _sub_thousand(z, not i and ordi)
@@ -576,8 +576,7 @@ def is_ordinal_sl(input_str):
         (bool) or (int): False if not an ordinal, otherwise the number
     """
     if not _ORDINAL_REVERSE_SL:
-        candidates = list(range(1, 101)) + \
-            [n * 100 for n in range(1, 11)] + [1000, 1000000]
+        candidates = list(range(1, 1000)) + [1000, 1000000]
         for n in candidates:
             _ORDINAL_REVERSE_SL[pronounce_number_sl(n, ordinals=True)] = n
     return _ORDINAL_REVERSE_SL.get(input_str.lower().strip(), False)

--- a/tests/test_sl_edges.py
+++ b/tests/test_sl_edges.py
@@ -1,7 +1,8 @@
 """Edge-path tests for the Slovenian number module."""
 import unittest
 
-from ovos_number_parser.numbers_sl import (extract_number_sl, nice_number_sl,
+from ovos_number_parser.numbers_sl import (extract_number_sl, is_ordinal_sl,
+                                           nice_number_sl,
                                            pronounce_number_sl)
 
 
@@ -59,6 +60,71 @@ class TestSlovenianPronounceLegacy(unittest.TestCase):
         for n in (1234567, 2000001, 100100100):
             spoken = pronounce_number_sl(n)
             self.assertEqual(extract_number_sl(spoken), n, spoken)
+
+
+class TestSlovenianCompoundOrdinals(unittest.TestCase):
+    """Ordinals above one hundred join the hundred to the remainder.
+
+    The cardinal masculine allomorphs "dva"/"trije" that the number "two"
+    and "three" take inside a hundreds group ("sto dve", "sto trije") must
+    not leak into the ordinal, which stays "stodrugi"/"stotretji".
+    """
+
+    def test_hundred_ordinals(self):
+        cases = [(101, "stoprvi"), (102, "stodrugi"), (103, "stotretji"),
+                 (111, "stoenajsti"), (121, "stoenaindvajseti"),
+                 (150, "stopetdeseti"), (203, "dvestotretji"),
+                 (303, "tristotretji"),
+                 (999, "devetstodevetindevetdeseti")]
+        for n, expected in cases:
+            self.assertEqual(pronounce_number_sl(n, ordinals=True),
+                             expected, n)
+
+    def test_hundred_ordinals_have_no_cardinal_suffix(self):
+        # regression: 103rd was "stotretjije", 203rd "dvestotretjije"
+        for n in (103, 203, 303, 403, 503):
+            self.assertNotIn("je", pronounce_number_sl(n, ordinals=True)[-2:])
+
+    def test_is_ordinal_recognises_compounds(self):
+        self.assertEqual(is_ordinal_sl("stoprvi"), 101)
+        self.assertEqual(is_ordinal_sl("stotretji"), 103)
+        self.assertEqual(is_ordinal_sl("dvestopetdeseti"), 250)
+        self.assertFalse(is_ordinal_sl("stotretjije"))
+        self.assertFalse(is_ordinal_sl("mačka"))
+
+    def test_ordinal_round_trip(self):
+        for n in list(range(1, 1000)) + [1000, 1000000]:
+            spoken = pronounce_number_sl(n, ordinals=True)
+            self.assertEqual(is_ordinal_sl(spoken), n, f"{n} -> {spoken!r}")
+
+    def test_extract_compound_ordinal_in_sentence(self):
+        self.assertEqual(
+            extract_number_sl("stoprvi poskus", ordinals=True), 101)
+        self.assertEqual(
+            extract_number_sl("stopetdeseti dan", ordinals=True), 150)
+
+
+class TestSlovenianAdversarial(unittest.TestCase):
+    def test_empty_and_junk(self):
+        self.assertFalse(extract_number_sl(""))
+        self.assertFalse(extract_number_sl("   "))
+        self.assertFalse(extract_number_sl("brez številk tukaj"))
+
+    def test_mixed_case(self):
+        self.assertEqual(extract_number_sl("PetInDvajset"), 25)
+        self.assertEqual(extract_number_sl("STO"), 100)
+
+    def test_punctuation_affixes(self):
+        self.assertEqual(extract_number_sl("imam petindvajset!"), 25)
+        self.assertEqual(extract_number_sl("dvesto..."), 200)
+        self.assertEqual(extract_number_sl("koliko? sto"), 100)
+
+    def test_dual_forms_in_context(self):
+        # the dual: two takes "dva"/"dve" and dual noun agreement
+        self.assertEqual(extract_number_sl("dve uri"), 2)
+        self.assertEqual(extract_number_sl("dva dni"), 2)
+        self.assertEqual(extract_number_sl("dve minuti"), 2)
+        self.assertEqual(extract_number_sl("dva milijona"), 2000000)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The Slovene number module composed ordinals above one hundred by reusing the masculine cardinal allomorphs that `dva` and `trije` take inside a hundreds group. As a result the 103rd rendered as `stotretjije` (a doubled cardinal ending) instead of `stotretji`, and `is_ordinal_sl` only recognised ordinals up to one hundred.

## Changes
- Restrict the `dva`/`trije` allomorph branches in `pronounce_number_sl` to the cardinal path, so ordinals keep their plain form.
- Widen `is_ordinal_sl` to recognise the full range of compound ordinals.

## Verification
- Every ordinal 1..999 (plus 1000, 1000000) round-trips `pronounce_number_sl(n, ordinals=True)` -> `is_ordinal_sl` back to `n`.
- Full suite green (pre-existing unrelated `test_packaging` metadata failure aside).

🤖 Generated with [Claude Code](https://claude.com/claude-code)