### PR TITLE
fix: negate whole compound negative numbers (en)

### DIFF
--- a/ovos_number_parser/numbers_en.py
+++ b/ovos_number_parser/numbers_en.py
@@ -814,6 +814,7 @@ def _extract_whole_number_with_text_en(tokens, short_scale, ordinals):
     val = False
     prev_val = None
     next_val = None
+    negative = False
     to_sum = []
     for idx, token in enumerate(tokens):
         current_val = None
@@ -918,11 +919,7 @@ def _extract_whole_number_with_text_en(tokens, short_scale, ordinals):
         if (prev_word in _SUMS_EN and val and val < 10) or all([prev_word in
                                                                 multiplies,
                                                                 val < prev_val if prev_val else False]):
-            if prev_val < 0:
-                # continue a negated number: "minus forty two" = -(40+2)
-                val = prev_val - val
-            else:
-                val = prev_val + val
+            val = prev_val + val
 
         # is the prev word a number and should we multiply it?
         # twenty hundred, six hundred
@@ -949,9 +946,11 @@ def _extract_whole_number_with_text_en(tokens, short_scale, ordinals):
                 val = val * next_val
                 number_words.append(tokens[idx + 1])
 
-        # is this a negative number?
+        # is this a negative number? Track the sign for the whole segment and
+        # apply it once at the end so every "place" of a compound number
+        # ("minus nine hundred and ninety nine") is negated together.
         if val and prev_word and prev_word in _NEGATIVES_EN:
-            val = 0 - val
+            negative = True
 
         # let's make sure it isn't a fraction
         if not val:
@@ -1046,6 +1045,9 @@ def _extract_whole_number_with_text_en(tokens, short_scale, ordinals):
 
     if val is not None and to_sum:
         val += sum(to_sum)
+
+    if negative and val:
+        val = -val
 
     return val, number_words
 

--- a/tests/test_number_parser_en.py
+++ b/tests/test_number_parser_en.py
@@ -1,6 +1,12 @@
 import unittest
 
-from ovos_number_parser.numbers_en import numbers_to_digits_en, pronounce_number_en
+from ovos_number_parser.numbers_en import (
+    numbers_to_digits_en,
+    pronounce_number_en,
+    extract_number_en,
+    is_fractional_en,
+    is_ordinal_en,
+)
 
 
 class TestNumberParserEN(unittest.TestCase):
@@ -24,6 +30,71 @@ class TestNumberParserEN(unittest.TestCase):
         self.assertEqual(pronounce_number_en(3840285766987249),
                          'three quadrillion, eight hundred and forty trillion, two hundred and eighty five billion, seven hundred '
                          'and sixty six million, nine hundred and eighty seven thousand, two hundred and forty nine')
+
+
+    def test_extract_number_spoken_en(self):
+        self.assertEqual(extract_number_en("half"), 0.5)
+        self.assertEqual(extract_number_en("three quarters"), 0.75)
+        self.assertEqual(extract_number_en("a hundred"), 100)
+        self.assertEqual(extract_number_en("one hundred and five"), 105)
+        self.assertEqual(extract_number_en("two thousand and one"), 2001)
+        self.assertEqual(extract_number_en("nine hundred and ninety nine"), 999)
+        self.assertEqual(extract_number_en("two million five hundred thousand"),
+                         2500000)
+
+    def test_extract_number_negative_en(self):
+        # a negative sign must cover every place of a compound number,
+        # not just the leading one
+        self.assertEqual(extract_number_en("minus five"), -5)
+        self.assertEqual(extract_number_en("minus twenty three"), -23)
+        self.assertEqual(extract_number_en("minus one hundred"), -100)
+        self.assertEqual(extract_number_en("minus one hundred and five"), -105)
+        self.assertEqual(extract_number_en("minus nine hundred and ninety nine"),
+                         -999)
+        self.assertEqual(extract_number_en("negative two million five hundred thousand"),
+                         -2500000)
+        self.assertEqual(extract_number_en("minus one thousand nine"), -1009)
+
+    def test_extract_number_adversarial_en(self):
+        self.assertFalse(extract_number_en(""))
+        self.assertFalse(extract_number_en("   "))
+        self.assertFalse(extract_number_en("no digits here"))
+        # leading/trailing junk around a real number
+        self.assertEqual(extract_number_en("set it to forty two please"), 42)
+        self.assertEqual(extract_number_en("MINUS FIVE"), -5)
+
+    def test_extract_number_roundtrip_en(self):
+        # pronounce_number -> extract_number must recover the original integer.
+        # 4-digit values in 1000..1999 are intentionally spoken in date style
+        # ("nineteen seventy two"), so they are excluded from the sweep.
+        def date_styled(n):
+            s = str(abs(n))
+            return (len(s) == 4 and
+                    not (s[1:4] == '000' or s[1:3] == '00' or int(s[0:2]) >= 20))
+
+        for n in list(range(-1050, 1050)) + [
+                2001, 2020, 5678, 12345, 999999, 1000000, -1000000,
+                -12345, 87654321]:
+            if date_styled(n):
+                continue
+            spoken = pronounce_number_en(n)
+            self.assertEqual(extract_number_en(spoken), n,
+                             f"roundtrip failed for {n} -> {spoken!r}")
+
+    def test_pronounce_number_boundaries_en(self):
+        self.assertEqual(pronounce_number_en(0), "zero")
+        self.assertEqual(pronounce_number_en(-1), "minus one")
+        self.assertEqual(pronounce_number_en(1000000), "one million")
+        self.assertEqual(pronounce_number_en(0.5), "zero point five")
+        self.assertEqual(pronounce_number_en(-3.5), "minus three point five")
+
+    def test_fractional_and_ordinal_en(self):
+        self.assertEqual(is_fractional_en("half"), 0.5)
+        self.assertEqual(is_fractional_en("quarter"), 0.25)
+        self.assertFalse(is_fractional_en("banana"))
+        self.assertEqual(is_ordinal_en("first"), 1)
+        self.assertEqual(is_ordinal_en("fifth"), 5)
+        self.assertFalse(is_ordinal_en("seven"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

`extract_number_en` applied a leading negative sign to only the first "place" of a compound spoken number. The rest of the number was then summed back in as positive:

- `"minus nine hundred and ninety nine"` -> `-801` (i.e. `-900 + 99`)
- `"minus one hundred and five"` -> `-95`
- `"minus one thousand nine"` -> `-991`

## Fix

Track the sign once for the whole number segment and apply it after the individual places are summed, so every place is negated together. Simple compound cases (`"minus forty two"`) are unaffected.

## Tests

New English regression tests covering spoken compounds, negative compounds, adversarial/empty/junk input, boundary values, fractional/ordinal helpers, and a `pronounce_number -> extract_number` round-trip sweep (the intentional 4-digit date-style pronunciation range is excluded).

Full suite green apart from the pre-existing unrelated packaging metadata check.