### PR TITLE
fix: Czech number scale words, minus, and year pronunciation

### DIFF
--- a/ovos_number_parser/numbers_cs.py
+++ b/ovos_number_parser/numbers_cs.py
@@ -262,7 +262,7 @@ def generate_plurals_cs(originals):
 
 
 # negate next number (-2 = 0 - 2)
-_NEGATIVES = {"záporné", "mínus"}
+_NEGATIVES = {"záporné", "mínus", "minus"}
 
 # sum the next number (twenty two = 20 + 2)
 _SUMS = {'dvacet', '20', 'třicet', '30', 'čtyřicet', '40', 'padesát', '50',
@@ -689,7 +689,12 @@ def _extract_whole_number_with_text_cs(tokens, short_scale, ordinals):
         if word in multiplies:
             if not prev_val:
                 prev_val = 1
-            val = prev_val * val
+                val = prev_val * val
+            elif current_val is not None and current_val > prev_val:
+                # ascending scale word multiplies ("dvě stě" = 2 * 100)
+                val = prev_val * val
+            # a descending scale word ("tisíc sto" = 1000 + 100) has already
+            # been summed above; multiplying here would corrupt the value
 
         # is this a spoken fraction?
         # half cup
@@ -1109,40 +1114,9 @@ def pronounce_number_cs(number, places=2, short_scale=True, scientific=False,
         result = "záporné " if scientific else "mínus "
     num = abs(num)
 
-    if not ordinals:
-        try:
-            # deal with 4 digits
-            # usually if it's a 4 digit num it should be said like a date
-            # i.e. 1972 => nineteen seventy two
-            if len(str(num)) == 4 and isinstance(num, int):
-                _num = str(num)
-                # deal with 1000, 2000, 2001, 2100, 3123, etc
-                # is skipped as the rest of the
-                # functin deals with this already
-                if _num[1:4] == '000' or _num[1:3] == '00' or int(_num[0:2]) >= 20:
-                    pass
-                # deal with 1900, 1300, etc
-                # i.e. 1900 => nineteen hundred
-                elif _num[2:4] == '00':
-                    first = number_names[int(_num[0:2])]
-                    last = number_names[100]
-                    return first + " " + last
-                # deal with 1960, 1961, etc
-                # i.e. 1960 => nineteen sixty
-                #      1961 => nineteen sixty one
-                else:
-                    first = number_names[int(_num[0:2])]
-                    if _num[3:4] == '0':
-                        last = number_names[int(_num[2:4])]
-                    else:
-                        second = number_names[int(_num[2:3]) * 10]
-                        last = second + " " + number_names[int(_num[3:4])]
-                    return first + " " + last
-        # exception used to catch any unforseen edge cases
-        # will default back to normal subroutine
-        except Exception as e:
-            # TODO this probably shouldn't go to stdout
-            print('ERROR: Exception in pronounce_number_cs: {}' + repr(e))
+    # Czech does not group years into digit pairs the way English does
+    # ("nineteen seventy two"); numbers are spoken with full scale words
+    # ("tisíc devět set sedmdesát dva"), handled by the routine below.
 
     # check for a direct match
     if num in number_names and not ordinals:

--- a/tests/test_number_parser_cs.py
+++ b/tests/test_number_parser_cs.py
@@ -58,5 +58,86 @@ class TestCzechRoundTrip(unittest.TestCase):
                 self.assertEqual(extract_number(spoken, lang="cs"), number)
 
 
+class TestCzechScaleWords(unittest.TestCase):
+    """Descending scale words must add, not multiply."""
+
+    def test_thousand_then_hundred(self):
+        # "tisíc sto" = 1000 + 100, not 1000 * 100
+        self.assertEqual(extract_number("tisíc sto", lang="cs"), 1100)
+        self.assertEqual(extract_number("dva tisíce sto", lang="cs"), 2100)
+        self.assertEqual(extract_number("dva tisíce sto dvacet tři", lang="cs"),
+                         2123)
+        self.assertEqual(extract_number("pět tisíc dvě stě", lang="cs"), 5200)
+
+    def test_ascending_scale_still_multiplies(self):
+        # "dvě stě" = 2 * 100, "sto tisíc" = 100 * 1000
+        self.assertEqual(extract_number("dvě stě", lang="cs"), 200)
+        self.assertEqual(extract_number("tři sta", lang="cs"), 300)
+        self.assertEqual(extract_number("pět set", lang="cs"), 500)
+        self.assertEqual(extract_number("sto tisíc", lang="cs"), 100000)
+        self.assertEqual(extract_number("dva tisíce", lang="cs"), 2000)
+
+    def test_declined_units_in_context(self):
+        self.assertEqual(extract_number("mám dvě kočky", lang="cs"), 2)
+        self.assertEqual(extract_number("nastav budík na pět hodin",
+                                        lang="cs"), 5)
+        self.assertEqual(extract_number("za deset minut", lang="cs"), 10)
+        self.assertEqual(extract_number("jeden den", lang="cs"), 1)
+
+
+class TestCzechNegatives(unittest.TestCase):
+    """Both the diacritic and ASCII spellings of minus negate."""
+
+    def test_minus_variants(self):
+        self.assertEqual(extract_number("mínus pět", lang="cs"), -5)
+        self.assertEqual(extract_number("minus pět", lang="cs"), -5)
+        self.assertEqual(extract_number("záporné tři", lang="cs"), -3)
+        self.assertEqual(extract_number("minus čtyřicet dva", lang="cs"), -42)
+
+
+class TestCzechYearPronunciation(unittest.TestCase):
+    """Czech speaks four-digit numbers with scale words, never digit pairs."""
+
+    def test_no_digit_pair_years(self):
+        # English "nineteen seventy two" style must not leak into Czech
+        for number in (1010, 1100, 1234, 1972, 1999):
+            with self.subTest(number=number):
+                spoken = pronounce_number(number, lang="cs")
+                self.assertIn("tisíc", spoken)
+                self.assertEqual(extract_number(spoken, lang="cs"), number)
+
+
+class TestCzechRoundTripSweep(unittest.TestCase):
+    """A dense sweep guards the pronounce/extract contract."""
+
+    def test_dense_sweep(self):
+        for number in range(0, 3000):
+            with self.subTest(number=number):
+                spoken = pronounce_number(number, lang="cs")
+                self.assertEqual(extract_number(spoken, lang="cs"), number)
+
+    def test_sparse_large_sweep(self):
+        for number in range(3000, 200001, 137):
+            with self.subTest(number=number):
+                spoken = pronounce_number(number, lang="cs")
+                self.assertEqual(extract_number(spoken, lang="cs"), number)
+
+
+class TestCzechAdversarial(unittest.TestCase):
+    """Malformed and boundary inputs must not crash."""
+
+    def test_empty_and_junk(self):
+        for text in ("", "   ", "?!.", "žžž qwerty"):
+            with self.subTest(text=text):
+                self.assertIn(extract_number(text, lang="cs"), (False, None))
+
+    def test_lang_code_variants(self):
+        self.assertEqual(extract_number("dvacet jedna", lang="cs-cz"), 21)
+        self.assertEqual(extract_number("dvacet jedna", lang="cs-CZ"), 21)
+
+    def test_mixed_case(self):
+        self.assertEqual(extract_number("Dvacet Jedna", lang="cs"), 21)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Bug fixes to the existing Czech number module, each covered by new tests.

## Descending scale words summed instead of multiplied
`extract_number` multiplied any scale word by the running value, so a smaller trailing scale word corrupted the result:

- `tisíc sto` (1100) → 1100000
- `dva tisíce sto` (2100) → 4200000
- `dva tisíce sto dvacet tři` (2123) → 4200023

A scale word now multiplies only when it ascends the running value (`dvě stě` = 2 × 100); a smaller trailing scale word has already been summed. Ascending cases (`dvě stě`, `sto tisíc`) are unaffected.

## `minus` did not negate
Only the diacritic spelling `mínus` negated. `minus pět` returned 5 instead of -5. The ASCII spelling now negates too.

## Four-digit numbers spoken as English digit pairs
`pronounce_number(1010)` returned `deset deset` and `pronounce_number(1234)` returned `dvanáct třicet čtyři` — the English "nineteen seventy two" pattern, which Czech never uses. The pairing block is removed; four-digit numbers now pronounce with scale words and round-trip.

## Tests
Added scale-word, negative, year-pronunciation, adversarial, and a dense pronounce/extract round-trip sweep (0–3000 exhaustive, plus a sparse sweep to 200000, all passing). Full suite green (pre-existing unrelated packaging metadata test excluded).