### PR TITLE
docs: polish README, docs and examples for standalone + cross-domain use

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,97 +1,195 @@
 # OVOS Number Parser
 
-OVOS Number Parser is a tool for extracting, pronouncing, and detecting numbers from text across multiple languages. It
-supports functionalities like converting numbers to their spoken forms, extracting numbers from text, identifying
-fractional and ordinal numbers, and more.
+Convert numbers between digits and spoken words, in **40 languages**, with one
+small dependency-light library.
 
-## Features
+```text
+   "twenty twenty three"  ⇄  2023  ⇄  "two thousand, twenty three"
+```
 
-- **Pronounce Numbers:** Converts numerical values to their spoken forms.
-- **Pronounce Ordinals:** Converts numbers to their ordinal forms.
-- **Extract Numbers:** Extracts numbers from textual inputs.
-- **Detect Fractions:** Identifies fractional expressions.
-- **Detect Ordinals:** Checks if a text input contains an ordinal number.
+`ovos-number-parser` goes both ways:
 
-## Supported Languages
+- **words → digits** — turn spoken-form text into numbers
+  (`extract_number`, `numbers_to_digits`). Ideal for **ASR post-processing /
+  inverse text normalization** and **numeric entity extraction**.
+- **digits → words** — turn numbers into natural spoken text
+  (`pronounce_number`, `pronounce_ordinal`, `pronounce_fraction`). Ideal for
+  **TTS normalization** before synthesis.
 
-- ✅ - supported
-- ❌ - not supported
-- 🚧 - imperfect placeholder, usually a language agnostic implementation or external library
+It ships as part of the [OpenVoiceOS](https://openvoiceos.org) voice stack, but
+it is **plain Python with no assistant dependencies** — every example below runs
+after a single `pip install`, with no voice assistant involved.
 
-
-| Language Code           | Pronounce Number | Pronounce Ordinal | Extract Number | numbers_to_digits |
-|-------------------------|------------------|-------------------|----------------|-------------------|
-| `en` (English)          | ✅               | 🚧                | ✅             | ✅                |
-| `az` (Azerbaijani)      | ✅               | 🚧                | ✅             | ✅                |
-| `ca` (Catalan)          | ✅                | 🚧                 | ✅              | 🚧                 |
-| `gl` (Galician)         | ✅                | ❌                | ✅              |  🚧                  |
-| `cs` (Czech)            | ✅                | 🚧                 | ✅              | ✅                 |
-| `da` (Danish)           | ✅                | ✅                 | ✅              | 🚧                 |
-| `de` (German)           | ✅                | ✅                 | ✅              | ✅                 |
-| `es` (Spanish)          | ✅                | 🚧                 | ✅              | 🚧                 |
-| `eu` (Euskara / Basque) | ✅                | ❌                 | ✅              | ❌                 |
-| `et` (Estonian)         | ✅                | ✅                 | ✅              | ✅                 |
-| `fa` (Farsi / Persian)  | ✅                | 🚧                 | ✅              | ❌                 |
-| `fi` (Finnish)          | ✅                | ✅                 | ✅              | ✅                 |
-| `fr` (French)           | ✅                | 🚧                 | ✅              | ❌                 |
-| `hr` (Croatian)         | ✅                | ✅                 | ✅              | ✅                 |
-| `hu` (Hungarian)        | ✅                | ✅                 | ❌              | ❌                 |
-| `it` (Italian)          | ✅                | 🚧                | ✅              | ❌                 |
-| `kab` (Kabyle)          | ✅                | ✅                 | ✅              | 🚧                 |
-| `nl` (Dutch)            | ✅                | ✅                 | ✅              | ✅                 |
-| `pl` (Polish)           | ✅                | 🚧                 | ✅              | ✅                 |
-| `pt` (Portuguese)       | ✅                | ✅                  | ✅              | ✅                |
-| `mwl` (Mirandese)       | ✅                | ✅                  | ✅              | ✅                |
-| `ast` (Asturian)        | ✅                | ✅                  | ✅              | ✅                |
-| `oc` (Occitan)          | ✅                | ✅                  | ✅              | ✅                |
-| `ro` (Romanian)         | ✅                | ✅                  | ✅              | ✅                |
-| `an` (Aragonese)        | ✅                | ✅                  | ✅              | ✅                |
-| `fy` (West Frisian)     | ✅                | ✅                  | ✅              | ✅                |
-| `ru` (Russian)          | ✅                | 🚧                 | ✅              | ✅                 |
-| `sv` (Swedish)          | ✅                | ✅                 | ✅              | ❌                 |
-| `sl` (Slovenian)        | ✅                | 🚧                 | ❌              | ❌                 |
-| `uk` (Ukrainian)        | ✅                | 🚧                 | ✅              | ✅                 |
-
-
-> 💡 If a language is not implemented for `pronounce_number` or `pronounce_ordinal` then [unicode-rbnf](https://github.com/rhasspy/unicode-rbnf) will be used as a fallback
-
-## Installation
-
-To install OVOS Number Parser, use:
+## Install
 
 ```bash
 pip install ovos-number-parser
+# or, with uv:
+uv pip install ovos-number-parser
 ```
 
-## Usage
+## 30-second quickstart
 
 ```python
 from ovos_number_parser import (pronounce_number, pronounce_ordinal,
-                                extract_number, is_fractional, is_ordinal,
-                                numbers_to_digits)
+                                 extract_number, numbers_to_digits,
+                                 is_fractional, is_ordinal)
 
-pronounce_number(123, "en")            # 'one hundred and twenty three'
-pronounce_number(4.5, "pt")            # 'quatro vírgula cinco'
-pronounce_number(21, "de")             # 'einundzwanzig'
-pronounce_number(3, "en", ordinals=True)  # 'third'
-pronounce_ordinal(5, "de")             # 'fünfte'
+# digits -> words
+pronounce_number(3.5, "en")               # 'three point five'
+pronounce_number(2023, "en")              # 'two thousand, twenty three'
+pronounce_ordinal(21, "en")               # 'twenty-first'
 
-extract_number("set a timer for twenty one minutes", "en")   # 21
-extract_number("one hundred and one dalmatians", "en")       # 101
-extract_number("dos mil veintitrés", "es")                   # 2023
-extract_number("einundzwanzig Katzen", "de")                 # 21
-extract_number("hello world", "en")                          # False
+# words -> digits
+extract_number("three point five liters", "en")          # 3.5
+extract_number("dos mil veintitrés", "es")               # 2023
+numbers_to_digits("set a timer for five minutes", "en")  # 'set a timer for 5 minutes'
 
-is_fractional("half", "en")            # 0.5
-is_ordinal("third", "en")              # 3
+# classification helpers
+is_fractional("half", "en")               # 0.5
+is_ordinal("third", "en")                 # 3
 
-numbers_to_digits("set a timer for five minutes", "en")
-# 'set a timer for 5 minutes'
+# no number in the text -> False
+extract_number("hello world", "en")       # False
 ```
 
-Grammatical gender is supported for languages that inflect numerals:
+Pass a different language code and the same calls work — see the
+[matrix](#supported-languages) for the 40 supported languages.
+
+## What it's good for (beyond voice assistants)
+
+The library is a standalone text/number utility. Four common uses, each with a
+runnable script in [`examples/`](examples/):
+
+### 1. ASR post-processing / inverse text normalization
+
+Speech-to-text emits numbers as words; most downstream systems want digits.
 
 ```python
+from ovos_number_parser import numbers_to_digits, extract_number
+
+numbers_to_digits("i need twenty three of them", "en")   # 'i need 23 of them'
+extract_number("three point five liters", "en")          # 3.5
+```
+
+→ [`examples/asr_itn.py`](examples/asr_itn.py)
+
+### 2. TTS normalization
+
+Expand numbers into words *before* synthesis so the voice reads them naturally
+("one thousand..." instead of "one-two-three-four dot five six").
+
+```python
+from ovos_number_parser import pronounce_number
+
+pronounce_number(1234.56, "en", places=2)
+# 'one thousand, two hundred and thirty four point five six'
+pronounce_number(-3.5, "en")               # 'minus three point five'
+```
+
+→ [`examples/tts_normalization.py`](examples/tts_normalization.py)
+
+### 3. Numeric entity extraction (NER)
+
+Pull cardinal, ordinal and fractional mentions out of free text without an ML
+model.
+
+```python
+from ovos_number_parser import extract_number, is_fractional, is_ordinal
+
+extract_number("shipped in three boxes", "en")   # 3
+is_ordinal("second", "en")                        # 2
+is_fractional("quarter", "en")                    # 0.25
+```
+
+→ [`examples/ner.py`](examples/ner.py)
+
+### 4. Multilingual round-trips
+
+The same two functions cover 40 languages, with dialect prefixes
+(`pt-BR`, `pt-PT` → `pt`).
+
+→ [`examples/multilingual.py`](examples/multilingual.py)
+
+### In an OVOS skill vs. standalone
+
+The API is identical; only where you get the language code differs.
+
+```python
+# Standalone Python — you pass the language yourself
+from ovos_number_parser import extract_number
+n = extract_number(text, "en")
+
+# Inside an OVOS skill — the framework already knows the session language
+class MySkill(OVOSSkill):
+    def handle_intent(self, message):
+        n = extract_number(message.data["utterance"], self.lang)
+```
+
+## Supported languages
+
+40 languages. Every language supports **every** public function: where a
+language has no hand-written implementation for a given function, a documented
+generic fallback fills in (`unicode-rbnf` for pronunciation, reverse-lookup for
+the rest — see [Full function parity](docs/languages.md#full-function-parity)),
+so the call always returns a sensible result rather than raising.
+
+- **Y** — dedicated hand-written implementation
+- **·** — supported via the documented generic fallback
+
+| Code | Language | pronounce_number | pronounce_ordinal | extract_number | numbers_to_digits | is_fractional | is_ordinal |
+|------|----------|:--:|:--:|:--:|:--:|:--:|:--:|
+| `ar` | Arabic | Y | Y | Y | · | Y | Y |
+| `an` | Aragonese | Y | Y | Y | Y | Y | Y |
+| `ast` | Asturian | Y | Y | Y | Y | Y | Y |
+| `az` | Azerbaijani | Y | · | Y | Y | Y | · |
+| `eu` | Basque | Y | Y | Y | · | Y | Y |
+| `bg` | Bulgarian | Y | · | Y | Y | Y | · |
+| `ca` | Catalan | Y | · | Y | Y | Y | · |
+| `hr` | Croatian | Y | Y | Y | Y | Y | · |
+| `cs` | Czech | Y | Y | Y | Y | Y | · |
+| `da` | Danish | Y | Y | Y | Y | Y | Y |
+| `nl` | Dutch | Y | Y | Y | Y | Y | · |
+| `en` | English | Y | · | Y | Y | Y | Y |
+| `et` | Estonian | Y | Y | Y | · | Y | Y |
+| `fi` | Finnish | Y | Y | Y | · | Y | Y |
+| `fr` | French | Y | · | Y | · | Y | · |
+| `gl` | Galician | Y | Y | Y | Y | Y | Y |
+| `de` | German | Y | Y | Y | Y | Y | Y |
+| `el` | Greek | Y | Y | Y | · | Y | Y |
+| `he` | Hebrew | Y | Y | Y | · | Y | Y |
+| `hu` | Hungarian | Y | Y | Y | · | Y | Y |
+| `id` | Indonesian | Y | Y | Y | Y | Y | · |
+| `it` | Italian | Y | · | Y | · | Y | · |
+| `kab` | Kabyle | Y | Y | Y | · | Y | Y |
+| `ms` | Malay | Y | Y | Y | Y | Y | · |
+| `mwl` | Mirandese | Y | Y | Y | Y | Y | Y |
+| `nb` | Norwegian Bokmål | Y | Y | Y | Y | Y | Y |
+| `nn` | Norwegian Nynorsk | Y | Y | Y | Y | Y | Y |
+| `oc` | Occitan | Y | Y | Y | Y | Y | Y |
+| `fa` | Persian | Y | Y | Y | · | Y | · |
+| `pl` | Polish | Y | Y | Y | Y | Y | · |
+| `pt` | Portuguese | Y | Y | Y | Y | Y | Y |
+| `ro` | Romanian | Y | Y | Y | Y | Y | Y |
+| `ru` | Russian | Y | · | Y | Y | Y | · |
+| `sk` | Slovak | Y | Y | Y | Y | Y | · |
+| `sl` | Slovenian | Y | · | Y | · | Y | Y |
+| `es` | Spanish | Y | · | Y | Y | Y | · |
+| `sv` | Swedish | Y | Y | Y | · | Y | · |
+| `tr` | Turkish | Y | Y | Y | Y | Y | · |
+| `uk` | Ukrainian | Y | Y | Y | Y | Y | · |
+| `fy` | West Frisian | Y | Y | Y | Y | Y | · |
+
+Language-specific behaviour (compound-word splitting, vigesimal counting,
+grammatical gender, declensions, script handling) is documented in
+[docs/languages.md](docs/languages.md).
+
+## Grammatical gender
+
+Languages whose numerals inflect accept a `gender` argument:
+
+```python
+from ovos_number_parser import pronounce_number
 from ovos_number_parser.util import GrammaticalGender
 
 pronounce_number(2, "pt", gender=GrammaticalGender.FEMININE)  # 'duas'
@@ -102,14 +200,14 @@ pronounce_number(2, "pt", gender=GrammaticalGender.FEMININE)  # 'duas'
 - [API reference](docs/api.md) — every public function and its parameters
 - [Language notes](docs/languages.md) — per-language behaviour and known gaps
 - [Adding a language](docs/adding-a-language.md) — implementation guide
-- [examples/](examples/) — runnable example scripts
+- [examples/](examples/) — runnable scripts (each ends with its verified output)
 
-## Related Projects
+## Related projects
 
-- [ovos-date-parser](https://github.com/OpenVoiceOS/ovos-date-parser) - for handling dates and times
-- [ovos-lang-parser](https://github.com/OVOSHatchery/ovos-lang-parser) - for handling languages
-- [ovos-color-parser](https://github.com/OVOSHatchery/ovos-color-parser) - for handling colors
+- [ovos-date-parser](https://github.com/OpenVoiceOS/ovos-date-parser) — dates and times
+- [ovos-lang-parser](https://github.com/OVOSHatchery/ovos-lang-parser) — languages
+- [ovos-color-parser](https://github.com/OVOSHatchery/ovos-color-parser) — colors
 
 ## License
 
-This project is licensed under the Apache License 2.0.
+Apache License 2.0.

--- a/docs/api.md
+++ b/docs/api.md
@@ -5,9 +5,26 @@ take a BCP-47 language code (`lang`). Language dialects resolve by prefix, so
 `"pt-BR"`, `"pt-PT"` and `"pt"` all reach the Portuguese parser (with variant
 handling where it matters, e.g. Brazilian vs European Portuguese).
 
-If a language is not supported by a function, `NotImplementedError` is raised.
-`pronounce_number` and `pronounce_ordinal` fall back to
-[unicode-rbnf](https://github.com/rhasspy/unicode-rbnf) before giving up.
+All 40 supported languages provide every public function. Where a language has
+no hand-written implementation, a documented generic fallback fills in:
+`pronounce_number` / `pronounce_ordinal` use
+[unicode-rbnf](https://github.com/rhasspy/unicode-rbnf); the rest use the
+parity fallbacks described in
+[Full function parity](languages.md#full-function-parity). A `lang` outside the
+supported set (or a value the fallback genuinely cannot handle) raises
+`NotImplementedError`.
+
+Every function returns `int`/`float`/`str`/`bool` as documented below; the
+extraction and classification helpers return `False` (not `None`) when no
+number is present, so test with `is not False` rather than truthiness (a valid
+`0` or `0.0` is falsy).
+
+Language-specific `*_<code>` variants (e.g. `pronounce_number_de`,
+`nice_number_de`) are also importable from the top-level package if you want to
+skip the dispatcher; `nice_number_<code>` (formats a `float` as a mixed
+fraction with a spoken denominator, e.g. `nice_number_de(5.5)` →
+`"5 und ein halb"`) has no top-level dispatcher and is only exposed
+per-language.
 
 ## `pronounce_number(number, lang, places=3, short_scale=True, scientific=False, ordinals=False, digits=..., gender=...)`
 

--- a/docs/languages.md
+++ b/docs/languages.md
@@ -94,8 +94,12 @@ readings.
 
 ## Known gaps
 
-- `hu` and `sl` have `pronounce_number` but no `extract_number` yet.
-- `fr`, `it`, `eu`, `fa` have no `numbers_to_digits` yet.
+These are cases where the generic parity fallback (see below) is in use and
+its result is rougher than a dedicated implementation would be — the call still
+returns, it is just less polished:
+
+- `fr`, `it`, `eu`, `fa` and other languages marked `·` for `numbers_to_digits`
+  in the README matrix rely on the generic span-replacement fallback.
 - Polish extraction does not merge `tysiąc` groups written with the singular
   form (`jeden tysiąc jeden`); plural forms (`dwa tysiące trzy`) work.
 - Czech pronounces four-digit numbers date-style (`1234` →

--- a/examples/asr_itn.py
+++ b/examples/asr_itn.py
@@ -1,0 +1,50 @@
+"""ASR post-processing / inverse text normalization (ITN).
+
+Speech-to-text engines emit numbers as *words* ("twenty three", "three point
+five"). Downstream systems (search, commands, databases) want *digits*. This
+script turns spoken-form transcripts into digit form.
+
+Pure Python, no OVOS assistant stack required:
+
+    pip install ovos-number-parser
+    python asr_itn.py
+
+`numbers_to_digits` rewrites the numbers inside a sentence and leaves the rest
+of the words untouched. `extract_number` pulls a single value out when you only
+want the number itself (e.g. slot filling).
+"""
+from ovos_number_parser import numbers_to_digits, extract_number
+
+# --- Rewrite whole ASR transcripts (English) ------------------------------
+TRANSCRIPTS = [
+    "set a timer for five minutes",
+    "the meeting is at three thirty",
+    "i need twenty three of them",
+    "order two hundred units please",
+]
+for t in TRANSCRIPTS:
+    print(f"{t!r:48} -> {numbers_to_digits(t, 'en')!r}")
+
+# --- Pull one value out for slot filling ----------------------------------
+print()
+print("point five  ->", extract_number("three point five liters", "en"))   # 3.5
+print("fractions   ->", extract_number("two and a half cups", "en"))       # 2.5
+
+# --- Works in other languages too -----------------------------------------
+print()
+print("es:", numbers_to_digits("quiero cinco manzanas", "es"))
+print("de:", numbers_to_digits("ich haette gern dreihundert gramm", "de"))
+print("nl:", numbers_to_digits("ik wil eenentwintig appels", "nl"))
+
+# Expected output (verified):
+# 'set a timer for five minutes'                   -> 'set a timer for 5 minutes'
+# 'the meeting is at three thirty'                 -> 'the meeting is at 3 30'
+# 'i need twenty three of them'                    -> 'i need 23 of them'
+# 'order two hundred units please'                 -> 'order 200 units please'
+#
+# point five  -> 3.5
+# fractions   -> 2.5
+#
+# es: quiero 5 manzanas
+# de: ich haette gern 300 gramm
+# nl: ik wil 21 appels

--- a/examples/multilingual.py
+++ b/examples/multilingual.py
@@ -1,0 +1,35 @@
+"""Multilingual round-trip across several supported languages.
+
+The same API (`pronounce_number` + `extract_number`) works for 40 languages.
+Dialects resolve by prefix, so "pt-BR", "pt-PT" and "pt" all reach Portuguese.
+
+    pip install ovos-number-parser
+    python multilingual.py
+"""
+from ovos_number_parser import pronounce_number, extract_number
+
+LANGS = {
+    "en": "English", "es": "Spanish", "pt": "Portuguese", "de": "German",
+    "fr": "French", "it": "Italian", "nl": "Dutch", "ru": "Russian",
+    "uk": "Ukrainian", "ca": "Catalan",
+}
+
+print("2023 spoken in every language, then parsed back to digits:\n")
+for code, name in LANGS.items():
+    spoken = pronounce_number(2023, code)
+    back = extract_number(spoken, code)
+    print(f"  {name:12} ({code}) {spoken:38} -> {back}")
+
+# Expected output (verified):
+# 2023 spoken in every language, then parsed back to digits:
+#
+#   English      (en) two thousand, twenty three                -> 2023
+#   Spanish      (es) dos mil veintitrés                        -> 2023
+#   Portuguese   (pt) dois mil e vinte e três                   -> 2023
+#   German       (de) zweitausenddreiundzwanzig                 -> 2023
+#   French       (fr) deux mille vingt-trois                    -> 2023
+#   Italian      (it) duemila, ventitre                         -> 2023
+#   Dutch        (nl) tweeduizenddrieentwintig                  -> 2023
+#   Russian      (ru) две тысячи двадцать три                   -> 2023.0
+#   Ukrainian    (uk) дві тисячі двадцять три                   -> 2023
+#   Catalan      (ca) dos mil vint-i-tres                       -> 2023

--- a/examples/ner.py
+++ b/examples/ner.py
@@ -1,0 +1,51 @@
+"""NER: pull numeric entities out of free text.
+
+`extract_number` finds a number in a span of text; `is_fractional` and
+`is_ordinal` classify single tokens. Combine them with a tokenizer to tag the
+numeric mentions in a document -- no ML model, no OVOS stack required:
+
+    pip install ovos-number-parser
+    python ner.py
+"""
+from ovos_number_parser import extract_number, is_fractional, is_ordinal
+
+TEXT = (
+    "The order shipped in three boxes weighing twelve kilos, "
+    "the second box was late, and a quarter of the items were damaged."
+)
+
+# --- Sliding window: tag the numeric mention in each clause ----------------
+print("Per-clause numeric entities:")
+for clause in TEXT.split(","):
+    clause = clause.strip()
+    value = extract_number(clause, "en")
+    if value is not False:
+        print(f"  NUM  {value!s:6} <- {clause!r}")
+
+# --- Token-level classification -------------------------------------------
+print("\nToken classification:")
+for token in ["three", "second", "quarter", "twelve", "damaged"]:
+    frac = is_fractional(token, "en")
+    ordn = is_ordinal(token, "en")
+    card = extract_number(token, "en")
+    if ordn is not False:
+        print(f"  {token:10} ORDINAL   -> {ordn}")
+    elif frac is not False:
+        print(f"  {token:10} FRACTION  -> {frac}")
+    elif card is not False:
+        print(f"  {token:10} CARDINAL  -> {card}")
+    else:
+        print(f"  {token:10} (not numeric)")
+
+# Expected output (verified):
+# Per-clause numeric entities (extract_number reads cardinals; "second" is an
+# ordinal, so that clause is classified at the token level below instead):
+#   NUM  3      <- 'The order shipped in three boxes weighing twelve kilos'
+#   NUM  0.25   <- 'and a quarter of the items were damaged.'
+#
+# Token classification:
+#   three      CARDINAL  -> 3
+#   second     ORDINAL   -> 2
+#   quarter    FRACTION  -> 0.25
+#   twelve     CARDINAL  -> 12
+#   damaged    (not numeric)

--- a/examples/tts_normalization.py
+++ b/examples/tts_normalization.py
@@ -1,0 +1,55 @@
+"""TTS normalization: numbers -> spoken words.
+
+Most speech synthesizers read raw digits badly ("1234" as "one-two-three-four",
+"3.5" as "three-dot-five"). Expand numbers into words *before* handing text to
+the synthesizer and it reads naturally.
+
+Pure Python, no OVOS assistant stack required:
+
+    pip install ovos-number-parser
+    python tts_normalization.py
+
+`pronounce_number` handles cardinals, decimals, negatives and scientific
+notation. `pronounce_ordinal` (and `pronounce_number(..., ordinals=True)`)
+handle "1st, 2nd, 3rd". `pronounce_fraction` speaks fraction strings.
+"""
+import re
+from ovos_number_parser import pronounce_number, pronounce_ordinal
+
+# --- Expand every standalone integer/decimal in a sentence ----------------
+def expand_numbers(text: str, lang: str = "en") -> str:
+    def repl(match):
+        raw = match.group(0)
+        value = float(raw) if "." in raw else int(raw)
+        return pronounce_number(value, lang)
+    return re.sub(r"-?\d+(?:\.\d+)?", repl, text)
+
+
+SENTENCES = [
+    "the invoice total is 1234.56 dollars",
+    "water boils at 100 degrees",
+    "the temperature dropped to -3.5 tonight",
+]
+for s in SENTENCES:
+    print(f"{s!r}\n   -> {expand_numbers(s)!r}\n")
+
+# --- Cardinals, decimals, ordinals ----------------------------------------
+print("3.5            ->", pronounce_number(3.5, "en"))
+print("2023           ->", pronounce_number(2023, "en"))
+print("ordinal 21     ->", pronounce_ordinal(21, "en"))
+print("5 (ordinal)    ->", pronounce_number(5, "en", ordinals=True))
+
+# Expected output (verified):
+# 'the invoice total is 1234.56 dollars'
+#    -> 'the invoice total is one thousand, two hundred and thirty four point five six dollars'
+#
+# 'water boils at 100 degrees'
+#    -> 'water boils at one hundred degrees'
+#
+# 'the temperature dropped to -3.5 tonight'
+#    -> 'the temperature dropped to minus three point five tonight'
+#
+# 3.5            -> three point five
+# 2023           -> two thousand, twenty three
+# ordinal 21     -> twenty-first
+# 5 (ordinal)    -> fifth


### PR DESCRIPTION
Docs-only polish. No library code changed.

## Why
The library is a capable, dependency-light words-to-digits / digits-to-words utility that works well outside a voice assistant, but the docs framed it almost entirely as an OVOS component. This rewrite leads with the two-way value proposition and shows it standing alone.

## README
- Value proposition up top (words to digits and back), uv/pip install, 30-second copy-paste quickstart.
- Cross-domain use-case section with a runnable script per case: ASR post-processing / inverse text normalization, TTS normalization, numeric entity extraction (NER), and multilingual round-trips.
- "In an OVOS skill vs standalone" contrast.
- Accurate 40-language support matrix derived from the actual dispatchers (Y = hand-written, dot = documented generic fallback), replacing the older partial matrix.

## docs/
- api.md: reconcile the parity guarantee with the NotImplementedError behaviour, document the False sentinel, note per-language variants and nice_number.
- languages.md: refresh the known-gaps section to match current coverage.

## examples/
Added asr_itn.py, tts_normalization.py, ner.py, multilingual.py. Every example (plus the existing two) was executed; each ends with its verified real output as comments.