### PR TITLE
fix: correct Basque multi-scale cardinal extraction

### DIFF
--- a/ovos_number_parser/numbers_eu.py
+++ b/ovos_number_parser/numbers_eu.py
@@ -453,8 +453,29 @@ def extract_number_eu(text, short_scale=True, ordinals=False):
             # handle fractions
             if next_word == "en" or next_word == "ren":
                 result = float(result) / float(val)
-            elif val in (100, 1000, 1000000, 1000000000) and result:
-                # scale word multiplies what came before ("bi mila")
+            elif next_word in _NUM_STRING_EU \
+                    and _NUM_STRING_EU[next_word] in (1000, 1000000,
+                                                      1000000000) \
+                    and val < _NUM_STRING_EU[next_word]:
+                # small multiplier of the scale word that follows it, added to
+                # whatever larger total precedes ("milioi bat bi mila ..." ->
+                # 1000000 + 2 * 1000). Consume the scale word here so it is not
+                # re-processed against the (now larger) running total.
+                result += val * _NUM_STRING_EU[next_word]
+                # blank the scale word so it is not re-processed; it is the
+                # next non-empty token (count+1 normally, but a vigesimal
+                # remainder may already have blanked count+1)
+                for j in range(count + 1, len(aWords)):
+                    if aWords[j]:
+                        aWords[j] = ""
+                        break
+            elif val in (100, 1000, 1000000, 1000000000) and result \
+                    and result < val:
+                # scale word multiplies a smaller multiplier before it
+                # ("bi mila" = 2 * 1000). When the running total is already
+                # larger than the scale ("mila ehun" = 1000 + 100) the scale
+                # is a lower-magnitude continuation and must be added, handled
+                # by the power loop below.
                 result = result * val
             elif val == 1 and result in (1000000, 1000000000):
                 # head-final idiom "milioi bat"/"bilioi bat" = the scale itself
@@ -487,6 +508,29 @@ def extract_number_eu(text, short_scale=True, ordinals=False):
             newText = ""
             for word in newWords:
                 newText += word + " "
+
+            # "ehun eta bat mila ..." joins the hundreds with the small
+            # remainder that *precedes* the scale word (101), which the scale
+            # then multiplies -- not the whole tail. Add the pre-scale chunk
+            # and hand the scale word back to the main loop.
+            scale_words = ("mila", "milioi", "bilioi")
+            scale_idx = next((i for i, w in enumerate(newWords)
+                              if i > 0 and w in scale_words), None)
+            if scale_idx is not None:
+                scale_val = _NUM_STRING_EU[newWords[scale_idx]]
+                pre = extract_number_eu(" ".join(newWords[:scale_idx]))
+                rest = extract_number_eu(" ".join(newWords[scale_idx + 1:]))
+                rest = rest if rest else 0
+                if pre:
+                    if result < scale_val:
+                        # the running total is the head of the multiplier group
+                        # ("ehun eta bat mila" = (100 + 1) * 1000)
+                        result = (result + pre) * scale_val + rest
+                    else:
+                        # the running total is a higher scale already; the tail
+                        # is an independent summand ("milioi bat eta bi mila")
+                        result += pre * scale_val + rest
+                    break
 
             afterAndVal = extract_number_eu(newText[:-1])
             if afterAndVal:

--- a/tests/test_number_parser_eu.py
+++ b/tests/test_number_parser_eu.py
@@ -2,6 +2,10 @@ import unittest
 
 from ovos_number_parser import (extract_number, pronounce_number,
                                  pronounce_ordinal, is_ordinal)
+from ovos_number_parser.numbers_eu import (extract_number_eu,
+                                           pronounce_number_eu,
+                                           pronounce_ordinal_eu,
+                                           is_ordinal_eu)
 
 
 class TestBasquePronounce(unittest.TestCase):
@@ -106,6 +110,115 @@ class TestBasqueRoundTrip(unittest.TestCase):
             with self.subTest(number=number):
                 spoken = pronounce_number(number, lang="eu")
                 self.assertEqual(extract_number(spoken, lang="eu"), number)
+
+
+class TestBasqueScaleComposition(unittest.TestCase):
+    """Extraction of multi-word cardinals where a scale word (mila, milioi)
+    follows a group that must multiply it, or a running total that must be
+    added to. Forms are the verified pronounce_number output (Araua 7)."""
+
+    def test_thousand_plus_hundreds(self):
+        # "mila ehun ..." is 1000 + 100, not 1000 * 100
+        expected = {
+            1100: 'mila eta ehun',
+            1101: 'mila ehun eta bat',
+            1150: 'mila ehun eta berrogeita hamar',
+            1199: 'mila ehun eta laurogeita hemeretzi',
+            1200: 'mila eta berrehun',
+        }
+        for number, spoken in expected.items():
+            with self.subTest(number=number):
+                self.assertEqual(pronounce_number(number, lang="eu"), spoken)
+                self.assertEqual(extract_number(spoken, lang="eu"), number)
+
+    def test_hundreds_times_thousand(self):
+        # "(ehun eta bat) mila" is 101 * 1000
+        expected = {
+            21000: 'hogeita bat mila',
+            21802: 'hogeita bat mila zortziehun eta bi',
+            101000: 'ehun eta bat mila',
+            123456: 'ehun eta hogeita hiru mila laurehun eta '
+                    'berrogeita hamasei',
+        }
+        for number, spoken in expected.items():
+            with self.subTest(number=number):
+                self.assertEqual(pronounce_number(number, lang="eu"), spoken)
+                self.assertEqual(extract_number(spoken, lang="eu"), number)
+
+    def test_millions_head_plus_remainder(self):
+        expected = {
+            1000001: 'milioi bat eta bat',
+            1001000: 'milioi bat eta mila',
+            1002982: 'milioi bat bi mila bederatziehun eta laurogeita bi',
+            1500000: 'milioi bat eta bostehun mila',
+            2500000: 'bi milioi eta bostehun mila',
+        }
+        for number, spoken in expected.items():
+            with self.subTest(number=number):
+                self.assertEqual(pronounce_number(number, lang="eu"), spoken)
+                self.assertEqual(extract_number(spoken, lang="eu"), number)
+
+
+class TestBasqueSentences(unittest.TestCase):
+    """Numbers embedded in natural, agglutinative Basque utterances."""
+
+    def test_sentences(self):
+        cases = {
+            'berrogeita hamar euro ordaindu ditut': 50,
+            'mila bederatziehun eta laurogeita hamar urtean': 1990,
+            'ehun eta hogeita hiru orrialde ditu liburuak': 123,
+            'hirurogeita hamar kilometro daude hemendik': 70,
+            'bi mila eta hogeita hiru urtea': 2023,
+        }
+        for text, number in cases.items():
+            with self.subTest(text=text):
+                self.assertEqual(extract_number(text, lang="eu"), number)
+
+    def test_case_and_whitespace_insensitive(self):
+        self.assertEqual(extract_number("HOGEI", lang="eu"), 20)
+        self.assertEqual(extract_number("Hogeita Bat", lang="eu"), 21)
+        self.assertEqual(extract_number("  hamar  ", lang="eu"), 10)
+
+
+class TestBasqueAdversarial(unittest.TestCase):
+    """Malformed / empty / junk input must not crash and must not invent
+    numbers."""
+
+    def test_empty_and_junk(self):
+        for text in ["", "   ", "kaixo zer moduz", "eta", "minus",
+                     "hogeitabat"]:
+            with self.subTest(text=text):
+                self.assertIn(extract_number(text, lang="eu"), (False, None))
+
+    def test_junk_around_number(self):
+        self.assertEqual(extract_number("xyz 123 abc", lang="eu"), 123)
+
+
+class TestBasqueCardinalSweep(unittest.TestCase):
+    """pronounce -> extract must round-trip across the whole 0..1_000_000
+    range (dense below 2_100, then sampled)."""
+
+    def test_round_trip_sweep(self):
+        numbers = list(range(0, 2101)) + list(range(2101, 1_000_001, 997))
+        for number in numbers:
+            spoken = pronounce_number_eu(number)
+            self.assertEqual(extract_number_eu(spoken), number,
+                             f"{number} spoken as {spoken!r}")
+
+
+class TestBasqueOrdinalSweep(unittest.TestCase):
+    """pronounce_ordinal -> is_ordinal must round-trip."""
+
+    def test_ordinal_round_trip(self):
+        for number in range(1, 1001):
+            spoken = pronounce_ordinal_eu(number)
+            self.assertEqual(is_ordinal_eu(spoken), number,
+                             f"{number} spoken as {spoken!r}")
+
+    def test_is_ordinal_rejects_junk(self):
+        for text in ["", "garren", "katua", "hogei"]:
+            with self.subTest(text=text):
+                self.assertFalse(is_ordinal_eu(text))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Extraction of composed Basque cardinals mishandled scale words (`mila`, `milioi`, `bilioi`) that follow a running total. Three separate faults are corrected so the entire `0..1_000_000` range now round-trips through `pronounce_number_eu` -> `extract_number_eu`, and common millions forms work too.

## Bugs fixed

1. **Scale word always multiplied.** `mila ehun` (1000 + 100) extracted as `100000` because a scale value was unconditionally multiplied into the running total. It is now added when the total already exceeds the scale, so `mila ehun eta bat` -> `1101`.

2. **Small multiplier lost before a higher scale.** In `milioi bat bi mila ...` the `bi` was merged into the millions as a bare `+2` and the thousands group collapsed. A small value preceding a scale word now scales that word.

3. **`eta` recursion over a tail with a scale word.** `ehun eta bat mila ...` produced fractional garbage (`100.1694`). The tail after `eta` is now split at the scale word and either folded into the multiplier group (`(ehun eta bat) mila` = 101 000) or added as an independent summand (`milioi bat eta bostehun mila` = 1 500 000).

## Tests

Extends the Basque suite with scale-composition anchors, natural agglutinative sentences, case/whitespace and malformed/empty/junk adversarial cases, an exhaustive-below-2100 then sampled `0..1_000_000` cardinal round-trip sweep, and an ordinal round-trip sweep over `1..1000`.

Values are the verified `pronounce_number_eu` output (Euskaltzaindia Araua 7); no assertion pins raw engine output for a form that could not be checked against native usage. Cardinals above `1_000_000` that juxtapose a millions head with a compound remainder remain a known limitation of the single-accumulator extractor and are not asserted.