### PR TITLE
fix: combine compound Spanish magnitudes when extracting numbers

### DIFF
--- a/ovos_number_parser/numbers_es.py
+++ b/ovos_number_parser/numbers_es.py
@@ -64,6 +64,9 @@ _STRING_NUM_ES = {
     "diecinueve": 19,
     "veinte": 20,
     "veintiuno": 21,
+    "veintiún": 21,
+    "veintiun": 21,
+    "veintiuna": 21,
     "veintidos": 22,
     "veintitres": 23,
     "veintidós": 22,
@@ -348,13 +351,23 @@ def extract_number_es(text, short_scale=True, ordinals=False):
     #
     # Returns incorrect output on certain fractional phrases like, "cuarto de dos"
     #  TODO: numbers greater than 999999
+    if not text:
+        return False
     aWords = text.lower().split()
     negative = False
     while aWords and aWords[0] in ['menos']:
         negative = True
         aWords = aWords[1:]
     count = 0
-    result = None
+    result = None   # locked sum of completed magnitude groups
+    group = 0       # value accumulated within the current magnitude group
+
+    def _combine():
+        # collapse the pending group into the running total
+        nonlocal result, group
+        result = (result or 0) + group
+        group = 0
+
     while count < len(aWords):
         val = 0
         word = aWords[count]
@@ -374,9 +387,11 @@ def extract_number_es(text, short_scale=True, ordinals=False):
         elif is_numeric(word):
             val = float(word)
         elif is_fractional_es(word):
-            if not result:
-                result = 1
-            result = result * is_fractional_es(word)
+            base = (result or 0) + group
+            if base == 0:
+                base = 1
+            result = base * is_fractional_es(word)
+            group = 0
             count += 1
             continue
 
@@ -389,70 +404,36 @@ def extract_number_es(text, short_scale=True, ordinals=False):
                 val = float(aPieces[0]) / float(aPieces[1])
 
         if val:
-            if result is None:
-                result = 0
-            # handle fractions
-            if next_word != "avos":
-                if val in (100, 1000, 1000000, 1000000000) and result:
-                    # scale word multiplies what came before ("dos mil")
-                    result = result * val
-                else:
-                    power = 10
-                    merged = False
-                    while result and power <= result:
-                        if result % power == 0 and val < power:
-                            # lower-magnitude continuation
-                            # ("dos mil veintitres" -> 2000 + 23)
-                            result = result + val
-                            merged = True
-                            break
-                        power *= 10
-                    if not merged:
-                        result = val
+            if next_word == "avos":
+                # denominator: what came before divided by this value
+                base = (result or 0) + group
+                result = float(base) / float(val)
+                group = 0
+            elif val >= 1000:
+                # scale word ("mil", "millón"): multiply the pending group
+                # and lock it into the running total so a following smaller
+                # scale starts a fresh group ("un millón dos mil" -> 1002000)
+                group = (group or 1) * val
+                _combine()
+            elif val == 100:
+                # "cien"/"ciento" scales the units before it ("cien mil")
+                group = (group or 1) * 100
             else:
-                result = float(result) / float(val)
+                group += val
 
         if next_word is None:
             break
 
         # number word and fraction
         ands = ["y"]
-        if next_word in ands:
-            zeros = 0
-            if result is None:
-                count += 1
-                continue
-            newWords = aWords[count + 2:]
-            newText = ""
-            for word in newWords:
-                newText += word + " "
-
-            afterAndVal = extract_number_es(newText[:-1])
-            if afterAndVal:
-                if result < afterAndVal or result < 20:
-                    while afterAndVal > 1:
-                        afterAndVal = afterAndVal / 10.0
-                    for word in newWords:
-                        if word == "cero" or word == "0":
-                            zeros += 1
-                        else:
-                            break
-                for _ in range(0, zeros):
-                    afterAndVal = afterAndVal / 10.0
-                result += afterAndVal
-                break
-        elif next_next_word is not None:
-            if next_next_word in ands and next_word not in _STRING_NUM_ES:
-                newWords = aWords[count + 3:]
-                newText = ""
-                for word in newWords:
-                    newText += word + " "
-                afterAndVal = extract_number_es(newText[:-1])
-                if afterAndVal:
-                    if result is None:
-                        result = 0
-                    result += afterAndVal
-                    break
+        # "y" only joins tens and units within a group ("noventa y nueve"),
+        # which the group accumulator already handles once the joiner is
+        # skipped. The one exception is a trailing fraction ("cinco y medio").
+        if next_word in ands and next_next_word and \
+                is_fractional_es(next_next_word):
+            _combine()
+            result = (result or 0) + is_fractional_es(next_next_word)
+            break
 
         decimals = ["punto", "coma", ".", ","]
         if next_word in decimals:
@@ -480,9 +461,14 @@ def extract_number_es(text, short_scale=True, ordinals=False):
             else:
                 afterDotVal = str(extract_number_es(newText[:-1]))
                 afterDotVal = zeros * "0" + afterDotVal
+            _combine()
             result = float(str(result or 0) + "." + afterDotVal)
             break
         count += 1
+
+    # collapse any pending group left after the final word
+    if group:
+        result = (result or 0) + group
 
     # Return the $str with the number related words removed
     # (now empty strings, so strlen == 0)

--- a/tests/test_number_parser_es.py
+++ b/tests/test_number_parser_es.py
@@ -58,5 +58,106 @@ class TestSpanishRoundTrip(unittest.TestCase):
                 self.assertEqual(extract_number(spoken, lang="es"), number)
 
 
+class TestSpanishMagnitudes(unittest.TestCase):
+    """Compound scale numbers must combine, not multiply, across magnitudes."""
+
+    def test_million_plus_thousand(self):
+        cases = {
+            "un millón dos mil": 1002000,
+            "un millón dos mil quinientos": 1002500,
+            "un millón cien mil": 1100000,
+            "dos millones quinientos mil": 2500000,
+            "tres millones dos mil": 3002000,
+            "un millón uno": 1000001,
+            "un millón dos mil trescientos cuarenta y cinco": 1002345,
+        }
+        for spoken, value in cases.items():
+            with self.subTest(spoken=spoken):
+                self.assertEqual(extract_number(spoken, lang="es"), value)
+
+    def test_thousands(self):
+        cases = {
+            "mil": 1000, "mil uno": 1001, "mil y uno": 1001,
+            "dos mil veintitrés": 2023, "cien mil": 100000,
+            "doscientos mil": 200000, "ciento cincuenta mil": 150000,
+            "novecientos noventa y nueve mil novecientos noventa y nueve": 999999,
+        }
+        for spoken, value in cases.items():
+            with self.subTest(spoken=spoken):
+                self.assertEqual(extract_number(spoken, lang="es"), value)
+
+    def test_hundreds_gendered(self):
+        for spoken in ("doscientos", "doscientas"):
+            self.assertEqual(extract_number(spoken, lang="es"), 200)
+        self.assertEqual(extract_number("doscientas cincuenta y dos", lang="es"), 252)
+
+
+class TestSpanishFusedAndGendered(unittest.TestCase):
+    def test_veintiuno_forms(self):
+        for spoken in ("veintiuno", "veintiún", "veintiuna"):
+            with self.subTest(spoken=spoken):
+                self.assertEqual(extract_number(spoken, lang="es"), 21)
+
+    def test_una(self):
+        self.assertEqual(extract_number("una", lang="es"), 1)
+
+    def test_cien_vs_ciento(self):
+        self.assertEqual(extract_number("cien", lang="es"), 100)
+        self.assertEqual(extract_number("ciento", lang="es"), 100)
+        self.assertEqual(extract_number("ciento uno", lang="es"), 101)
+
+
+class TestSpanishFractions(unittest.TestCase):
+    def test_simple_fractions(self):
+        self.assertEqual(extract_number("un cuarto", lang="es"), 0.25)
+        self.assertEqual(extract_number("tres cuartos", lang="es"), 0.75)
+        self.assertEqual(extract_number("medio", lang="es"), 0.5)
+
+    def test_number_and_half(self):
+        # nice_number renders 5.5 as "cinco y medio"
+        self.assertEqual(extract_number("cinco y medio", lang="es"), 5.5)
+        self.assertEqual(extract_number("dos y medio", lang="es"), 2.5)
+
+
+class TestSpanishAdversarial(unittest.TestCase):
+    def test_empty(self):
+        self.assertFalse(extract_number("", lang="es"))
+
+    def test_none(self):
+        self.assertFalse(extract_number(None, lang="es"))
+
+    def test_junk(self):
+        self.assertIn(extract_number("hola qué tal amigo", lang="es"), (False, None))
+
+    def test_mixed_case(self):
+        self.assertEqual(extract_number("Cuarenta Y Dos", lang="es"), 42)
+
+    def test_number_in_sentence(self):
+        self.assertEqual(extract_number("quiero cuarenta y dos manzanas", lang="es"), 42)
+
+    def test_negative_and_decimal(self):
+        self.assertEqual(extract_number("menos cinco", lang="es"), -5)
+        self.assertEqual(extract_number("tres coma uno cuatro", lang="es"), 3.14)
+
+
+class TestSpanishRoundTripLarge(unittest.TestCase):
+    """Sweep a wide integer range plus compound magnitudes."""
+
+    def test_sweep(self):
+        numbers = list(range(0, 3000, 7)) + [
+            5000, 9999, 12345, 100000, 250000, 999999,
+            1000000, 1000001, 1002000, 1002345, 2000000,
+            2500000, 3002000, 1100000, 1234567,
+        ]
+        for number in numbers:
+            with self.subTest(number=number):
+                spoken = pronounce_number(number, lang="es")
+                got = extract_number(spoken, lang="es")
+                if number == 0:
+                    self.assertIn(got, (0, False))
+                else:
+                    self.assertEqual(got, number, spoken)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Spanish number extraction multiplied magnitude words together instead of combining them. "un millón dos mil" resolved to 1000002000 rather than 1002000, and any phrase mixing millions and thousands was off by orders of magnitude.

The accumulator now builds each magnitude group and locks it into a running total, so a smaller scale following a larger one starts a fresh group. Round-tripping pronounce_number through extract_number is now exact across a wide integer sweep and the mixed-magnitude cases.

Also included:
- recognise the apocopated and feminine forms "veintiún" and "veintiuna"
- treat "y" as the tens-and-units joiner, while keeping "N y medio" fractions
- return a falsy result for empty or missing input instead of raising

Adds Spanish tests covering compound magnitudes, gendered hundreds, fused twenties, fractions, adversarial input and a large round-trip sweep.