### PR TITLE
fix: harden Arabic number extraction (duals, article, unit lists)

### DIFF
--- a/ovos_number_parser/numbers_ar.py
+++ b/ovos_number_parser/numbers_ar.py
@@ -263,6 +263,18 @@ def _norm_map(mapping):
     return {_normalize_ar(k): v for k, v in mapping.items()}
 
 
+# dual forms of common counting nouns carry the value 2 lexically
+# ("ساعتين" = two hours); both nominative (ـان) and oblique (ـين) endings
+_DUAL_NOUNS_AR = {
+    "يومان", "يومين", "ساعتان", "ساعتين", "دقيقتان", "دقيقتين",
+    "ثانيتان", "ثانيتين", "أسبوعان", "أسبوعين", "شهران", "شهرين",
+    "سنتان", "سنتين", "عامان", "عامين", "ليلتان", "ليلتين",
+    "مرتان", "مرتين", "اثنتان", "اثنتين",
+    "ريالان", "ريالين", "دولاران", "دولارين", "درهمان", "درهمين",
+    "جنيهان", "جنيهين",
+}
+
+
 def _build_lookup():
     units = {}
     for i, w in enumerate(_ONES_AR):
@@ -273,6 +285,8 @@ def _build_lookup():
     units["اثنين"] = 2  # oblique masculine dual
     units["اثنتين"] = 2  # oblique feminine dual
     units["ثماني"] = 8  # alternative feminine 8
+    for w in _DUAL_NOUNS_AR:
+        units[w] = 2
     tens = {}
     for value, word in _TENS_AR.items():
         tens[word] = value
@@ -316,6 +330,44 @@ _ORDINAL_UNITS_LOOKUP = _norm_map(
 _ORDINAL_UNITS_LOOKUP.update(_norm_map(
     {stem: value for value, stem in _ORDINAL_STEMS_FEM_AR.items()}))
 _ORDINAL_UNITS_LOOKUP.update(_norm_map({"حادي": 1, "حادية": 1}))
+
+# every cardinal building-block word, used to strip a tolerated ال- article
+_NUMBER_WORDS = (set(_UNITS_LOOKUP) | set(_TENS_LOOKUP) | set(_HUNDREDS_LOOKUP) |
+                 set(_SCALES_LOOKUP) | set(_SCALE_DUALS_LOOKUP) |
+                 set(_FRACTIONS_LOOKUP) | set(_TEEN_FIRST_LOOKUP) |
+                 _TEEN_SECOND_LOOKUP)
+
+
+def _bare(token):
+    """Strip a leading definite article when it fronts a number word."""
+    if token.startswith("ال") and token[2:] in _NUMBER_WORDS:
+        return token[2:]
+    return token
+
+
+def _group_slot(tokens, j):
+    """Magnitude slot a number word at ``tokens[j]`` fills in its <1000 group.
+
+    Returns one of ``"unit"``/``"ten"``/``"hundred"`` (which may occur only
+    once per group), ``"scale"``/``"frac"`` (which never conflict), or None
+    when the token is not a number word."""
+    tok = _bare(tokens[j])
+    nxt = _bare(tokens[j + 1]) if j + 1 < len(tokens) else None
+    if tok in _TEEN_FIRST_LOOKUP and nxt in _TEEN_SECOND_LOOKUP:
+        return "unit"
+    if tok in _UNITS_LOOKUP:
+        if nxt in _HUNDRED_MULT_LOOKUP and 1 <= _UNITS_LOOKUP[tok] <= 9:
+            return "hundred"
+        return "unit"
+    if tok in _TENS_LOOKUP:
+        return "ten"
+    if tok in _HUNDREDS_LOOKUP:
+        return "hundred"
+    if tok in _SCALES_LOOKUP or tok in _SCALE_DUALS_LOOKUP:
+        return "scale"
+    if tok in _FRACTIONS_LOOKUP:
+        return "frac"
+    return None
 
 
 def _is_number(s):
@@ -428,69 +480,86 @@ def _parse_number_span(tokens, i):
     total = 0
     current = 0
     started = False
+    filled = set()  # magnitude slots already used in the current <1000 group
     n = len(tokens)
     j = i
     while j < n:
-        tok = tokens[j]
-        if tok == "و" and started and j + 1 < n:
-            # the conjunction only continues the number if a number word
-            # follows and forms part of the same number
-            nxt = tokens[j + 1]
-            if (nxt in _UNITS_LOOKUP or nxt in _TENS_LOOKUP or
-                    nxt in _HUNDREDS_LOOKUP or nxt in _SCALES_LOOKUP or
-                    nxt in _SCALE_DUALS_LOOKUP or
-                    nxt in _TEEN_FIRST_LOOKUP or
-                    nxt in _FRACTIONS_LOOKUP):
+        raw = tokens[j]
+        if raw == "و" and started and j + 1 < n:
+            # the conjunction continues the number only when the next word is
+            # a number component that fills a slot not already taken (two
+            # units in a row, "ثلاثة وخمسة", are separate numbers, not eight)
+            slot = _group_slot(tokens, j + 1)
+            if slot in ("scale", "frac") or (
+                    slot in ("unit", "ten", "hundred") and slot not in filled):
                 j += 1
                 continue
             break
-        if _is_number(tok):
+        if _is_number(raw):
             if started:
                 break
-            value = float(tok)
+            value = float(raw)
             if value.is_integer():
                 value = int(value)
             return value, j + 1
+        tok = _bare(raw)
+        nxt = _bare(tokens[j + 1]) if j + 1 < n else None
         # teens: unit word followed by عشر/عشرة
         if (tok in _TEEN_FIRST_LOOKUP or
                 (tok in _UNITS_LOOKUP and 1 <= _UNITS_LOOKUP[tok] <= 9)) and \
-                j + 1 < n and tokens[j + 1] in _TEEN_SECOND_LOOKUP:
+                nxt in _TEEN_SECOND_LOOKUP:
+            if {"unit", "ten"} & filled:
+                break
             unit = _TEEN_FIRST_LOOKUP.get(tok) or _UNITS_LOOKUP[tok]
             current += 10 + unit
+            filled |= {"unit", "ten"}
             started = True
             j += 2
             continue
         if tok in _UNITS_LOOKUP:
             # unit followed by مئة multiplies: "ثلاث مئة" = 300
-            if j + 1 < n and tokens[j + 1] in _HUNDRED_MULT_LOOKUP and \
-                    1 <= _UNITS_LOOKUP[tok] <= 9:
+            if nxt in _HUNDRED_MULT_LOOKUP and 1 <= _UNITS_LOOKUP[tok] <= 9:
+                if "hundred" in filled:
+                    break
                 current += _UNITS_LOOKUP[tok] * 100
+                filled.add("hundred")
                 started = True
                 j += 2
                 continue
+            if "unit" in filled:
+                break
             current += _UNITS_LOOKUP[tok]
+            filled.add("unit")
             started = True
             j += 1
             continue
         if tok in _TENS_LOOKUP:
+            if "ten" in filled:
+                break
             current += _TENS_LOOKUP[tok]
+            filled.add("ten")
             started = True
             j += 1
             continue
         if tok in _HUNDREDS_LOOKUP:
+            if "hundred" in filled:
+                break
             current += _HUNDREDS_LOOKUP[tok]
+            filled.add("hundred")
             started = True
             j += 1
             continue
         if tok in _SCALES_LOOKUP:
             total += (current if current else 1) * _SCALES_LOOKUP[tok]
             current = 0
+            filled = set()
             started = True
             j += 1
             continue
         if tok in _SCALE_DUALS_LOOKUP:
             total += _SCALE_DUALS_LOOKUP[tok]
             current = 0
+            filled = set()
             started = True
             j += 1
             continue

--- a/tests/test_number_parser_ar.py
+++ b/tests/test_number_parser_ar.py
@@ -3,6 +3,11 @@ import unittest
 from ovos_number_parser import (extract_number, pronounce_number,
                                 pronounce_ordinal, pronounce_fraction,
                                 is_fractional, is_ordinal, numbers_to_digits)
+from ovos_number_parser.numbers_ar import extract_numbers_ar
+
+
+def extract_number_ar(text, ordinals=False):
+    return extract_number(text, lang="ar", ordinals=ordinals)
 
 
 class TestArabicPronounce(unittest.TestCase):
@@ -147,6 +152,71 @@ class TestArabicExtract(unittest.TestCase):
         self.assertEqual(
             numbers_to_digits("لدي خمسة وعشرون قطة", lang="ar"),
             "لدي 25 قطة")
+
+    def test_extract_dual_nouns(self):
+        # the dual of common counting nouns carries the value 2 lexically
+        for spoken in ["يومين", "يومان", "ساعتين", "ساعتان", "دقيقتين",
+                       "دقيقتان", "ثانيتين", "أسبوعين", "شهرين", "سنتين",
+                       "عامين", "ليلتين", "مرتين", "مرتان", "اثنتين",
+                       "ريالين", "دولارين", "درهمين", "جنيهين"]:
+            with self.subTest(spoken=spoken):
+                self.assertEqual(extract_number_ar(spoken), 2)
+
+    def test_extract_dual_in_context(self):
+        # timer / duration phrasing
+        self.assertEqual(extract_number_ar("اضبط مؤقت لمدة ساعتين"), 2)
+        self.assertEqual(extract_number_ar("بعد يومين"), 2)
+        self.assertAlmostEqual(extract_number_ar("ساعتين ونصف"), 2.5)
+        self.assertEqual(extract_number_ar("سالب ساعتين"), -2)
+
+    def test_definite_article_on_cardinals(self):
+        # the ال- article is tolerated on cardinals
+        self.assertEqual(extract_number_ar("الخمسة"), 5)
+        self.assertEqual(extract_number_ar("العشرون"), 20)
+        self.assertEqual(extract_number_ar("المئة"), 100)
+        self.assertEqual(extract_number_ar("الألف"), 1000)
+        self.assertEqual(extract_number_ar("الثلاثة والعشرون"), 23)
+
+    def test_consecutive_units_are_separate_numbers(self):
+        # two units cannot combine into one Arabic number: they are a list
+        self.assertEqual(extract_numbers_ar("ثلاثة وخمسة وسبعة"), [3, 5, 7])
+        self.assertEqual(extract_numbers_ar("واحد واثنان"), [1, 2])
+        self.assertEqual(extract_numbers_ar("خمسة ثلاثة"), [5, 3])
+        self.assertEqual(
+            extract_numbers_ar("عندي ثلاثة كتب وخمسة أقلام"), [3, 5])
+
+    def test_connector_compounds(self):
+        expected = {121: "مئة وواحد وعشرون",
+                    123: "مئة وثلاثة وعشرون",
+                    111: "مئة وأحد عشر",
+                    225: "مئتان وخمسة وعشرون",
+                    250: "مئتين وخمسين",
+                    1200: "ألف ومئتان",
+                    1994: "ألف وتسعمئة وأربعة وتسعون",
+                    2024: "ألفان وأربعة وعشرون",
+                    5300: "خمسة آلاف وثلاثمئة",
+                    123456: "مئة وثلاثة وعشرون ألف وأربعمئة وستة وخمسون",
+                    1001000000: "مليار ومليون"}
+        for number, spoken in expected.items():
+            with self.subTest(spoken=spoken):
+                self.assertEqual(extract_number_ar(spoken), number)
+
+    def test_extract_diacritized(self):
+        # fully / partially voweled input parses like the bare form
+        self.assertEqual(extract_number_ar("ثَلاثة"), 3)
+        self.assertEqual(extract_number_ar("وَاحِد"), 1)
+        self.assertEqual(extract_number_ar("ثَمَانِيَة"), 8)
+
+    def test_extract_hundreds_variants(self):
+        expected = [(700, "سبعمئة"), (800, "ثمانمئة"), (800, "ثمانمائة"),
+                    (999, "تسعمائة وتسعة وتسعون"), (300, "ثلاث مئة")]
+        for number, spoken in expected:
+            with self.subTest(spoken=spoken):
+                self.assertEqual(extract_number_ar(spoken), number)
+
+    def test_extract_mixed_digit_systems(self):
+        self.assertEqual(extract_number_ar("٢5"), 25)
+        self.assertEqual(extract_numbers_ar("لدي ٥ و 3"), [5, 3])
 
 
 class TestArabicRoundTrip(unittest.TestCase):


### PR DESCRIPTION
Hardens Modern Standard Arabic number handling with three correctness fixes and extensive regression coverage.

## Fixes

- **Dual counting nouns → 2.** The dual of common duration/counting nouns carries the value 2 lexically (`ساعتين`, `يومين`, `دقيقتين`, `أسبوعين`, `شهرين`, `سنتين`, `مرتين`, `ثانيتين`, currency duals, ...), in both nominative (ـان) and oblique (ـين) endings. Previously these returned no number, so a phrase like `ساعتين ونصف` extracted `0.5` instead of `2.5`.
- **Definite-article tolerance on cardinals.** A leading `ال-` on a cardinal is now accepted: `الخمسة` = 5, `العشرون` = 20, `المئة` = 100, `الألف` = 1000.
- **Consecutive units no longer merge.** Two units cannot combine into one Arabic number, so `ثلاثة وخمسة وسبعة` is the list `[3, 5, 7]` rather than `15`. Additive groups now track which magnitude slot (unit / ten / hundred) is filled and begin a new number when a slot would repeat. Valid compounds (`مئة وواحد وعشرون` = 121, `ألف وتسعمئة وأربعة وتسعون` = 1994) are unaffected, and scale words reset the slot state.

## Tests

Adds regression tests for the dual nouns, article tolerance, unit-list separation, connector compounds, diacritized input, hundreds spelling variants, and mixed Western/Eastern-Arabic-Indic digit strings. Full suite green.

### Known limitation

The numerator + plural-fraction construction (`ثلاثة أرباع` = 3/4) is not parsed as `0.75`; the additive fraction form `ثلاثة وربع` = 3.25 works. This is left unsupported rather than returning a wrong value.