### PR TITLE
fix: emit milijon remainder in Slovene long-scale numbers

### DIFF
--- a/ovos_number_parser/numbers_sl.py
+++ b/ovos_number_parser/numbers_sl.py
@@ -396,39 +396,58 @@ def pronounce_number_sl(num, places=2, short_scale=True, scientific=False,
             else:
                 ordi_force = False
 
+            def _long_numeral(count, masculine, ordi=False):
+                # spoken numeral preceding a long-scale word, in the gender the
+                # word requires: "-jon" words (milijon) are masculine and take
+                # dva/trije, "-jarda" words (milijarda) are feminine and keep
+                # dve/tri from the plain cardinal.
+                spoken = pronounce_number_sl(count, places, True, scientific,
+                                             ordinals=ordi)
+                if masculine and not ordi:
+                    prefix = spoken.split()[0] + " " if count > 100 else ""
+                    if count % 100 == 2:
+                        spoken = prefix + digits[2][:-1] + "a"
+                    elif count % 100 == 3:
+                        spoken = prefix + digits[3] + "je"
+                return spoken
+
             for i, z in enumerate(split):
                 if not z:
                     continue
 
-                number = pronounce_number_sl(z, places, True, scientific)
-                if z > 100:
-                    add = number.split()[0] + " "
-                else:
-                    add = ""
-                if z % 100 == 2 and i >= 1:
-                    number = add + digits[2][:-1] + "a"
-                if z % 100 == 3 and i >= 1:
-                    number = add + digits[3] + "je"
+                if i == 0:
+                    # units group: a plain sub-million number
+                    res.append(pronounce_number_sl(z, places, True, scientific))
+                    continue
 
-                # strip off the comma after the thousand
-                if i:
-                    if i >= len(hundreds):
-                        return ""
-                    # plus one as we skip 'thousand'
-                    # (and 'hundred', but this is excluded by index value)
-                    hundred = _plural_hundreds(
-                        z, hundreds[i + 1], True if ordi_force else ordi and not i)
+                if i + 1 >= len(hundreds):
+                    return ""
 
-                    if z >= 1000:
-                        z //= 1000
-                        number = pronounce_number_sl(z, places, True, scientific,
-                                                     ordinals=True if ordi_force else ordi and not i)
+                # a million-group value 0..999999 carries two magnitudes: the
+                # "-jarda" tier (z // 1000, e.g. milijarda) and the "-jon" tier
+                # (z % 1000, e.g. milijon). Both must be emitted, larger first.
+                word = hundreds[i + 1]
+                high, low = divmod(z, 1000)
+                group = []
 
-                    if z == 1:
-                        number = hundred
+                if high:
+                    hundred = _plural_hundreds(high * 1000, word, ordi_force)
+                    if high == 1:
+                        group.append(hundred)
                     else:
-                        number += " " + hundred
-                res.append(number)
+                        group.append(
+                            _long_numeral(high, masculine=False,
+                                          ordi=ordi_force) + " " + hundred)
+
+                if low:
+                    hundred = _plural_hundreds(low, word, ordi_force)
+                    if low == 1:
+                        group.append(hundred)
+                    else:
+                        group.append(
+                            _long_numeral(low, masculine=True) + " " + hundred)
+
+                res.append(" ".join(group))
             return " ".join(reversed(res))
 
         if short_scale:

--- a/tests/test_sl_edges.py
+++ b/tests/test_sl_edges.py
@@ -62,6 +62,57 @@ class TestSlovenianPronounceLegacy(unittest.TestCase):
             self.assertEqual(extract_number_sl(spoken), n, spoken)
 
 
+class TestSlovenianLongScaleMixedMagnitudes(unittest.TestCase):
+    """Long-scale groups spanning both the milijarda (10^9) and milijon (10^6)
+    tiers must emit both tiers.
+
+    A million-group value (0..999999) carries a 'milijarda' part (its thousands)
+    and a 'milijon' part (its remainder); the remainder used to be dropped, so
+    281 407 million came out as '... milijard' with the '407 milijonov' lost.
+    """
+
+    def test_milijarda_and_milijon_both_emitted(self):
+        # 1 milijarda + 407 milijonov
+        self.assertEqual(
+            pronounce_number_sl(1407000000, short_scale=False),
+            "milijarda štiristo sedem milijonov")
+
+    def test_full_mixed_magnitude_number(self):
+        self.assertEqual(
+            pronounce_number_sl(281407561516, short_scale=False),
+            "dvesto enainosemdeset milijard štiristo sedem milijonov "
+            "petsto enainšestdeset tisoč petsto šestnajst")
+
+    def test_bilijon_group_keeps_milijon_remainder(self):
+        self.assertEqual(
+            pronounce_number_sl(2000407000000, short_scale=False),
+            "dva bilijona štiristo sedem milijonov")
+
+    def test_long_scale_round_trip_sweep(self):
+        cases = [1407000000, 407000000, 281407561516, 2000407000000,
+                 281000000000, 123456789012, 1000407000000, 999999000000,
+                 5000005000000, 1002003000000]
+        for n in cases:
+            spoken = pronounce_number_sl(n, short_scale=False)
+            self.assertEqual(
+                extract_number_sl(spoken, short_scale=False), n, spoken)
+
+    def test_pure_tiers_unchanged(self):
+        # regression guard: single-tier groups keep their established forms
+        anchors = {
+            2000000000: "dve milijardi",
+            3000000000: "tri milijarde",
+            5000000000: "pet milijard",
+            2000000: "dva milijona",
+            3000000: "trije milijoni",
+            5000000: "pet milijonov",
+            1000000000: "milijarda",
+        }
+        for n, expected in anchors.items():
+            self.assertEqual(
+                pronounce_number_sl(n, short_scale=False), expected, n)
+
+
 class TestSlovenianCompoundOrdinals(unittest.TestCase):
     """Ordinals above one hundred join the hundred to the remainder.
 


### PR DESCRIPTION
## Problem

In long-scale (`short_scale=False`) Slovene, a million-group value (0..999999) carries two magnitudes: the **milijarda** tier (`z // 1000`) and the **milijon** tier (`z % 1000`). The old `_long_scale` divided the group by 1000 and only spoke the milijarda tier, silently dropping the milijon remainder.

```
281 407 561 516 -> "dvesto enainosemdeset milijard petsto ... šestnajst"   # 407 milijonov lost
1 407 000 000   -> "milijarda"                                             # 407 milijonov lost
```

## Fix

Each group is split into its milijarda and milijon parts and both are emitted, larger magnitude first, preserving Slovene gender agreement: `-jarda` words are feminine (`dve milijardi`, `tri milijarde`), `-jon` words masculine (`dva milijona`, `trije milijoni`).

```
281 407 561 516 -> dvesto enainosemdeset milijard štiristo sedem milijonov petsto enainšestdeset tisoč petsto šestnajst
1 407 000 000   -> milijarda štiristo sedem milijonov
```

## Tests

New `TestSlovenianLongScaleMixedMagnitudes` with exact-form anchors, a pronounce->extract round-trip sweep across mixed-magnitude values, and a regression guard pinning the single-tier forms. Full suite green (one pre-existing packaging test fails only because the shared venv has an older wheel installed than the source tree).