### PR TITLE
fix: multiply the scale when a fraction precedes it in Romance numbers

### DIFF
--- a/ovos_number_parser/util.py
+++ b/ovos_number_parser/util.py
@@ -547,11 +547,20 @@ class RomanceNumberExtractor:
             fraction = self.is_fractional(token)
             if fraction is not False:
                 saw_number = True
-                if token in plural_fractions:
-                    result += (current or 1) * fraction
+                next_token = tokens[i + 1] if i + 1 < len(tokens) else None
+                next_val = numbers_map.get(next_token) if next_token else None
+                if token not in plural_fractions and next_val is not None \
+                        and next_val >= 1000:
+                    # a singular fraction before a scale word multiplies that
+                    # scale ("meio milhão" = 500000, "medio millón" = 500000),
+                    # so leave it pending for the scale branch to multiply
+                    current += fraction
                 else:
-                    result += current + fraction
-                current = 0
+                    if token in plural_fractions:
+                        result += (current or 1) * fraction
+                    else:
+                        result += current + fraction
+                    current = 0
                 i += 1
                 continue
 

--- a/tests/test_romance_extractor_contracts.py
+++ b/tests/test_romance_extractor_contracts.py
@@ -45,5 +45,38 @@ class TestGalicianWiring(unittest.TestCase):
         self.assertFalse(is_fractional("can", "gl"))
 
 
+class TestFractionBeforeScale(unittest.TestCase):
+    """A "half" before a scale word multiplies the scale, it does not add 0.5.
+
+    "meio milhão" is half of a million (500000), never a million and a half.
+    """
+
+    def test_half_million(self):
+        self.assertEqual(extract_number("meio milhão", "pt"), 500000)
+        self.assertEqual(extract_number("medio millón", "gl"), 500000)
+        self.assertEqual(extract_number("jumătate de milion", "ro"), 500000)
+
+    def test_half_thousand(self):
+        self.assertEqual(extract_number("meio mil", "pt"), 500)
+        self.assertEqual(extract_number("medio mil", "gl"), 500)
+        self.assertEqual(extract_number("jumătate de mie", "ro"), 500)
+
+    def test_result_never_the_scale_plus_half(self):
+        for lang, text in [("pt", "meio milhão"), ("gl", "medio millón"),
+                           ("pt", "meio mil"), ("gl", "medio mil")]:
+            val = extract_number(text, lang)
+            self.assertLess(val, 1000000, f"{lang} {text}")
+
+    def test_standalone_and_trailing_fractions_unchanged(self):
+        # a fraction not followed by a scale word keeps its additive meaning
+        self.assertEqual(extract_number("dois e meio", "pt"), 2.5)
+        self.assertEqual(extract_number("dous e medio", "gl"), 2.5)
+        # plural fractions still multiply the preceding cardinal
+        self.assertEqual(extract_number("três quartos", "pt"), 0.75)
+
+    def test_negative_half_scale(self):
+        self.assertEqual(extract_number("menos meio milhão", "pt"), -500000)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
`meio milhão` (pt) / `medio millón` (gl) / `jumătate de milion` (ro) yielded 1000000.5 instead of 500000. A singular fraction before a scale word (mil/milhão/…) must multiply that scale, not add 0.5 on top of the fully-multiplied value.

The fix lives in the shared `RomanceNumberExtractor`, so every language it backs benefits. When a singular fraction is immediately followed by a scale word (value >= 1000), the fraction is left pending as the working multiplier and the scale branch multiplies it; standalone and trailing fractions keep their additive/plural-multiplicative meaning.

- `meio milhão` -> 1000000.5 -> **500000**
- `meio mil` -> 1000.5 -> **500**

Adds a `TestFractionBeforeScale` suite (6 tests) covering pt/gl/ro half-of-scale, the never-scale-plus-half invariant, unchanged standalone/plural fractions, and a negative case.