### PR TITLE
fix: return the no-number sentinel for non-string input in Romance numbers

### DIFF
--- a/ovos_number_parser/util.py
+++ b/ovos_number_parser/util.py
@@ -478,6 +478,11 @@ class RomanceNumberExtractor:
         Returns:
             int or float: The extracted number if found; otherwise, False.
         """
+        # no text, no number: honour the "no number" sentinel instead of
+        # raising on None or other non-string input
+        if not isinstance(text, str):
+            return False
+
         scale = scale or self.vocab.DEFAULT_SCALE
         numbers_map = self.vocab.get_number_strings(scale)
         ordinals_map = self.vocab.get_ordinal_strings(scale)

--- a/tests/test_number_parser_pt.py
+++ b/tests/test_number_parser_pt.py
@@ -698,11 +698,11 @@ class TestRoundTripSweep(unittest.TestCase):
 class TestAdversarialNumberInputs(unittest.TestCase):
     """Malformed and boundary inputs."""
 
-    def test_none_raises_predictably(self):
-        # None is not a valid string input
-        for fn in (PT_PT.extract_number, PT_PT.is_fractional):
-            with self.assertRaises(AttributeError):
-                fn(None)
+    def test_none_returns_false(self):
+        # non-string input is "no number", not an error
+        self.assertIs(PT_PT.extract_number(None), False)
+        for bad in (None, 123, 4.5, [], {}):
+            self.assertIs(PT_PT.extract_number(bad), False)
 
     def test_pronounce_rejects_non_numbers(self):
         for bad in ("not a number", None, [1, 2]):

--- a/tests/test_romance_extractor_contracts.py
+++ b/tests/test_romance_extractor_contracts.py
@@ -45,5 +45,30 @@ class TestGalicianWiring(unittest.TestCase):
         self.assertFalse(is_fractional("can", "gl"))
 
 
+class TestNonStringInput(unittest.TestCase):
+    """Non-string input is "no number": return the False sentinel, never raise."""
+
+    ROMANCE = ("pt", "gl", "mwl", "ast", "an", "oc", "ro")
+
+    def test_none_returns_false(self):
+        for lang in self.ROMANCE:
+            self.assertIs(extract_number(None, lang), False, lang)
+
+    def test_numbers_and_containers_return_false(self):
+        for value in (123, 4.5, True, [], {}, (), object()):
+            for lang in self.ROMANCE:
+                self.assertIs(extract_number(value, lang), False,
+                              f"{lang} {value!r}")
+
+    def test_empty_string_still_false(self):
+        for lang in self.ROMANCE:
+            self.assertIs(extract_number("", lang), False, lang)
+
+    def test_real_numbers_still_extracted(self):
+        # the guard must not swallow genuine strings
+        self.assertEqual(extract_number("sete", "pt"), 7)
+        self.assertEqual(extract_number("sete", "gl"), 7)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
`extract_number(None, lang)` raised `AttributeError: 'NoneType' object has no attribute 'lower'` for every language backed by the shared `RomanceNumberExtractor` (pt, gl, mwl, ast, an, oc, ro). The same happened for ints, floats, and containers.

Non-string input means "no number found": the extractor now returns `False` (the sentinel every caller already checks) instead of raising.

- `extract_number(None, 'pt')` -> AttributeError -> **False**

Adds a `TestNonStringInput` suite across all Romance langs (None, numeric, container, and empty-string cases, plus a guard that real strings still parse) and updates the pt adversarial test that previously pinned the raising behavior.