### PR TITLE
fix: correct Swedish ordinal pronunciation

### DIFF
--- a/ovos_number_parser/numbers_sv.py
+++ b/ovos_number_parser/numbers_sv.py
@@ -82,6 +82,41 @@ _FRACTION_STRING_SV = {
     20: 'tjugondel'
 }
 
+_ORDINAL_STRING_SV = {
+    0: 'nollte',
+    1: 'första',
+    2: 'andra',
+    3: 'tredje',
+    4: 'fjärde',
+    5: 'femte',
+    6: 'sjätte',
+    7: 'sjunde',
+    8: 'åttonde',
+    9: 'nionde',
+    10: 'tionde',
+    11: 'elfte',
+    12: 'tolfte',
+    13: 'trettonde',
+    14: 'fjortonde',
+    15: 'femtonde',
+    16: 'sextonde',
+    17: 'sjuttonde',
+    18: 'artonde',
+    19: 'nittonde',
+    20: 'tjugonde',
+    30: 'trettionde',
+    40: 'fyrtionde',
+    50: 'femtionde',
+    60: 'sextionde',
+    70: 'sjuttionde',
+    80: 'åttionde',
+    90: 'nittionde',
+    100: 'hundrade',
+    1000: 'tusende',
+    1000000: 'miljonte',
+    1000000000: 'miljardte'
+}
+
 _EXTRA_SPACE_SV = " "
 
 
@@ -260,31 +295,55 @@ def pronounce_ordinal_sv(number):
         (str): The pronounced number string.
     """
 
-    # ordinals for 1, 3, 7 and 8 are irregular
-    # this produces the base form, it will have to be adapted for genus,
-    # casus, numerus
-
-    ordinals = ["noll", "första", "andra", "tredje", "fjärde", "femte",
-                "sjätte", "sjunde", "åttonde", "nionde", "tionde"]
-
-    tens = int(floor(number / 10.0)) * 10
-    ones = number % 10
+    # In Swedish only the final element of a compound is inflected as an
+    # ordinal; the preceding magnitude words stay in their cardinal form
+    # (121 -> "hundratjugoförsta"). This produces the base (uter) form, which
+    # may need adaption for genus, kasus and numerus.
 
     if number < 0 or number != int(number):
         return number
-    if number == 0:
-        return ordinals[number]
+    number = int(number)
 
-    result = ""
-    if number > 10:
-        result += pronounce_number_sv(tens).rstrip()
+    if number in _ORDINAL_STRING_SV:
+        return _ORDINAL_STRING_SV[number]
 
-    if ones > 0:
-        result += ordinals[ones]
-    else:
-        result += 'de'
+    if number < 100:
+        tens = number // 10 * 10
+        ones = number % 10
+        return _NUM_STRING_SV[tens] + _ORDINAL_STRING_SV[ones]
 
-    return result
+    if number < 1000:
+        hundreds = number // 100
+        rem = number % 100
+        prefix = 'hundra' if hundreds == 1 \
+            else _NUM_STRING_SV[hundreds] + 'hundra'
+        if rem == 0:
+            return prefix + 'de'
+        return prefix + pronounce_ordinal_sv(rem)
+
+    if number < 1000000:
+        thousands = number // 1000
+        rem = number % 1000
+        prefix = 'tusen' if thousands == 1 \
+            else pronounce_number_sv(thousands).replace(' ', '') + 'tusen'
+        if rem == 0:
+            return prefix + 'de'
+        return prefix + pronounce_ordinal_sv(rem)
+
+    if number < 1000000000000:
+        scale = 1000000000 if number >= 1000000000 else 1000000
+        word = 'miljard' if scale == 1000000000 else 'miljon'
+        count = number // scale
+        rem = number % scale
+        if rem == 0:
+            prefix = word if count == 1 \
+                else pronounce_number_sv(count).replace(' ', '') + word
+            return prefix + 'te'
+        # magnitude word stays cardinal; only the remainder is the ordinal
+        return pronounce_number_sv(number - rem).strip() + ' ' \
+            + pronounce_ordinal_sv(rem)
+
+    return str(number)
 
 
 def _find_numbers_in_text(tokens):

--- a/tests/test_number_parser_sv.py
+++ b/tests/test_number_parser_sv.py
@@ -1,6 +1,81 @@
 import unittest
 
 from ovos_number_parser import extract_number, pronounce_number
+from ovos_number_parser.numbers_sv import pronounce_ordinal_sv
+
+
+class TestSwedishOrdinals(unittest.TestCase):
+    """Anchors for spoken Swedish ordinals.
+
+    Reference: standard Swedish grammar / Svenska Akademiens ordlista. Only the
+    final element of a compound inflects as an ordinal; the preceding magnitude
+    words keep their cardinal form.
+    """
+
+    def test_units_and_teens(self):
+        expected = {
+            0: 'nollte', 1: 'första', 2: 'andra', 3: 'tredje', 4: 'fjärde',
+            5: 'femte', 6: 'sjätte', 7: 'sjunde', 8: 'åttonde', 9: 'nionde',
+            10: 'tionde', 11: 'elfte', 12: 'tolfte', 13: 'trettonde',
+            14: 'fjortonde', 15: 'femtonde', 16: 'sextonde', 17: 'sjuttonde',
+            18: 'artonde', 19: 'nittonde',
+        }
+        for n, spoken in expected.items():
+            with self.subTest(number=n):
+                self.assertEqual(pronounce_ordinal_sv(n), spoken)
+
+    def test_tens(self):
+        expected = {
+            20: 'tjugonde', 30: 'trettionde', 40: 'fyrtionde',
+            50: 'femtionde', 60: 'sextionde', 70: 'sjuttionde',
+            80: 'åttionde', 90: 'nittionde',
+        }
+        for n, spoken in expected.items():
+            with self.subTest(number=n):
+                self.assertEqual(pronounce_ordinal_sv(n), spoken)
+
+    def test_compound_tens(self):
+        expected = {
+            21: 'tjugoförsta', 22: 'tjugoandra', 23: 'tjugotredje',
+            25: 'tjugofemte', 33: 'trettiotredje', 48: 'fyrtioåttonde',
+            99: 'nittionionde',
+        }
+        for n, spoken in expected.items():
+            with self.subTest(number=n):
+                self.assertEqual(pronounce_ordinal_sv(n), spoken)
+
+    def test_hundreds_and_thousands(self):
+        expected = {
+            100: 'hundrade', 101: 'hundraförsta', 111: 'hundraelfte',
+            121: 'hundratjugoförsta', 150: 'hundrafemtionde',
+            200: 'tvåhundrade', 203: 'tvåhundratredje',
+            999: 'niohundranittionionde',
+            1000: 'tusende', 1001: 'tusenförsta', 2000: 'tvåtusende',
+        }
+        for n, spoken in expected.items():
+            with self.subTest(number=n):
+                self.assertEqual(pronounce_ordinal_sv(n), spoken)
+
+    def test_large_scale(self):
+        expected = {
+            1000000: 'miljonte',
+            2000000: 'tvåmiljonte',
+            1000000000: 'miljardte',
+        }
+        for n, spoken in expected.items():
+            with self.subTest(number=n):
+                self.assertEqual(pronounce_ordinal_sv(n), spoken)
+
+    def test_no_bare_de_suffix_regression(self):
+        # regression: multiples of ten used to yield "tjugode"/"trettiode"
+        # and teens "tioförsta"; the ten must inflect to "-nde".
+        for n in (20, 30, 40, 50, 60, 70, 80, 90):
+            self.assertTrue(pronounce_ordinal_sv(n).endswith('nde'), n)
+        self.assertNotIn('tio', pronounce_ordinal_sv(11))
+
+    def test_rejects_non_integer_and_negative(self):
+        self.assertEqual(pronounce_ordinal_sv(-3), -3)
+        self.assertEqual(pronounce_ordinal_sv(2.5), 2.5)
 
 
 class TestSwedishPronounce(unittest.TestCase):


### PR DESCRIPTION
## Problem

`pronounce_ordinal_sv` glued the cardinal tens onto a units-only ordinal table, so anything past the units was wrong:

| n | before | correct |
|---|--------|---------|
| 10 | `de` | `tionde` |
| 11 | `tioförsta` | `elfte` |
| 13 | `tiotredje` | `trettonde` |
| 20 | `tjugode` | `tjugonde` |
| 30 | `trettiode` | `trettionde` |
| 100 | `etthundrade` | `hundrade` |
| 1000 | `ettusende` | `tusende` |

Reference: standard Swedish grammar / Svenska Akademiens ordlista.

## Fix

Drive the ordinal from a table of the irregular base forms (units, teens, tens, `hundra`, `tusen`, `miljon`, `miljard`) and compose compounds recursively so that only the final element inflects while the preceding magnitude words stay cardinal — matching how Swedish builds e.g. `hundratjugoförsta` (121st), `tvåtusende` (2000th).

## Tests

New `TestSwedishOrdinals`: exact-form anchors across units, teens, tens, compound tens, hundreds, thousands and the million/billion scale words, plus regression guards for the `-nde` tens suffix and the old bare `de`. Full suite green (one pre-existing packaging test fails only because the shared venv has an older wheel installed than the source tree).

Ordinal extraction (`extract_number_sv(..., ordinals=True)`) does not yet round-trip these forms, so no round-trip assertions are made here — left for a separate change.