### PR TITLE
fix: index English scale words by place value for large ordinals

### DIFF
--- a/ovos_number_parser/numbers_en.py
+++ b/ovos_number_parser/numbers_en.py
@@ -453,11 +453,11 @@ def pronounce_number_en(number, places=2, short_scale=True, scientific=False,
                     number += " "
                     if ordi:
 
-                        if i * 1000 in _SHORT_ORDINAL_EN:
+                        if 1000 ** i in _SHORT_ORDINAL_EN:
                             if z == 1:
-                                number = _SHORT_ORDINAL_EN[i * 1000]
+                                number = _SHORT_ORDINAL_EN[1000 ** i]
                             else:
-                                number += _SHORT_ORDINAL_EN[i * 1000]
+                                number += _SHORT_ORDINAL_EN[1000 ** i]
                         else:
                             if n not in _SHORT_SCALE_EN:
                                 num = int("1" + "0" * (len(str(n)) - 2))
@@ -503,13 +503,11 @@ def pronounce_number_en(number, places=2, short_scale=True, scientific=False,
                     number = number.replace(',', '')
 
                     if ordi:
-                        if i * 1000000 in _LONG_ORDINAL_EN:
+                        if 1000000 ** i in _LONG_ORDINAL_EN:
                             if z == 1:
-                                number = _LONG_ORDINAL_EN[
-                                    (i + 1) * 1000000]
+                                number = _LONG_ORDINAL_EN[1000000 ** i]
                             else:
-                                number += _LONG_ORDINAL_EN[
-                                    (i + 1) * 1000000]
+                                number += " " + _LONG_ORDINAL_EN[1000000 ** i]
                         else:
                             if n not in _LONG_SCALE_EN:
                                 num = int("1" + "0" * (len(str(n)) - 2))

--- a/tests/test_number_parser_en.py
+++ b/tests/test_number_parser_en.py
@@ -96,6 +96,42 @@ class TestNumberParserEN(unittest.TestCase):
         self.assertEqual(is_ordinal_en("fifth"), 5)
         self.assertFalse(is_ordinal_en("seven"))
 
+    def test_large_ordinals_short_scale(self):
+        # scale words must be looked up by place value (1000**group), not by
+        # group index times 1000 — otherwise groups above thousands crash or
+        # name the wrong scale
+        cases = {
+            1000000: "millionth",
+            2000000: "two millionth",
+            3000000: "three millionth",
+            5000000: "five millionth",
+            21000000: "twenty one millionth",
+            1000000000: "billionth",
+            2000000000: "two billionth",
+            1000000000000: "trillionth",
+        }
+        for n, expected in cases.items():
+            self.assertEqual(
+                pronounce_number_en(n, ordinals=True, short_scale=True),
+                expected, n)
+
+    def test_large_ordinals_long_scale(self):
+        cases = {
+            1000000: "millionth",
+            2000000: "two millionth",
+            1000000000000: "billionth",
+            2000000000000: "two billionth",
+        }
+        for n, expected in cases.items():
+            self.assertEqual(
+                pronounce_number_en(n, ordinals=True, short_scale=False),
+                expected, n)
+
+    def test_large_ordinals_do_not_raise(self):
+        for n in range(1000000, 40000000, 1000000):
+            pronounce_number_en(n, ordinals=True, short_scale=True)
+            pronounce_number_en(n, ordinals=True, short_scale=False)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The English ordinal builders indexed scale dictionaries by group position rather than place value — the same latent bug already noted in the Azerbaijani builder. `_short_scale` checked `i * 1000` and `_long_scale` checked `i * 1000000`, but group `i` holds place value `1000 ** i` (short) / `1000000 ** i` (long). Only the thousands group happened to line up.

For any group above thousands the ordinal path either named the wrong scale or raised `KeyError`:

- `pronounce_number_en(2000000, ordinals=True)` -> **KeyError: 100000** -> `two millionth`
- long-scale two-million-plus additionally lacked the separating space (`twomillionth` -> `two millionth`)

Cardinals were unaffected (they never used these branches).

Adds short- and long-scale large-ordinal expectation tests plus a no-raise sweep over 1M–40M in both scales. Round-trip extraction of these spoken ordinals is a separate, pre-existing extractor limitation and is deliberately not asserted here.