### PR TITLE
test: guard English "X hundred and Y" digit fusion

### DIFF
--- a/tests/test_number_parser_en.py
+++ b/tests/test_number_parser_en.py
@@ -96,6 +96,27 @@ class TestNumberParserEN(unittest.TestCase):
         self.assertEqual(is_ordinal_en("fifth"), 5)
         self.assertFalse(is_ordinal_en("seven"))
 
+    def test_hundred_and_units_combine(self):
+        # "X hundred and Y" is a single number: hundreds and units must fuse
+        # into one value, never split into "1 101" style fragments
+        self.assertEqual(numbers_to_digits_en("one hundred and one"), "101")
+        self.assertEqual(extract_number_en("one hundred and one"), 101)
+        cases = {
+            "two hundred and five": ("205", 205),
+            "nine hundred and ninety nine": ("999", 999),
+            "one hundred and twenty one": ("121", 121),
+            "three hundred and forty two": ("342", 342),
+            "one thousand one hundred and one": ("1101", 1101),
+        }
+        for text, (digits, value) in cases.items():
+            self.assertEqual(numbers_to_digits_en(text), digits, text)
+            self.assertEqual(extract_number_en(text), value, text)
+
+    def test_hundred_and_units_in_context(self):
+        self.assertEqual(
+            numbers_to_digits_en("it was one hundred and one degrees"),
+            "it was 101 degrees")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The reported defect — `numbers_to_digits_en("one hundred and one")` yielding `"1 101"` instead of `"101"` — does not reproduce on current `dev`. Both `extract_number_en` and `numbers_to_digits_en` already fuse "X hundred and Y" into a single value; a brute-force sweep of `<ones> hundred and <ones/tens>` across short/long scale and ordinal flags produced no split output.

Rather than change working code, this locks the behavior in: hundreds+units fusion for `one hundred and one`, `two hundred and five`, `nine hundred and ninety nine`, `one thousand one hundred and one`, and an in-sentence case, asserting both the extracted value and the digit substitution.