### PR TITLE
fix: Italian bare hundreds multiplied instead of added after larger numbers

### DIFF
--- a/ovos_number_parser/numbers_it.py
+++ b/ovos_number_parser/numbers_it.py
@@ -674,7 +674,14 @@ def extract_number_it(text, short_scale=False, ordinals=False):
         if word in multiplies:
             if not prev_val:
                 prev_val = 1
-            val = prev_val * val
+            if prev_val < val:
+                val = prev_val * val
+            else:
+                # the multiplier is smaller than what came before it, so it
+                # opens a new lower-order addend rather than scaling it
+                # ("mille cento" = 1000 + 100, not 1000 * 100)
+                to_sum.append(prev_val)
+                prev_val = 0
 
         # is this a spoken fraction?
         # mezza tazza

--- a/tests/test_it_hundreds_multiplier.py
+++ b/tests/test_it_hundreds_multiplier.py
@@ -1,0 +1,44 @@
+import unittest
+
+from ovos_number_parser.numbers_it import (extract_number_it,
+                                           pronounce_number_it)
+
+
+class TestItalianHundredsMultiplier(unittest.TestCase):
+    def test_bare_cento_after_thousand_adds(self):
+        # "mille cento" is 1000 + 100, not 1000 * 100
+        self.assertEqual(extract_number_it("mille cento"), 1100)
+        self.assertEqual(extract_number_it("mille cento uno"), 1101)
+        self.assertEqual(extract_number_it("duemila cento"), 2100)
+        self.assertEqual(extract_number_it("tremila cento cinquanta"), 3150)
+
+    def test_solid_and_spaced_agree(self):
+        self.assertEqual(extract_number_it("millecento"),
+                         extract_number_it("mille cento"))
+        self.assertEqual(extract_number_it("milleduecento"), 1200)
+
+    def test_cento_as_multiplier_still_works(self):
+        # a hundreds multiplier still scales a smaller preceding value
+        self.assertEqual(extract_number_it("due cento"), 200)
+        self.assertEqual(extract_number_it("cinque cento"), 500)
+        self.assertEqual(extract_number_it("cento"), 100)
+        self.assertEqual(extract_number_it("cento mila"), 100000)
+        self.assertEqual(extract_number_it("duecentomila"), 200000)
+
+    def test_natural_sentences(self):
+        self.assertEqual(
+            extract_number_it("ho bisogno di mille cento pezzi"), 1100)
+        self.assertEqual(
+            extract_number_it("il costo è di duemila cento euro"), 2100)
+
+    def test_roundtrip_up_to_100000(self):
+        # every value the engine can pronounce must extract back to itself
+        bad = []
+        for n in list(range(0, 3000)) + list(range(3000, 100001, 331)):
+            if extract_number_it(pronounce_number_it(n)) != n:
+                bad.append(n)
+        self.assertEqual(bad, [], f"round-trip failures: {bad[:10]}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug

`extract_number_it` registered `cento` both as the value 100 and as a multiplier word. A bare `cento` following a larger number was multiplied rather than added:

| input | before | correct |
|-------|--------|---------|
| `mille cento` | 100000 | 1100 |
| `mille cento uno` | 100001 | 1101 |
| `duemila cento` | 200000 | 2100 |

This surfaced in pronounce->extract round-trips (`pronounce_number_it(1100)` -> `'mille, cento'` -> 100000) and in natural sentences like "ho bisogno di mille cento pezzi".

## Fix

A multiplier word now only scales a *strictly smaller* preceding value; when the preceding accumulated value is already larger, the multiplier opens a new lower-order addend (`mille cento` = 1000 + 100). Genuine multiplier uses (`due cento` = 200, `cento mila` = 100000) are unchanged.

## Tests

Adds natural-sentence cases and a pronounce->extract round-trip sweep over 0..100000. Full suite green (pre-existing packaging metadata failure aside).

## Known follow-up (out of scope)

Values >= 100000 still mis-round-trip because `pronounce_number_it` emits a space inside the hundreds group (`'cento unomila'` for 101000) that glues the scale word to the wrong token. That is a separate pronounce-formatting issue.