### PR TITLE
fix: Catalan bare hundreds multiplied instead of added after larger numbers

### DIFF
--- a/ovos_number_parser/numbers_ca.py
+++ b/ovos_number_parser/numbers_ca.py
@@ -637,8 +637,11 @@ def extract_number_ca(text, short_scale=True, ordinals=False):
             # TODO: caution, review use of "ens" word
             if next_word == "ens":
                 result = float(result) / float(val)
-            elif val in (100, 1000, 1000000, 1000000000) and result:
-                # scale word multiplies what came before ("dos mil")
+            elif val in (100, 1000, 1000000, 1000000000) and result \
+                    and result < val:
+                # scale word multiplies what came before ("dos mil"); it only
+                # scales a strictly smaller value, so a bare hundred after a
+                # larger number is an addend ("mil cent" = 1000 + 100)
                 result = result * val
             else:
                 power = 10

--- a/tests/test_ca_hundreds_multiplier.py
+++ b/tests/test_ca_hundreds_multiplier.py
@@ -1,0 +1,32 @@
+import unittest
+
+from ovos_number_parser.numbers_ca import (extract_number_ca,
+                                           pronounce_number_ca)
+
+
+class TestCatalanHundredsMultiplier(unittest.TestCase):
+    def test_bare_hundred_after_thousand_adds(self):
+        self.assertEqual(extract_number_ca("mil cent"), 1100)
+        self.assertEqual(extract_number_ca("mil cent un"), 1101)
+        self.assertEqual(extract_number_ca("dos mil cent"), 2100)
+
+    def test_scale_multiplier_still_works(self):
+        self.assertEqual(extract_number_ca("dos mil"), 2000)
+        self.assertEqual(extract_number_ca("cent mil"), 100000)
+        self.assertEqual(extract_number_ca("cent"), 100)
+        self.assertEqual(extract_number_ca("dos-cents"), 200)
+
+    def test_natural_sentence(self):
+        self.assertEqual(
+            extract_number_ca("necessito mil cent unitats"), 1100)
+
+    def test_roundtrip_up_to_100000(self):
+        bad = []
+        for n in list(range(0, 3000)) + list(range(3000, 100001, 331)):
+            if extract_number_ca(pronounce_number_ca(n)) != n:
+                bad.append(n)
+        self.assertEqual(bad, [], f"round-trip failures: {bad[:10]}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug

`extract_number_ca` treated 100/1000/1000000/1000000000 as multipliers of whatever came before. A bare `cent` following a larger value was multiplied instead of added:

| input | before | correct |
|-------|--------|---------|
| `mil cent` | 100000 | 1100 |
| `mil cent un` | 100001 | 1101 |
| `dos mil cent` | 200000 | 2100 |

Surfaced by pronounce->extract round-trips and natural sentences ("necessito mil cent unitats").

## Fix

A scale word now only multiplies a *strictly smaller* preceding value; otherwise the existing additive/merge path handles it. Genuine multiplier uses (`dos mil`, `cent mil`, `dos-cents`) are unchanged.

## Tests

Natural-sentence cases plus a pronounce->extract round-trip sweep over 0..100000. Full suite green (packaging metadata artifact aside).