### PR TITLE
fix: Turkish extraction — bare hundreds after a thousand, and whole-number minus sign

### DIFF
--- a/ovos_number_parser/numbers_tr.py
+++ b/ovos_number_parser/numbers_tr.py
@@ -791,7 +791,11 @@ def _extract_whole_number_with_text_tr(tokens, short_scale, ordinals):
         if word in multiplies:
             if not prev_val:
                 prev_val = 1
-            val = prev_val * val
+            if current_val is None or prev_val < current_val:
+                val = prev_val * val
+            # else: the scale word is smaller than what came before it, so it
+            # opens a new addend ("bin yüz" = 1000 + 100) already accumulated
+            # by the summing branch above rather than a multiplier
 
         # is this a spoken fraction?
         # bir buçuk fincan - yarım fincan

--- a/ovos_number_parser/numbers_tr.py
+++ b/ovos_number_parser/numbers_tr.py
@@ -711,6 +711,7 @@ def _extract_whole_number_with_text_tr(tokens, short_scale, ordinals):
     val = False
     prev_val = None
     next_val = None
+    negative = False
     to_sum = []
     for idx, token in enumerate(tokens):
         current_val = None
@@ -720,6 +721,7 @@ def _extract_whole_number_with_text_tr(tokens, short_scale, ordinals):
 
         word = token.word.lower()
         if word in _NEGATIVES_TR:
+            negative = True
             number_words.append(token)
             continue
 
@@ -823,8 +825,8 @@ def _extract_whole_number_with_text_tr(tokens, short_scale, ordinals):
                 prev_val = temp
 
         # is this a negative number?
-        if val and prev_word and prev_word in _NEGATIVES_TR:
-            val = 0 - val
+        # the sign is applied once to the whole number after parsing,
+        # so no per-token negation happens here
 
         # let's make sure it isn't a fraction
         if not val:
@@ -871,6 +873,8 @@ def _extract_whole_number_with_text_tr(tokens, short_scale, ordinals):
 
     if val is not None and to_sum:
         val += sum(to_sum)
+    if negative and val not in (None, False):
+        val = -val
     return val, number_words
 
 

--- a/tests/test_tr_hundreds_after_thousand.py
+++ b/tests/test_tr_hundreds_after_thousand.py
@@ -1,0 +1,32 @@
+import unittest
+
+from ovos_number_parser.numbers_tr import (extract_number_tr,
+                                           pronounce_number_tr)
+
+
+class TestTurkishHundredsAfterThousand(unittest.TestCase):
+    def test_bare_hundred_after_thousand_adds(self):
+        self.assertEqual(extract_number_tr("bin yüz"), 1100)
+        self.assertEqual(extract_number_tr("bin yüz bir"), 1101)
+        self.assertEqual(extract_number_tr("iki bin yüz"), 2100)
+
+    def test_multiplier_uses_unchanged(self):
+        self.assertEqual(extract_number_tr("iki yüz"), 200)
+        self.assertEqual(extract_number_tr("yüz bin"), 100000)
+        self.assertEqual(extract_number_tr("bin iki yüz"), 1200)
+        self.assertEqual(extract_number_tr("yüz"), 100)
+
+    def test_natural_sentence(self):
+        self.assertEqual(
+            extract_number_tr("bana bin yüz tane lazım"), 1100)
+
+    def test_roundtrip_to_one_million(self):
+        bad = []
+        for n in list(range(0, 5000)) + list(range(5000, 1000001, 997)):
+            if extract_number_tr(pronounce_number_tr(n)) != n:
+                bad.append(n)
+        self.assertEqual(bad, [], f"round-trip failures: {bad[:10]}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_tr_negative_compound.py
+++ b/tests/test_tr_negative_compound.py
@@ -1,0 +1,23 @@
+import unittest
+
+from ovos_number_parser.numbers_tr import (extract_number_tr,
+                                           pronounce_number_tr)
+
+
+class TestNegativeCompoundtr(unittest.TestCase):
+    def test_negative_compound_roundtrip(self):
+        for n in (-9, -21, -200, -1200, -1234, -999999, -1000000):
+            self.assertEqual(
+                extract_number_tr(pronounce_number_tr(n)), n)
+
+    def test_signed_roundtrip_to_one_million(self):
+        bad = []
+        for n in list(range(0, 3000)) + list(range(3000, 1000001, 997)):
+            for m in (n, -n):
+                if extract_number_tr(pronounce_number_tr(m)) != m:
+                    bad.append(m)
+        self.assertEqual(bad, [], f"round-trip failures: {bad[:10]}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Two extraction fixes for Turkish, both surfaced by pronounce->extract round-trips.

## 1. Bare hundreds multiplied instead of added

`bin yüz` was summed to 1100 and then multiplied again (×100 → 1100000). The multiply step now runs only when the scale word is larger than the preceding value, so a smaller scale word ('yüz' after 'bin') stays the addend. `iki yüz`, `yüz bin` unchanged.

## 2. Minus sign applied only to the first word

`eksi bin iki yüz otuz dört` gave -766 instead of -1234. The parser now negates the fully assembled magnitude once at the end.

## Tests

Round-trip sweeps over 0..1000000 for both signs, plus targeted cases. Full suite green (packaging metadata artifact aside).