### PR TITLE
fix: Azerbaijani extraction — bare hundreds after a thousand, and whole-number minus sign

### DIFF
--- a/ovos_number_parser/numbers_az.py
+++ b/ovos_number_parser/numbers_az.py
@@ -904,7 +904,11 @@ def _extract_whole_number_with_text_az(tokens, short_scale, ordinals):
         if word in multiplies:
             if not prev_val:
                 prev_val = 1
-            val = prev_val * val
+            if current_val is None or prev_val < current_val:
+                val = prev_val * val
+            # else: the scale word is smaller than what came before it, so it
+            # opens a new addend ("min yüz" = 1000 + 100) already accumulated
+            # by the summing branch above rather than a multiplier
             # print("e")
 
         # is this a spoken fraction?

--- a/ovos_number_parser/numbers_az.py
+++ b/ovos_number_parser/numbers_az.py
@@ -812,6 +812,7 @@ def _extract_whole_number_with_text_az(tokens, short_scale, ordinals):
     val = False
     prev_val = None
     next_val = None
+    negative = False
     to_sum = []
     # print(tokens, ordinals)
     for idx, token in enumerate(tokens):
@@ -822,6 +823,7 @@ def _extract_whole_number_with_text_az(tokens, short_scale, ordinals):
 
         word = token.word.lower()
         if word in _NEGATIVES_AZ:
+            negative = True
             number_words.append(token)
             continue
 
@@ -939,8 +941,8 @@ def _extract_whole_number_with_text_az(tokens, short_scale, ordinals):
             # print("g", prev_val)
 
         # is this a negative number?
-        if val and prev_word and prev_word in _NEGATIVES_AZ:
-            val = 0 - val
+        # the sign is applied once to the whole number after parsing,
+        # so no per-token negation happens here
             # print("h")
 
         # let's make sure it isn't a fraction
@@ -1040,6 +1042,8 @@ def _extract_whole_number_with_text_az(tokens, short_scale, ordinals):
     if val is not None and to_sum:
         # print("m", to_sum)
         val += sum(to_sum)
+    if negative and val not in (None, False):
+        val = -val
     # print(val, number_words, "end")
     return val, number_words
 

--- a/tests/test_az_hundreds_after_thousand.py
+++ b/tests/test_az_hundreds_after_thousand.py
@@ -1,0 +1,26 @@
+import unittest
+
+from ovos_number_parser.numbers_az import (extract_number_az,
+                                           pronounce_number_az)
+
+
+class TestAzerbaijaniHundredsAfterThousand(unittest.TestCase):
+    def test_bare_hundred_after_thousand_adds(self):
+        self.assertEqual(extract_number_az("min yüz"), 1100)
+        self.assertEqual(extract_number_az("iki min yüz"), 2100)
+
+    def test_multiplier_uses_unchanged(self):
+        self.assertEqual(extract_number_az("iki yüz"), 200)
+        self.assertEqual(extract_number_az("yüz min"), 100000)
+        self.assertEqual(extract_number_az("min"), 1000)
+
+    def test_roundtrip_to_one_million(self):
+        bad = []
+        for n in list(range(0, 5000)) + list(range(5000, 1000001, 997)):
+            if extract_number_az(pronounce_number_az(n)) != n:
+                bad.append(n)
+        self.assertEqual(bad, [], f"round-trip failures: {bad[:10]}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_az_negative_compound.py
+++ b/tests/test_az_negative_compound.py
@@ -1,0 +1,23 @@
+import unittest
+
+from ovos_number_parser.numbers_az import (extract_number_az,
+                                           pronounce_number_az)
+
+
+class TestNegativeCompoundaz(unittest.TestCase):
+    def test_negative_compound_roundtrip(self):
+        for n in (-9, -21, -200, -1200, -1234, -999999, -1000000):
+            self.assertEqual(
+                extract_number_az(pronounce_number_az(n)), n)
+
+    def test_signed_roundtrip_to_one_million(self):
+        bad = []
+        for n in list(range(0, 3000)) + list(range(3000, 1000001, 997)):
+            for m in (n, -n):
+                if extract_number_az(pronounce_number_az(m)) != m:
+                    bad.append(m)
+        self.assertEqual(bad, [], f"round-trip failures: {bad[:10]}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Two extraction fixes for Azerbaijani, both surfaced by pronounce->extract round-trips.

## 1. Bare hundreds multiplied instead of added

`min yüz` was summed to 1100 and then multiplied again (×100 → 1100000). The multiply step now runs only when the scale word is larger than the preceding value. `iki yüz`, `yüz min` unchanged.

## 2. Minus sign applied only to the first word

`mənfi min iki yüz otuz dörd` gave -766 instead of -1234. The parser now negates the fully assembled magnitude once at the end.

## Tests

Round-trip sweeps over 0..1000000 for both signs, plus targeted cases. Full suite green (packaging metadata artifact aside).