### PR TITLE
fix: Russian minus sign applied only to the first word of a compound number

### DIFF
--- a/ovos_number_parser/numbers_ru.py
+++ b/ovos_number_parser/numbers_ru.py
@@ -918,6 +918,7 @@ def _extract_whole_number_with_text_ru(tokens, short_scale, ordinals):
     val = False
     prev_val = None
     next_val = None
+    negative = False
     to_sum = []
     for idx, token in enumerate(tokens):
         current_val = None
@@ -926,7 +927,8 @@ def _extract_whole_number_with_text_ru(tokens, short_scale, ordinals):
             continue
 
         word = token.word
-        if word in word in _NEGATIVES:
+        if word in _NEGATIVES:
+            negative = True
             number_words.append(token)
             continue
 
@@ -1031,9 +1033,8 @@ def _extract_whole_number_with_text_ru(tokens, short_scale, ordinals):
                 val = val * next_val
                 number_words.append(tokens[idx + 1])
 
-        # is this a negative number?
-        if val and prev_word and prev_word in _NEGATIVES:
-            val = 0 - val
+        # the sign is applied once to the whole number after parsing, so no
+        # per-token negation happens here
 
         # let's make sure it isn't a fraction
         if not val:
@@ -1129,6 +1130,9 @@ def _extract_whole_number_with_text_ru(tokens, short_scale, ordinals):
 
     if val is not None and to_sum:
         val += sum(to_sum)
+
+    if negative and val not in (None, False):
+        val = -val
 
     return val, number_words
 

--- a/tests/test_ru_negative_compound.py
+++ b/tests/test_ru_negative_compound.py
@@ -1,0 +1,31 @@
+import unittest
+
+from ovos_number_parser.numbers_ru import (extract_number_ru,
+                                           pronounce_number_ru)
+
+
+class TestRussianNegativeCompound(unittest.TestCase):
+    def test_negative_compound_numbers(self):
+        # the sign must apply to the whole number, not just the first word
+        self.assertEqual(
+            extract_number_ru("минус тысяча двести тридцать четыре"), -1234)
+        self.assertEqual(extract_number_ru("минус тысяча двести"), -1200)
+        self.assertEqual(
+            extract_number_ru("минус двести тридцать четыре"), -234)
+        self.assertEqual(extract_number_ru("минус двести"), -200)
+
+    def test_natural_sentence(self):
+        self.assertEqual(
+            extract_number_ru("температура минус двадцать один градус"), -21)
+
+    def test_signed_roundtrip_to_one_million(self):
+        bad = []
+        for n in list(range(0, 3000)) + list(range(3000, 1000001, 997)):
+            for m in (n, -n):
+                if extract_number_ru(pronounce_number_ru(m)) != m:
+                    bad.append(m)
+        self.assertEqual(bad, [], f"round-trip failures: {bad[:10]}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug

`extract_number_ru` negated only the first parsed component of a compound number:

| input | before | correct |
|-------|--------|---------|
| `минус тысяча двести` | -800 | -1200 |
| `минус тысяча двести тридцать четыре` | -766 | -1234 |
| `минус двести тридцать четыре` | 34 | -234 |

The mid-parse negation (`val = 0 - val`) turned the first term negative, after which the remaining terms were added positively (and the summing branch's `val < prev_val` guard misfired against the now-negative running value).

## Fix

The parser records that a minus was seen and negates the fully assembled magnitude once, after summing. Removes the fragile per-token negation and a `word in word in _NEGATIVES` typo.

## Tests

Targeted negatives, a natural sentence, and a signed pronounce->extract round-trip sweep over 0..1000000. Full suite green (packaging metadata artifact aside).