### PR TITLE
fix: Ukrainian minus sign applied only to the first word of a compound number

### DIFF
--- a/ovos_number_parser/numbers_uk.py
+++ b/ovos_number_parser/numbers_uk.py
@@ -943,6 +943,7 @@ def _extract_whole_number_with_text_uk(tokens, short_scale, ordinals):
     val = False
     prev_val = None
     next_val = None
+    negative = False
     to_sum = []
     for idx, token in enumerate(tokens):
         current_val = None
@@ -951,7 +952,8 @@ def _extract_whole_number_with_text_uk(tokens, short_scale, ordinals):
             continue
 
         word = token.word
-        if word in word in _NEGATIVES:
+        if word in _NEGATIVES:
+            negative = True
             number_words.append(token)
             continue
 
@@ -1060,9 +1062,8 @@ def _extract_whole_number_with_text_uk(tokens, short_scale, ordinals):
                 val = val * prev_val
             else:
                 val = 2
-        # is this a negative number?
-        if val and prev_word and prev_word in _NEGATIVES:
-            val = 0 - val
+        # the sign is applied once to the whole number after parsing,
+        # so no per-token negation happens here
 
         # let's make sure it isn't a fraction
         if not val:
@@ -1160,6 +1161,8 @@ def _extract_whole_number_with_text_uk(tokens, short_scale, ordinals):
 
     if val is not None and to_sum:
         val += sum(to_sum)
+    if negative and val not in (None, False):
+        val = -val
     return val, number_words
 
 

--- a/tests/test_uk_negative_compound.py
+++ b/tests/test_uk_negative_compound.py
@@ -1,0 +1,26 @@
+import unittest
+
+from ovos_number_parser.numbers_uk import (extract_number_uk,
+                                           pronounce_number_uk)
+
+
+class TestUkrainianNegativeCompound(unittest.TestCase):
+    def test_negative_compound_numbers(self):
+        self.assertEqual(extract_number_uk("мінус тисяча двісті"), -1200)
+        self.assertEqual(
+            extract_number_uk("мінус тисяча двісті тридцять чотири"), -1234)
+        self.assertEqual(
+            extract_number_uk("мінус двісті тридцять чотири"), -234)
+        self.assertEqual(extract_number_uk("мінус двісті"), -200)
+
+    def test_signed_roundtrip_to_one_million(self):
+        bad = []
+        for n in list(range(0, 3000)) + list(range(3000, 1000001, 997)):
+            for m in (n, -n):
+                if extract_number_uk(pronounce_number_uk(m)) != m:
+                    bad.append(m)
+        self.assertEqual(bad, [], f"round-trip failures: {bad[:10]}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug

`extract_number_uk` negated only the first parsed component:

| input | before | correct |
|-------|--------|---------|
| `мінус тисяча двісті` | -800 | -1200 |
| `мінус тисяча двісті тридцять чотири` | -766 | -1234 |
| `мінус двісті тридцять чотири` | 34 | -234 |

## Fix

The parser records that a minus was seen and negates the fully assembled magnitude once, after summing. Removes the fragile per-token negation and a `word in word in _NEGATIVES` typo.

## Tests

Targeted negatives and a signed pronounce->extract round-trip sweep over 0..1000000. Full suite green (packaging metadata artifact aside).