### PR TITLE
fix: Croatian minus sign applied only to the first word of a compound number

### DIFF
--- a/ovos_number_parser/numbers_hr.py
+++ b/ovos_number_parser/numbers_hr.py
@@ -687,6 +687,7 @@ def _extract_whole_number_with_text_hr(tokens, short_scale, ordinals):
     val = False
     prev_val = None
     next_val = None
+    negative = False
     to_sum = []
     for idx, token in enumerate(tokens):
         current_val = None
@@ -696,6 +697,7 @@ def _extract_whole_number_with_text_hr(tokens, short_scale, ordinals):
 
         word = token.word
         if word in _NEGATIVES:
+            negative = True
             number_words.append(token)
             continue
 
@@ -793,9 +795,8 @@ def _extract_whole_number_with_text_hr(tokens, short_scale, ordinals):
                 val = val * next_val
                 number_words.append(tokens[idx + 1])
 
-        # is this a negative number?
-        if val and prev_word and prev_word in _NEGATIVES:
-            val = 0 - val
+        # the sign is applied once to the whole number after parsing,
+        # so no per-token negation happens here
 
         # let's make sure it isn't a fraction
         if not val:
@@ -842,6 +843,8 @@ def _extract_whole_number_with_text_hr(tokens, short_scale, ordinals):
 
     if val is not None and to_sum:
         val += sum(to_sum)
+    if negative and val not in (None, False):
+        val = -val
 
     return val, number_words
 

--- a/tests/test_hr_negative_compound.py
+++ b/tests/test_hr_negative_compound.py
@@ -1,0 +1,23 @@
+import unittest
+
+from ovos_number_parser.numbers_hr import (extract_number_hr,
+                                           pronounce_number_hr)
+
+
+class TestNegativeCompoundhr(unittest.TestCase):
+    def test_negative_compound_roundtrip(self):
+        for n in (-9, -21, -200, -1200, -1234, -999999, -1000000):
+            self.assertEqual(
+                extract_number_hr(pronounce_number_hr(n)), n)
+
+    def test_signed_roundtrip_to_one_million(self):
+        bad = []
+        for n in list(range(0, 3000)) + list(range(3000, 1000001, 997)):
+            for m in (n, -n):
+                if extract_number_hr(pronounce_number_hr(m)) != m:
+                    bad.append(m)
+        self.assertEqual(bad, [], f"round-trip failures: {bad[:10]}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug

`extract_number_hr` negated only the first parsed component of a compound number, so a spoken "minus one thousand two hundred" evaluated to -1000 + 200 = -800 instead of -1200, and larger negative compounds were corrupted further.

## Fix

The parser records that a minus was seen and negates the fully assembled magnitude once, after summing, instead of negating a single mid-stream token.

## Tests

Signed pronounce->extract round-trip sweep over 0..1000000 plus targeted negatives. Full suite green (packaging metadata artifact aside).