### PR TITLE
fix: Polish loses the thousand and the sign in compound numbers

### DIFF
--- a/ovos_number_parser/numbers_pl.py
+++ b/ovos_number_parser/numbers_pl.py
@@ -536,7 +536,8 @@ _NEGATIVES = {"ujemne", "minus"}
 _SUMS = {'dwadzieścia', '20', 'trzydzieści', '30', 'czterdzieści', '40', 'pięćdziesiąt', '50',
          'sześćdziesiąt', '60', 'siedemdziesiąt', '70', 'osiemdziesiąt', '80', 'dziewięćdziesiąt', '90'}
 
-_MULTIPLIES_SHORT_SCALE_PL = generate_plurals_pl(_SHORT_SCALE_PL.values())
+_MULTIPLIES_SHORT_SCALE_PL = generate_plurals_pl(_SHORT_SCALE_PL.values()) | \
+    {word for value, word in _SHORT_SCALE_PL.items() if value >= 1000}
 
 # split sentence parse separately and sum ( 2 and a half = 2 + 0.5 )
 _FRACTION_MARKER = {'i'}
@@ -826,6 +827,7 @@ def _extract_whole_number_with_text_pl(tokens, short_scale, ordinals):
     val = False
     prev_val = None
     next_val = None
+    negative = False
     to_sum = []
     for idx, token in enumerate(tokens):
         current_val = None
@@ -843,6 +845,11 @@ def _extract_whole_number_with_text_pl(tokens, short_scale, ordinals):
             word = word[:-1]
 
         word = normalize_word_pl(word)
+
+        if word in _NEGATIVES:
+            negative = True
+            number_words.append(token)
+            continue
 
         if word not in string_num_scale and \
                 word not in _STRING_NUM_PL and \
@@ -926,9 +933,8 @@ def _extract_whole_number_with_text_pl(tokens, short_scale, ordinals):
                 val *= next_val
                 number_words.append(tokens[idx + 1])
 
-        # is this a negative number?
-        if val and prev_word and prev_word in _NEGATIVES:
-            val = 0 - val
+        # the sign is applied once to the whole number after parsing, so no
+        # per-token negation happens here
 
         if next_word in _STRING_NUM_PL:
             prev_val = val
@@ -1025,6 +1031,9 @@ def _extract_whole_number_with_text_pl(tokens, short_scale, ordinals):
 
     if val is not None and to_sum:
         val += sum(to_sum)
+
+    if negative and val not in (None, False):
+        val = -val
 
     return val, number_words
 

--- a/tests/test_pl_thousand_grouping.py
+++ b/tests/test_pl_thousand_grouping.py
@@ -1,0 +1,35 @@
+import unittest
+
+from ovos_number_parser.numbers_pl import (extract_number_pl,
+                                           pronounce_number_pl)
+
+
+class TestPolishThousandGrouping(unittest.TestCase):
+    def test_explicit_one_thousand_compound(self):
+        # "jeden tysiąc" (explicit one thousand) must keep its 1000 when
+        # followed by lower-order groups
+        self.assertEqual(extract_number_pl("jeden tysiąc"), 1000)
+        self.assertEqual(extract_number_pl("jeden tysiąc dwieście"), 1200)
+        self.assertEqual(
+            extract_number_pl("jeden tysiąc dwieście trzydzieści cztery"),
+            1234)
+        self.assertEqual(extract_number_pl("milion"), 1000000)
+
+    def test_negative_compound_keeps_sign(self):
+        self.assertEqual(
+            extract_number_pl(
+                "minus jeden tysiąc dwieście trzydzieści cztery"), -1234)
+        self.assertEqual(extract_number_pl("minus tysiąc"), -1000)
+        self.assertEqual(extract_number_pl("minus milion"), -1000000)
+
+    def test_signed_roundtrip_to_one_million(self):
+        bad = []
+        for n in list(range(0, 4000)) + list(range(4000, 1000001, 997)):
+            for m in (n, -n):
+                if extract_number_pl(pronounce_number_pl(m)) != m:
+                    bad.append(m)
+        self.assertEqual(bad, [], f"round-trip failures: {bad[:10]}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bugs

Both surfaced by pronounce->extract round-trips.

### 1. Explicit `jeden tysiąc` loses its thousand

The multiplier set was built purely from pluralised scale words, omitting the singular bases (`tysiąc`, `milion`, `miliard`, ...). So a spoken "one thousand two hundred" using the singular `tysiąc` collapsed:

| input | before | correct |
|-------|--------|---------|
| `jeden tysiąc dwieście` | 200 | 1200 |
| `jeden tysiąc dwieście trzydzieści cztery` | 234 | 1234 |

### 2. Minus sign dropped on large compounds

`minus jeden tysiąc dwieście trzydzieści cztery` returned 234 (positive) instead of -1234, because only the first token was negated.

## Fix

Singular scale words for values >= 1000 are added to the multiplier set, and the sign is recorded once and applied to the fully assembled magnitude.

## Tests

Signed pronounce->extract round-trip sweep over 0..1000000 plus targeted cases. Full suite green (packaging metadata artifact aside).