### PR TITLE
fix: Spanish pronounces a bare hundred as 'cien' not 'ciento'

### DIFF
--- a/ovos_number_parser/numbers_es.py
+++ b/ovos_number_parser/numbers_es.py
@@ -696,7 +696,9 @@ def pronounce_number_es(number, places=2, short_scale=False):
             else:
                 q, r = divmod(n, 100)
                 if q == 1:
-                    _partial = "ciento"
+                    # exactly one hundred is "cien"; "ciento" only combines
+                    # with a following remainder ("ciento uno")
+                    _partial = "ciento" if r else "cien"
                 elif q == 5:
                     _partial = "quinientos"
                 elif q == 7:

--- a/tests/test_es_cien_pronounce.py
+++ b/tests/test_es_cien_pronounce.py
@@ -1,0 +1,25 @@
+import unittest
+
+from ovos_number_parser.numbers_es import (pronounce_number_es,
+                                           extract_number_es)
+
+
+class TestSpanishCienPronounce(unittest.TestCase):
+    def test_exact_hundred_is_cien(self):
+        # 100 is "cien"; "ciento" only precedes a remainder
+        self.assertEqual(pronounce_number_es(100), "cien")
+        self.assertEqual(pronounce_number_es(101), "ciento uno")
+        self.assertEqual(pronounce_number_es(150), "ciento cincuenta")
+        self.assertEqual(pronounce_number_es(1100), "mil cien")
+        self.assertEqual(pronounce_number_es(100000), "cien mil")
+
+    def test_roundtrip_up_to_100000(self):
+        bad = []
+        for n in list(range(0, 3000)) + list(range(3000, 100001, 331)):
+            if extract_number_es(pronounce_number_es(n)) != n:
+                bad.append(n)
+        self.assertEqual(bad, [], f"round-trip failures: {bad[:10]}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug

`pronounce_number_es` used `ciento` for the hundreds digit 1 regardless of the remainder:

| n | before | correct |
|---|--------|---------|
| 100 | cien (ok) | cien |
| 1100 | mil ciento | mil cien |
| 100000 | ciento mil | cien mil |

Standard Spanish uses `cien` for an exact hundred and `ciento` only before a remainder (`ciento uno`, `ciento cincuenta`).

## Fix

The hundreds builder emits `cien` when the remainder is zero, `ciento` otherwise.

## Tests

Targeted cases plus a pronounce->extract round-trip sweep. Full suite green (packaging metadata artifact aside).