### PR TITLE
fix: return the no-number sentinel for non-string input across all languages

### DIFF
--- a/ovos_number_parser/__init__.py
+++ b/ovos_number_parser/__init__.py
@@ -611,6 +611,9 @@ def extract_number(text: str, lang: str,
         (int, float or False): The number extracted or False if the input
                                text contains no numbers
     """
+    if not isinstance(text, str):
+        # non-string input carries no number to extract
+        return False
     scale = scale or Scale.SHORT
     if short_scale is not None:
         # TODO log warning
@@ -718,6 +721,9 @@ def is_fractional(input_str: str, lang: str,
     Returns:
         (bool) or (float): False if not a fraction, otherwise the fraction
     """
+    if not isinstance(input_str, str):
+        # non-string input cannot be a fraction
+        return False
     scale = scale or Scale.SHORT
     if short_scale is not None:
         # TODO log warning

--- a/tests/test_nonstr_input_sentinel.py
+++ b/tests/test_nonstr_input_sentinel.py
@@ -1,0 +1,34 @@
+import unittest
+
+from ovos_number_parser import extract_number, is_fractional
+
+# every language that has an extractor wired into the dispatch
+LANGS = ["en", "es", "pt", "de", "fr", "it", "nl", "ru", "ar", "fa", "pl",
+         "sv", "fi", "el", "he", "hu", "sl", "ro", "ast", "oc", "an", "kab",
+         "id", "ms", "tr", "sk", "hr", "bg", "cs", "uk", "az", "da", "ca",
+         "gl", "eu", "et", "fy", "nb", "nn", "mwl"]
+
+
+class TestNonStringInputSentinel(unittest.TestCase):
+    def test_extract_number_returns_false_for_non_string(self):
+        for lang in LANGS:
+            for value in (None, 123, 1.5, [], {}, object()):
+                self.assertIs(
+                    extract_number(value, lang), False,
+                    f"extract_number({value!r}, {lang!r}) should be False")
+
+    def test_is_fractional_returns_false_for_non_string(self):
+        for lang in LANGS:
+            for value in (None, 123, [], {}):
+                self.assertIs(
+                    is_fractional(value, lang), False,
+                    f"is_fractional({value!r}, {lang!r}) should be False")
+
+    def test_empty_string_handled_gracefully(self):
+        # an empty string carries no number and must not raise
+        for lang in LANGS:
+            self.assertFalse(extract_number("", lang))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug

`extract_number(None, lang)` and `is_fractional(None, lang)` raised `AttributeError`/`TypeError` for 38 of the wired languages (only the Romance guard from a separate branch was covered). Any non-string value (None, int, list, ...) crashed instead of returning the documented `False` sentinel.

## Fix

Both dispatch entry points return `False` for non-string input before delegating. Empty strings and real values are unaffected.

## Tests

Asserts `extract_number`/`is_fractional` return `False` for None/int/float/list/dict/object across every dispatched language, and that empty strings are still handled without raising. Full suite green (packaging metadata artifact aside).