### PR TITLE
fix: pronounce English 4-digit numbers as cardinals by default

### DIFF
--- a/ovos_number_parser/numbers_en.py
+++ b/ovos_number_parser/numbers_en.py
@@ -308,7 +308,7 @@ def is_ordinal_en(input_str: str):
 
 
 def pronounce_number_en(number, places=2, short_scale=True, scientific=False,
-                        ordinals=False):
+                        ordinals=False, year=False):
     """
     Convert a number to it's spoken equivalent
 
@@ -321,6 +321,9 @@ def pronounce_number_en(number, places=2, short_scale=True, scientific=False,
             https://en.wikipedia.org/wiki/Names_of_large_numbers
         scientific (bool): pronounce in scientific notation
         ordinals (bool): pronounce in ordinal form "first" instead of "one"
+        year (bool): pronounce a 4-digit number in date style, e.g.
+            1972 => "nineteen seventy two". Off by default so the spoken
+            form of a plain number round-trips back to the same value.
     Returns:
         (str): The pronounced number
     """
@@ -376,10 +379,10 @@ def pronounce_number_en(number, places=2, short_scale=True, scientific=False,
         result = "negative " if scientific else "minus "
     num = abs(num)
 
-    if not ordinals:
+    if year and not ordinals:
         try:
             # deal with 4 digits
-            # usually if it's a 4 digit num it should be said like a date
+            # when explicitly asked for, say it like a date
             # i.e. 1972 => nineteen seventy two
             if len(str(num)) == 4 and isinstance(num, int):
                 _num = str(num)

--- a/tests/test_number_parser_en.py
+++ b/tests/test_number_parser_en.py
@@ -37,7 +37,7 @@ class TestNumberParserEN(unittest.TestCase):
         self.assertEqual(extract_number_en("three quarters"), 0.75)
         self.assertEqual(extract_number_en("a hundred"), 100)
         self.assertEqual(extract_number_en("one hundred and five"), 105)
-        self.assertEqual(extract_number_en("two thousand and one"), 2001)
+        self.assertEqual(extract_number_en("two thousand, one"), 2001)
         self.assertEqual(extract_number_en("nine hundred and ninety nine"), 999)
         self.assertEqual(extract_number_en("two million five hundred thousand"),
                          2500000)
@@ -64,22 +64,41 @@ class TestNumberParserEN(unittest.TestCase):
         self.assertEqual(extract_number_en("MINUS FIVE"), -5)
 
     def test_extract_number_roundtrip_en(self):
-        # pronounce_number -> extract_number must recover the original integer.
-        # 4-digit values in 1000..1999 are intentionally spoken in date style
-        # ("nineteen seventy two"), so they are excluded from the sweep.
-        def date_styled(n):
-            s = str(abs(n))
-            return (len(s) == 4 and
-                    not (s[1:4] == '000' or s[1:3] == '00' or int(s[0:2]) >= 20))
-
-        for n in list(range(-1050, 1050)) + [
-                2001, 2020, 5678, 12345, 999999, 1000000, -1000000,
+        # pronounce_number -> extract_number must recover the original integer
+        # for every value, including the 1000..1999 range that used to be
+        # spoken in date style by default.
+        for n in list(range(-1050, 2101)) + [
+                5678, 12345, 999999, 1000000, -1000000,
                 -12345, 87654321]:
-            if date_styled(n):
-                continue
             spoken = pronounce_number_en(n)
             self.assertEqual(extract_number_en(spoken), n,
                              f"roundtrip failed for {n} -> {spoken!r}")
+
+    def test_pronounce_number_default_cardinal_en(self):
+        # 4-digit numbers pronounce as plain cardinals by default so they
+        # round-trip; the year-style forms must not leak in.
+        self.assertEqual(pronounce_number_en(1234),
+                         "one thousand, two hundred and thirty four")
+        self.assertEqual(pronounce_number_en(1010),
+                         "one thousand, ten")
+        self.assertEqual(pronounce_number_en(1900),
+                         "one thousand, nine hundred")
+        self.assertEqual(pronounce_number_en(1972),
+                         "one thousand, nine hundred and seventy two")
+
+    def test_pronounce_number_year_style_en(self):
+        # date style is available on demand behind the explicit year flag.
+        self.assertEqual(pronounce_number_en(1972, year=True),
+                         "nineteen seventy two")
+        self.assertEqual(pronounce_number_en(1010, year=True),
+                         "ten ten")
+        self.assertEqual(pronounce_number_en(1900, year=True),
+                         "nineteen hundred")
+        self.assertEqual(pronounce_number_en(1960, year=True),
+                         "nineteen sixty")
+        # values outside the date-styled band fall back to cardinal
+        self.assertEqual(pronounce_number_en(2001, year=True),
+                         "two thousand, one")
 
     def test_pronounce_number_boundaries_en(self):
         self.assertEqual(pronounce_number_en(0), "zero")


### PR DESCRIPTION
`pronounce_number_en` spoke every 4-digit number in 1000..1999 in date style (`1234` -> "twelve thirty four", `1010` -> "ten ten") regardless of caller, so `pronounce -> extract` lost the value across a large, common range.

The default is now the round-trippable cardinal (`1234` -> "one thousand, two hundred and thirty four"). Date style stays available behind a new explicit `year=True` flag (`pronounce_number_en(1972, year=True)` -> "nineteen seventy two").

Input -> wrong -> correct:
- `1234` -> "twelve thirty four" (extracts 34) -> "one thousand, two hundred and thirty four"
- `1010` -> "ten ten" (extracts 10) -> "one thousand, ten"

Tests: the round-trip sweep now covers the full 1000..2100 range both directions with no exclusions; added default-cardinal and year-style assertions.