### PR TITLE
fix: join Italian digit groups before their scale word

### DIFF
--- a/ovos_number_parser/numbers_it.py
+++ b/ovos_number_parser/numbers_it.py
@@ -885,8 +885,11 @@ def pronounce_number_it(number, places=2, short_scale=False, scientific=False):
                     continue
                 number = _sub_thousand(z)
                 if i:
-                    number += ""  # separa ordini grandezza
-                    number += hundreds[i]
+                    # a scale word joins onto a single Italian word, so the
+                    # digit group it multiplies must collapse to one token
+                    # first: "cento uno" + "mila" -> "centounomila", never
+                    # "cento unomila" (which reads back as 100 + 1000)
+                    number = number.replace(" ", "") + hundreds[i]
                 res.append(number)
 
             return ", ".join(reversed(res))
@@ -913,7 +916,10 @@ def pronounce_number_it(number, places=2, short_scale=False, scientific=False):
                 if i:
                     # plus one as we skip 'thousand'
                     # (and 'hundred', but this is excluded by index value)
-                    number = number.replace(',', '')
+                    # collapse the group to a single token so the following
+                    # scale word ("milioni") multiplies the whole group and
+                    # not just its trailing word
+                    number = number.replace(',', '').replace(" ", "")
                     number += " " + hundreds[i + 1]
                 res.append(number)
             return ", ".join(reversed(res))

--- a/tests/test_it_scale_spacing.py
+++ b/tests/test_it_scale_spacing.py
@@ -1,0 +1,37 @@
+import unittest
+
+from ovos_number_parser.numbers_it import (extract_number_it,
+                                           pronounce_number_it)
+
+
+class TestItalianScaleSpacing(unittest.TestCase):
+    def test_scale_word_joins_the_whole_group(self):
+        # the thousands scale word attaches to a single Italian word, so a
+        # multi-token group must collapse first: 101000 is "centounomila",
+        # never "cento unomila" (which reads back as 100 + 1000)
+        self.assertEqual(pronounce_number_it(101000), "centounomila")
+        self.assertEqual(pronounce_number_it(150000), "centocinquantamila")
+        self.assertEqual(pronounce_number_it(999000), "novecentonovantanovemila")
+
+    def test_hundred_thousands_roundtrip(self):
+        for n in list(range(100000, 1000000, 337)) + [
+                101000, 123456, 150000, 200000, 555555, 987654, 999999]:
+            spoken = pronounce_number_it(n)
+            self.assertEqual(extract_number_it(spoken), n,
+                             f"roundtrip failed for {n} -> {spoken!r}")
+
+    def test_negative_hundred_thousands_roundtrip(self):
+        for n in [-101000, -123456, -150000, -999000]:
+            spoken = pronounce_number_it(n)
+            self.assertEqual(extract_number_it(spoken), n,
+                             f"roundtrip failed for {n} -> {spoken!r}")
+
+    def test_millions_still_roundtrip(self):
+        for n in [1000000, 2500000, 101000000]:
+            spoken = pronounce_number_it(n)
+            self.assertEqual(extract_number_it(spoken), n,
+                             f"roundtrip failed for {n} -> {spoken!r}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
A scale word attaches to a single Italian word, but a multi-token digit group such as "cento uno" kept its internal space, so the scale word glued onto the trailing token only. Values above 100000 did not round-trip.

Input -> wrong -> correct:
- `101000` -> "cento unomila" (extracts 1100) -> "centounomila"
- `999000` -> "novecento novantanovemila" (extracts 99900) -> "novecentonovantanovemila"
- `101000000` -> "cento uno milioni" (extracts 1000100) -> "centouno milioni"

The millions defect (the `101000000` case) was uncovered while sweeping this fix. Each thousands and millions group now collapses to one token before its scale word is appended.

Tests: added a spacing/round-trip suite sweeping 100000..1000000 plus millions and negatives; existing Italian pronounce expectations for standalone sub-1000 values are unchanged.