### PR TITLE
fix: normalize Russian plural fraction endings to the singular form

### DIFF
--- a/ovos_number_parser/numbers_ru.py
+++ b/ovos_number_parser/numbers_ru.py
@@ -1194,8 +1194,12 @@ def is_fractional_ru(input_str, short_scale=True):
         (bool) or (float): False if not a fraction, otherwise the fraction
 
     """
-    if input_str[-3:] in ["тые", "тых"]:  # leading number is bigger than one (две четвёртые, три пятых)
-        input_str = input_str[-3:] + "тая"
+    # Ordinal-derived fraction nouns are feminine ("пятая", 1/5). After a
+    # numerator they take the plural nominative "-ые" or genitive "-ых"
+    # ("две пятые", "три пятых"); normalize that ending back to the singular
+    # "-тая" citation form so it matches the table.
+    if input_str[-3:] in ["тые", "тых"]:
+        input_str = input_str[:-3] + "тая"
     fractions = {"целая": 1}  # first four numbers have little different format
 
     for num in _FRACTION_STRING_RU:  # Numbers from 2 to 1 hundred, more is not usually used in common speech

--- a/tests/test_number_parser_ru.py
+++ b/tests/test_number_parser_ru.py
@@ -1,6 +1,6 @@
 import unittest
 
-from ovos_number_parser import extract_number, pronounce_number
+from ovos_number_parser import extract_number, pronounce_number, is_fractional
 
 
 class TestRussianPronounce(unittest.TestCase):
@@ -116,6 +116,28 @@ class TestRussianAdversarial(unittest.TestCase):
             extract_number("поставь будильник на семь", lang="ru"), 7)
         self.assertEqual(
             extract_number("осталось двадцать три дня", lang="ru"), 23)
+
+
+class TestRussianFractions(unittest.TestCase):
+    """Fraction nouns, singular citation form and inflected plurals."""
+
+    def test_singular_forms(self):
+        self.assertEqual(is_fractional("целая", lang="ru"), 1.0)
+        self.assertEqual(is_fractional("пятая", lang="ru"), 0.2)
+        self.assertEqual(is_fractional("десятая", lang="ru"), 0.1)
+        self.assertEqual(is_fractional("сотая", lang="ru"), 0.01)
+
+    def test_plural_forms_normalize_to_singular(self):
+        # "две пятые" = 2/5, "три пятых" = 3/5 -> each fifth is 1/5
+        self.assertEqual(is_fractional("пятые", lang="ru"), 0.2)
+        self.assertEqual(is_fractional("пятых", lang="ru"), 0.2)
+        self.assertEqual(is_fractional("десятые", lang="ru"), 0.1)
+        self.assertEqual(is_fractional("десятых", lang="ru"), 0.1)
+
+    def test_non_fraction_returns_false(self):
+        for word in ["", "привет", "пять", "целые", "тые"]:
+            with self.subTest(word=word):
+                self.assertFalse(is_fractional(word, lang="ru"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Ordinal-derived Russian fraction nouns are feminine (`пятая` = 1/5). After a numerator they take the plural nominative `-ые` or genitive `-ых` (`две пятые`, `три пятых`). The normalization that maps those back to the singular citation form sliced the wrong side of the string — `input_str[-3:]` kept the ending and dropped the stem — so `пятые`/`пятых` became the non-word `тыетая` and never matched the table.

Input -> before -> after:
- `пятые` -> False -> 0.2
- `пятых` -> False -> 0.2
- `десятых` -> False -> 0.1

Singular forms and non-fractions are unchanged. Adds a fraction test class (3 tests) covering singular forms, plural normalization, and non-fraction rejection.