### PR TITLE
fix: sum Catalan scale groups so millions and hundred-thousands combine

### DIFF
--- a/ovos_number_parser/numbers_ca.py
+++ b/ovos_number_parser/numbers_ca.py
@@ -567,6 +567,14 @@ def extract_number_ca(text, short_scale=True, ordinals=False):
     """
     This function prepares the given text for parsing by making
     numbers consistent, getting rid of contractions, etc.
+
+    Cardinal numerals follow the standard Catalan structure described in the
+    Consorci per a la Normalització Lingüística grammar, "6. Els numerals"
+    (IEC normativa; https://www.cpnl.cat/gramatica/24/6-els-numerals): the
+    scale words "mil" and "milions" carry no hyphen and multiply the hundreds
+    group that precedes them, and the products are summed, so
+    "un milió dos-cents trenta-quatre mil sis-cents" reads 1 234 600.
+
     Args:
         text (str): the string to normalize
     Returns:
@@ -584,6 +592,14 @@ def extract_number_ca(text, short_scale=True, ordinals=False):
         aWords = aWords[1:]
     count = 0
     result = None
+    # A Catalan number is a run of groups joined by scale words: each hundreds
+    # group ("cinc-cents") multiplied by its scale ("mil", "milions") and the
+    # products summed. "total" holds the already-scaled groups, "current" the
+    # group under construction, so a scale word multiplies only its own group
+    # and never the accumulated higher-magnitude total ("dos milions cinc-cents
+    # mil" = 2000000 + 500*1000, not 2000000 + 500 + 1000).
+    total = 0
+    current = 0
     while count < len(aWords):
         val = 0
         word = aWords[count]
@@ -637,25 +653,24 @@ def extract_number_ca(text, short_scale=True, ordinals=False):
             # TODO: caution, review use of "ens" word
             if next_word == "ens":
                 result = float(result) / float(val)
-            elif val in (100, 1000, 1000000, 1000000000) and result \
-                    and result < val:
-                # scale word multiplies what came before ("dos mil"); it only
-                # scales a strictly smaller value, so a bare hundred after a
-                # larger number is an addend ("mil cent" = 1000 + 100)
-                result = result * val
+                total = result
+                current = 0
+            elif val in (1000, 1000000, 1000000000):
+                # a thousand/million scale word multiplies the group being
+                # built and banks the product ("cinc-cents mil" -> 500*1000)
+                total += (current or 1) * val
+                current = 0
+                result = total + current
+            elif val == 100:
+                # "cent" multiplies its group ("cent mil" -> 100*1000) or opens
+                # a new hundreds group ("mil cent" -> 1000 + 100)
+                current = (current or 1) * 100
+                result = total + current
             else:
-                power = 10
-                merged = False
-                while result and power <= result:
-                    if result % power == 0 and val < power:
-                        # lower-magnitude continuation
-                        # ("dos mil vint-i-tres" -> 2000 + 23)
-                        result = result + val
-                        merged = True
-                        break
-                    power *= 10
-                if not merged:
-                    result = (result or 0) + val
+                # ones, tens and hyphenated hundreds accumulate within the group
+                # ("dos mil vint-i-tres" -> 2000 + 23)
+                current += val
+                result = total + current
 
         if next_word is None:
             break

--- a/tests/test_number_parser_ca.py
+++ b/tests/test_number_parser_ca.py
@@ -38,6 +38,25 @@ class TestCatalanExtract(unittest.TestCase):
         self.assertEqual(extract_number('tinc vint-i-un gats', lang="ca"),
                          21)
 
+    def test_extract_scale_groups(self):
+        # Exact written forms taken from the Consorci per a la Normalització
+        # Lingüística grammar "6. Els numerals" (IEC normativa) and the Optimot
+        # fitxa "Guionet en els numerals compostos": a hundreds group before a
+        # scale word multiplies that scale word and the products are summed.
+        expected = {
+            'cinc-cents mil': 500000,
+            'cent mil': 100000,
+            'dos milions cent mil': 2100000,
+            'dos milions cinc-cents mil': 2500000,
+            'un milió dos-cents trenta-quatre mil sis-cents': 1234600,
+            'dos milions cinc-cents seixanta-nou mil vuit-cents setanta-cinc':
+                2569875,
+            'mil cent': 1100,
+        }
+        for spoken, number in expected.items():
+            with self.subTest(spoken=spoken):
+                self.assertEqual(extract_number(spoken, lang="ca"), number)
+
     def test_no_number(self):
         self.assertIn(extract_number("hola com estàs", lang="ca"), (False, None))
 
@@ -46,7 +65,8 @@ class TestCatalanRoundTrip(unittest.TestCase):
     """pronounce_number output must be understood by extract_number."""
 
     def test_round_trip(self):
-        for number in [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 201, 222, 300, 345, 400, 456, 500, 678, 700, 891, 900, 1000, 1001, 1234, 2000, 2023, 5000, 9999, 10000, 100000, 1000000, 2000000]:
+        for number in [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 201, 222, 300, 345, 400, 456, 500, 678, 700, 891, 900, 1000, 1001, 1234, 2000, 2023, 5000, 9999, 10000, 100000, 1000000, 2000000, 2100000, 2500000, 3400000, 1500000,
+                       2001500, 1234600, 2569875, 9999999]:
             with self.subTest(number=number):
                 spoken = pronounce_number(number, lang="ca")
                 self.assertEqual(extract_number(spoken, lang="ca"), number)


### PR DESCRIPTION
Round-trip pronounce→extract failed across the 1M–10M range in Catalan: a millions group followed by a hundred-thousands group did not recombine.

## Bug
extract_number_ca kept a single accumulator, and a scale word multiplied the whole running value only when it was strictly larger than it. After a millions total that guard blocked the multiplication, so the trailing thousands group was merged as a plain addend:

- `dos milions cinc-cents mil` (2 500 000) extracted **2 001 500** (2 000 000 + 500 + 1 000) instead of 2 000 000 + 500×1 000
- `dos milions cent mil` (2 100 000) extracted **2 001 100**
- `un milió cinc-cents mil` (1 500 000) extracted **1 001 500**

## Fix
Track the hundreds group under construction (`current`) separately from the banked, already-scaled total (`total`). A thousand/million scale word multiplies only `current` and banks the product; the products are summed. This matches the standard Catalan structure where `mil` and `milions` carry no hyphen and multiply the hundreds group that precedes them.

## Validation
- New exact-form anchor tests use written numerals quoted from the cited grammar, e.g. `un milió dos-cents trenta-quatre mil sis-cents` = 1 234 600.
- Round-trip anchors extended across the failing millions range.
- Full suite green (the pre-existing packaging metadata artifact aside).

## Source cross-check
Forms and joining rules confirmed against the Consorci per a la Normalització Lingüística grammar "6. Els numerals" (IEC normativa; https://www.cpnl.cat/gramatica/24/6-els-numerals) and the Optimot fitxa "Guionet en els numerals compostos"; cited in the extractor docstring.