### PR TITLE
fix: match Spanish fraction words case-insensitively

### DIFF
--- a/ovos_number_parser/numbers_es.py
+++ b/ovos_number_parser/numbers_es.py
@@ -313,6 +313,7 @@ def is_fractional_es(input_str, short_scale=True):
         (bool) or (float): False if not a fraction, otherwise the fraction
 
     """
+    input_str = input_str.lower()
     if input_str.endswith('s', -1):
         input_str = input_str[:len(input_str) - 1]  # e.g. "fifths"
 
@@ -322,15 +323,15 @@ def is_fractional_es(input_str, short_scale=True):
              "noveno": 9, "novena": 9, "décimo": 10, "décima": 10,
              "onceavo": 11, "onceava": 11, "doceavo": 12, "doceava": 12}
 
-    if input_str.lower() in aFrac:
+    if input_str in aFrac:
         return 1.0 / aFrac[input_str]
-    if (input_str == "vigésimo" or input_str == "vigésima"):
+    if input_str in ("vigésimo", "vigésima"):
         return 1.0 / 20
-    if (input_str == "trigésimo" or input_str == "trigésima"):
+    if input_str in ("trigésimo", "trigésima"):
         return 1.0 / 30
-    if (input_str == "centésimo" or input_str == "centésima"):
+    if input_str in ("centésimo", "centésima"):
         return 1.0 / 100
-    if (input_str == "milésimo" or input_str == "milésima"):
+    if input_str in ("milésimo", "milésima"):
         return 1.0 / 1000
     return False
 

--- a/tests/test_number_parser_es.py
+++ b/tests/test_number_parser_es.py
@@ -1,6 +1,6 @@
 import unittest
 
-from ovos_number_parser import extract_number, pronounce_number
+from ovos_number_parser import extract_number, pronounce_number, is_fractional
 
 
 class TestSpanishPronounce(unittest.TestCase):
@@ -157,6 +157,28 @@ class TestSpanishRoundTripLarge(unittest.TestCase):
                     self.assertIn(got, (0, False))
                 else:
                     self.assertEqual(got, number, spoken)
+
+
+class TestSpanishFractions(unittest.TestCase):
+    """Spanish fraction nouns, including gendered and capitalized forms."""
+
+    def test_basic_and_gendered(self):
+        self.assertEqual(is_fractional("medio", lang="es"), 0.5)
+        self.assertEqual(is_fractional("media", lang="es"), 0.5)
+        self.assertEqual(is_fractional("tercio", lang="es"), 1.0 / 3)
+        self.assertEqual(is_fractional("cuarta", lang="es"), 0.25)
+        self.assertEqual(is_fractional("centésima", lang="es"), 0.01)
+
+    def test_capitalized_input_does_not_crash(self):
+        # a sentence-initial or shouted fraction must not raise
+        self.assertEqual(is_fractional("Medio", lang="es"), 0.5)
+        self.assertEqual(is_fractional("MEDIO", lang="es"), 0.5)
+        self.assertEqual(is_fractional("Centésimo", lang="es"), 0.01)
+
+    def test_non_fraction_returns_false(self):
+        for word in ["", "hola", "cinco"]:
+            with self.subTest(word=word):
+                self.assertFalse(is_fractional(word, lang="es"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`is_fractional_es` lowercased the input for the `in aFrac` membership test but then looked the value up with the original-case string (`aFrac[input_str]`) and compared the higher denominators (`vigésima`, `centésima`...) against the un-lowered input. A capitalized fraction therefore raised `KeyError` instead of returning the value.

Input -> before -> after:
- `Medio` -> KeyError -> 0.5
- `MEDIO` -> KeyError -> 0.5
- `Centésimo` -> False -> 0.01

Lowercasing once at the top fixes the crash and makes the higher-denominator branches case-insensitive too. Adds a Spanish fraction test class (3 tests).