### PR TITLE
fix: reject NaN uniformly in pronounce_number

### DIFF
--- a/ovos_number_parser/__init__.py
+++ b/ovos_number_parser/__init__.py
@@ -359,13 +359,24 @@ def pronounce_number(number: Union[int, float], lang: str,
         str: The pronounced form of the number.
      
     Raises:
+        ValueError: If ``number`` is NaN, which has no cardinal spoken form.
         NotImplementedError: If the specified language is not supported.
+
+    Note:
+        NaN is rejected up front so every language fails the same way. IEEE 754
+        defines NaN as a value that "does not represent any numeric quantity"
+        (IEEE 754-2019, clause 6.2), so it has no cardinal reading. Without this
+        guard each backend crashes differently while formatting it: scientific
+        formatting does ``"%E" % nan`` -> ``"NAN"`` and then fails to split off an
+        exponent, while cardinal formatting fails converting NaN to ``int``.
     """
     scale = scale or Scale.SHORT
     if short_scale is not None:
         # TODO log warning
         pass
     short_scale = scale == Scale.SHORT
+    if isinstance(number, float) and number != number:
+        raise ValueError("cannot pronounce NaN (not a number)")
     if lang.startswith("en"):
         return pronounce_number_en(number, places, short_scale, scientific, ordinals)
     if lang.startswith("az"):

--- a/tests/test_dispatch_fixes.py
+++ b/tests/test_dispatch_fixes.py
@@ -1,7 +1,8 @@
 """Regression tests for language dispatch and return-contract fixes."""
 import unittest
 
-from ovos_number_parser import extract_number, is_fractional, is_ordinal, numbers_to_digits
+from ovos_number_parser import (extract_number, is_fractional, is_ordinal,
+                                 numbers_to_digits, pronounce_number)
 from ovos_number_parser.numbers_es import nice_number_es
 
 
@@ -31,6 +32,52 @@ class TestDispatchFixes(unittest.TestCase):
     def test_es_nice_number_pluralizes_tercios(self):
         self.assertEqual(nice_number_es(2 / 3), "2 tercios")
         self.assertEqual(nice_number_es(0.75), "3 cuartos")
+
+
+class TestPronounceNaNGuard(unittest.TestCase):
+    """NaN has no cardinal reading; every backend must reject it the same way.
+
+    Before the guard each language crashed differently while formatting NaN:
+    scientific formatting did ``"%E" % nan`` -> ``"NAN"`` and then raised
+    ``ValueError: not enough values to unpack`` splitting the (absent) exponent,
+    while cardinal formatting raised ``ValueError: cannot convert float NaN to
+    integer``. The dispatcher now raises one deliberate ValueError instead.
+    """
+
+    NAN = float("nan")
+    # a spread across the scientific-notation backends, the decimal-expansion
+    # backends, and the Romance / RBNF fallbacks
+    LANGS = ["en", "fa", "it", "ru", "ar", "de", "es", "ca", "pt", "eu", "kab"]
+
+    def test_nan_raises_valueerror_plain(self):
+        for lang in self.LANGS:
+            with self.subTest(lang=lang):
+                with self.assertRaises(ValueError):
+                    pronounce_number(self.NAN, lang=lang)
+
+    def test_nan_raises_valueerror_scientific(self):
+        for lang in self.LANGS:
+            with self.subTest(lang=lang):
+                with self.assertRaises(ValueError):
+                    pronounce_number(self.NAN, lang=lang, scientific=True)
+
+    def test_nan_message_is_explicit(self):
+        with self.assertRaises(ValueError) as ctx:
+            pronounce_number(self.NAN, lang="en")
+        self.assertIn("NaN", str(ctx.exception))
+
+    def test_finite_numbers_unaffected(self):
+        # the guard must not touch ordinary values, including scientific ones
+        self.assertEqual(pronounce_number(5.0, lang="en"), "five")
+        self.assertEqual(
+            pronounce_number(1.5e10, lang="en", scientific=True),
+            "one point five times ten to the power of ten")
+
+    def test_infinity_still_localized(self):
+        # inf is a distinct sentinel with a real spoken form; keep it working
+        self.assertEqual(pronounce_number(float("inf"), lang="en"), "infinity")
+        self.assertEqual(pronounce_number(float("-inf"), lang="en"),
+                         "negative infinity")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
NaN reached each language backend and crashed while being formatted, and the failure mode differed per language:

- scientific path: `"%E" % nan` -> `"NAN"`, then `ValueError: not enough values to unpack` splitting the (absent) exponent
- cardinal path: `ValueError: cannot convert float NaN to integer`
- Basque: `KeyError`; Kabyle: capacity `OverflowError`; etc.

The dispatcher now rejects NaN once, up front, with a single deliberate `ValueError("cannot pronounce NaN (not a number)")`. NaN has no cardinal spoken form — IEEE 754 defines it as a value that does not represent any numeric quantity. Infinity is untouched and keeps its per-language spoken form.

## Tests
New `TestPronounceNaNGuard` (5 tests) in `tests/test_dispatch_fixes.py`:
- NaN raises `ValueError` across 11 languages spanning the scientific-notation, decimal-expansion, and Romance/RBNF backends — both plain and `scientific=True`
- the message is explicit
- finite values (incl. scientific) and infinity are unaffected

Full suite green (the sole unrelated failure is the order-dependent installed-metadata packaging check, which passes in isolation and on clean dev).