### PR TITLE
fix: match Basque fraction words case-insensitively

### DIFF
--- a/ovos_number_parser/numbers_eu.py
+++ b/ovos_number_parser/numbers_eu.py
@@ -354,6 +354,7 @@ def is_fractional_eu(input_str):
         (bool) or (float): False if not a fraction, otherwise the fraction
 
     """
+    input_str = input_str.lower()
     if input_str.endswith('s', -1):
         input_str = input_str[:len(input_str) - 1]  # e.g. "fifths"
 
@@ -363,15 +364,15 @@ def is_fractional_eu(input_str):
              "bederatziren": 9, "bederatzirena": 9, "hamarren": 10, "hamarrena": 10,
              "hamaikaren": 11, "hamaikarena": 11, "hamabiren": 12, "hamabirena": 12}
 
-    if input_str.lower() in aFrac:
+    if input_str in aFrac:
         return 1.0 / aFrac[input_str]
-    if (input_str == "hogeiren" or input_str == "hogeirena"):
+    if input_str in ("hogeiren", "hogeirena"):
         return 1.0 / 20
-    if (input_str == "hogeita hamarren" or input_str == "hogeita hamarrena"):
+    if input_str in ("hogeita hamarren", "hogeita hamarrena"):
         return 1.0 / 30
-    if (input_str == "ehunen" or input_str == "ehunena"):
+    if input_str in ("ehunen", "ehunena"):
         return 1.0 / 100
-    if (input_str == "milaren" or input_str == "milarena"):
+    if input_str in ("milaren", "milarena"):
         return 1.0 / 1000
     return False
 

--- a/tests/test_number_parser_eu.py
+++ b/tests/test_number_parser_eu.py
@@ -1,7 +1,7 @@
 import unittest
 
 from ovos_number_parser import (extract_number, pronounce_number,
-                                 pronounce_ordinal, is_ordinal)
+                                 pronounce_ordinal, is_ordinal, is_fractional)
 from ovos_number_parser.numbers_eu import (extract_number_eu,
                                            pronounce_number_eu,
                                            pronounce_ordinal_eu,
@@ -219,6 +219,26 @@ class TestBasqueOrdinalSweep(unittest.TestCase):
         for text in ["", "garren", "katua", "hogei"]:
             with self.subTest(text=text):
                 self.assertFalse(is_ordinal_eu(text))
+
+
+class TestBasqueFractions(unittest.TestCase):
+    """Basque fraction nouns, including capitalized forms."""
+
+    def test_basic(self):
+        self.assertEqual(is_fractional("erdi", lang="eu"), 0.5)
+        self.assertEqual(is_fractional("heren", lang="eu"), 1.0 / 3)
+        self.assertEqual(is_fractional("laurden", lang="eu"), 0.25)
+        self.assertEqual(is_fractional("ehunen", lang="eu"), 0.01)
+
+    def test_capitalized_input_does_not_crash(self):
+        self.assertEqual(is_fractional("Erdi", lang="eu"), 0.5)
+        self.assertEqual(is_fractional("LAURDEN", lang="eu"), 0.25)
+        self.assertEqual(is_fractional("Ehunen", lang="eu"), 0.01)
+
+    def test_non_fraction_returns_false(self):
+        for word in ["", "kaixo", "bost"]:
+            with self.subTest(word=word):
+                self.assertFalse(is_fractional(word, lang="eu"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`is_fractional_eu` lowercased the input for the `in aFrac` membership test but then looked the value up with the original-case string and compared the higher denominators against the un-lowered input, so a capitalized fraction raised `KeyError`.

Input -> before -> after:
- `Erdi` -> KeyError -> 0.5
- `LAURDEN` -> KeyError -> 0.25
- `Ehunen` -> False -> 0.01

Lowercasing once at the top fixes it. Adds a Basque fraction test class (3 tests).