### PR TITLE
fix: Finnish ordinal recursion on million multiples

### DIFF
--- a/ovos_number_parser/numbers_fi.py
+++ b/ovos_number_parser/numbers_fi.py
@@ -179,11 +179,29 @@ def pronounce_number_fi(number, places=2, short_scale=True, scientific=False,
     return result
 
 
+def _ordinal_multiplier_fi(number):
+    """Ordinal stem of a scale-word multiplier (before "tuhannes"/"miljoonas").
+
+    A bare multiplier takes the compositive ordinal stem rather than the
+    standalone form: 2000th is "kahdestuhannes", not "toinentuhannes". Kotus,
+    Kielitoimiston ohjepankki, "järjestyslukujen taivuttaminen", gives the
+    compound base "kahdeskymmenesyhdes" (21st), showing the compositive stems
+    "yhdes"/"kahdes" carry through compounds instead of "ensimmäinen"/"toinen".
+    """
+    if number in _ORDINAL_UNITS_COMPOUND_FI and number < 10:
+        return _ORDINAL_UNITS_COMPOUND_FI[number]
+    return pronounce_ordinal_fi(number)
+
+
 def pronounce_ordinal_fi(number):
     """
     Pronounce a number as a Finnish ordinal.
 
-    1 -> "ensimmäinen", 2 -> "toinen", 21 -> "kahdeskymmenesensimmäinen"
+    1 -> "ensimmäinen", 2 -> "toinen", 21 -> "kahdeskymmenesensimmäinen",
+    2000 -> "kahdestuhannes", 2000000 -> "kahdesmiljoonas"
+
+    Compound ordinals mark every inflectable part with the compositive ordinal
+    stem (Kotus, Kielitoimiston ohjepankki, "järjestyslukujen taivuttaminen").
 
     Args:
         number (int): the number to format
@@ -213,13 +231,24 @@ def pronounce_ordinal_fi(number):
     if number < 10 ** 6 and number % 1000 == 0:
         thousands = number // 1000
         return 'tuhannes' if thousands == 1 else \
-            pronounce_ordinal_fi(thousands) + 'tuhannes'
-    if number == 10 ** 6:
-        return 'miljoonas'
-    # compose: ordinal prefix from the largest round part + remainder
+            _ordinal_multiplier_fi(thousands) + 'tuhannes'
+    if number < 10 ** 9 and number % 10 ** 6 == 0:
+        millions = number // 10 ** 6
+        return 'miljoonas' if millions == 1 else \
+            _ordinal_multiplier_fi(millions) + 'miljoonas'
+    if number >= 10 ** 9:
+        # above the supported "miljoonas" scale: fall back to digits rather
+        # than composing an unidiomatic mix of words and figures
+        return str(number)
+    # compose: ordinal prefix from the largest round part + remainder.
+    # ``head`` must be a strict prefix of ``number`` or the recursion never
+    # shrinks; an exact multiple of a base is handled by the branches above,
+    # so a base yielding ``head == number`` here is out of representable range.
     for base in (10 ** 6, 1000, 100):
         if number > base:
             head = (number // base) * base
+            if head == number:
+                continue
             return pronounce_ordinal_fi(head) + \
                 pronounce_ordinal_fi(number - head)
     return str(number)

--- a/tests/test_number_parser_fi.py
+++ b/tests/test_number_parser_fi.py
@@ -44,6 +44,27 @@ class TestPronounceNumberFi(unittest.TestCase):
         for n, expected in cases:
             self.assertEqual(pronounce_ordinal(n, "fi"), expected, n)
 
+    def test_ordinals_scale_multiples(self):
+        # a bare scale multiplier takes the compositive ordinal stem
+        # (kahdes-/yhdes-), not the standalone ensimmäinen/toinen forms
+        cases = [(2000, "kahdestuhannes"), (3000, "kolmastuhannes"),
+                 (12000, "kahdestoistatuhannes"),
+                 (200000, "kahdessadastuhannes"),
+                 (2000000, "kahdesmiljoonas"),
+                 (3000000, "kolmasmiljoonas"),
+                 (25000000, "kahdeskymmenesviidesmiljoonas")]
+        for n, expected in cases:
+            self.assertEqual(pronounce_ordinal(n, "fi"), expected, n)
+
+    def test_ordinals_no_recursion_or_crash(self):
+        # exact multiples of a million once triggered unbounded recursion
+        for n in (2000000, 3000000, 999000000):
+            self.assertIsInstance(pronounce_ordinal(n, "fi"), str)
+        # above the supported "miljoonas" scale falls back to digits cleanly
+        self.assertEqual(pronounce_ordinal(10 ** 9, "fi"), "1000000000")
+        self.assertEqual(pronounce_ordinal(999999999999, "fi"),
+                         "999999999999")
+
 
 class TestExtractNumberFi(unittest.TestCase):
     def test_anchors(self):


### PR DESCRIPTION
## Problem

pronounce_ordinal(n, 'fi') recursed without bound for every exact multiple of a million above one million. pronounce_ordinal(2000000, 'fi') — an ordinary number — raised RecursionError; so did 3000000, 25000000, ... 1000000000.

Root cause: the compose loop computed head = (number // base) * base, which equals number when number is an exact multiple of base, so the recursion never shrank.

## Fix

- Add a miljoonas branch mirroring the existing tuhannes one.
- Guard the compose loop against a non-shrinking head.
- Fall back to a plain digit string above the supported million scale (10**9 and up) instead of composing a word/figure mix or recursing.
- A bare scale multiplier now takes the compositive ordinal stem: 2000 -> kahdestuhannes, 2000000 -> kahdesmiljoonas (previously toinentuhannes).

## Source

Formation grounded in Kotus (Institute for the Languages of Finland), Kielitoimiston ohjepankki, 'Luvut ja numerot: järjestyslukujen taivuttaminen', whose compound base form kahdeskymmenesyhdes (21st) shows the compositive stems kahdes/yhdes carry through compounds rather than ensimmäinen/toinen.

## Tests

Added test_ordinals_scale_multiples (correct compositive forms) and test_ordinals_no_recursion_or_crash (regression: no recursion on million multiples, clean digit fallback above scale). Full suite green.