### PR TITLE
fix: robust Arabic numbers for Persian digits and glued punctuation

### DIFF
--- a/ovos_number_parser/__init__.py
+++ b/ovos_number_parser/__init__.py
@@ -225,9 +225,13 @@ def _numbers_to_digits_generic(utterance: str, lang: str) -> str:
     lang2 = lang.lower().split("-")[0]
     connectors = _NUMBER_CONNECTORS.get(lang2, set())
     tokens = utterance.split()
+    # ASCII plus Arabic comma, semicolon and question mark, so a number glued
+    # to punctuation ("٢٠٢٤،", "25.") is still recognised and the mark is
+    # carried over onto the digits instead of being dropped
+    punct = ".,!?;:؟،؛"
 
     def _clean(t):
-        return t.strip(".,!?;:").lower()
+        return t.strip(punct).lower()
 
     def _is_num(t):
         c = _clean(t)
@@ -271,7 +275,7 @@ def _numbers_to_digits_generic(utterance: str, lang: str) -> str:
                 break
         span = " ".join(_clean(t) for t in tokens[i:j + 1])
         val = extract_number(span, lang)
-        stripped = tokens[j].rstrip(".,!?;:")
+        stripped = tokens[j].rstrip(punct)
         trail = tokens[j][len(stripped):]
         if isinstance(val, float) and val.is_integer():
             val = int(val)

--- a/ovos_number_parser/numbers_ar.py
+++ b/ovos_number_parser/numbers_ar.py
@@ -4,17 +4,21 @@ Pronunciation defaults to the masculine citation forms (the forms used for
 counting in the abstract). Extraction accepts both genders, since Arabic
 numerals 3-10 take the opposite gender of the counted noun (gender
 polarity), both nominative and oblique dual/plural case endings
-(``اثنان``/``اثنين``, ``عشرون``/``عشرين``), and both Western (0-9) and
-Eastern Arabic-Indic (٠-٩) digits.
+(``اثنان``/``اثنين``, ``عشرون``/``عشرين``), Western (0-9), Eastern
+Arabic-Indic (٠-٩) and Persian/Urdu (۰-۹) digits, and numbers written
+immediately adjacent to punctuation (``٢٠٢٤،``, ``25.``).
 """
 
 from ovos_number_parser.util import convert_to_mixed_fraction
 
 _AR_SEPARATOR = " و"  # the conjunction attaches to the following word
 
-# Arabic-Indic digits and decimal/thousands separators, hamza/taa
-# normalization and diacritics stripping used to match typed variants
+# Arabic-Indic and Persian (extended Arabic-Indic) digits, decimal/thousands
+# separators, hamza/taa normalization and diacritics stripping used to match
+# typed variants
 _NORM_TABLE = {ord(e): w for e, w in zip("٠١٢٣٤٥٦٧٨٩", "0123456789")}
+# Persian / Urdu digits (U+06F0..U+06F9) carry the same values as 0-9
+_NORM_TABLE.update({ord(e): w for e, w in zip("۰۱۲۳۴۵۶۷۸۹", "0123456789")})
 _NORM_TABLE[ord("٫")] = "."  # Arabic decimal separator
 _NORM_TABLE[ord("٬")] = None  # Arabic thousands separator
 _NORM_TABLE[ord("أ")] = "ا"

--- a/tests/test_number_parser_ar.py
+++ b/tests/test_number_parser_ar.py
@@ -153,6 +153,54 @@ class TestArabicExtract(unittest.TestCase):
             numbers_to_digits("لدي خمسة وعشرون قطة", lang="ar"),
             "لدي 25 قطة")
 
+
+class TestArabicRobustDigits(unittest.TestCase):
+    """Robustness to Persian/Arabic-Indic digits and glued punctuation."""
+
+    def test_persian_digits(self):
+        # Persian/Urdu (extended Arabic-Indic) digits carry 0-9 values
+        self.assertEqual(extract_number("۲۵", lang="ar"), 25)
+        self.assertEqual(extract_number("۱۹۸۵", lang="ar"), 1985)
+        self.assertEqual(extract_number("عندي ۳ قطط", lang="ar"), 3)
+        self.assertAlmostEqual(extract_number("۵٫۲", lang="ar"), 5.2)
+
+    def test_punctuation_glued_digits(self):
+        # a number glued to an Arabic comma/semicolon/question mark or an
+        # ASCII period is still recognised as a number
+        for text, value in [("10،", 10), ("25.", 25), ("٢٥؛", 25),
+                             ("۲۰۲۴،", 2024), ("۳؟", 3),
+                             ("لدي ٢٥، كتاب", 25)]:
+            with self.subTest(text=text):
+                self.assertEqual(extract_number(text, lang="ar"), value)
+
+    def test_regression_clean_and_decimal(self):
+        # clean integers and decimals keep working unchanged
+        self.assertEqual(extract_number("٢٥", lang="ar"), 25)
+        self.assertEqual(extract_number("مئة وثلاثة وعشرون", lang="ar"), 123)
+        self.assertAlmostEqual(extract_number("٥٫٢", lang="ar"), 5.2)
+        self.assertEqual(extract_number("سالب سبعة", lang="ar"), -7)
+
+
+class TestArabicNumbersToDigitsRobust(unittest.TestCase):
+    """Verbalizing digits inside text keeps adjacent punctuation."""
+
+    def test_persian_and_arabic_indic_digits(self):
+        self.assertEqual(
+            numbers_to_digits("الرقم ٢٠٢٤", lang="ar"), "الرقم 2024")
+        self.assertEqual(
+            numbers_to_digits("عندي ۳ قطط", lang="ar"), "عندي 3 قطط")
+
+    def test_glued_punctuation_is_reattached(self):
+        # the Arabic comma / semicolon must survive verbalization, not vanish
+        self.assertEqual(
+            numbers_to_digits("لدي ٢٥، كتاب", lang="ar"), "لدي 25، كتاب")
+        self.assertEqual(
+            numbers_to_digits("لدي خمسة؛ كتب", lang="ar"), "لدي 5؛ كتب")
+        self.assertEqual(
+            numbers_to_digits("السنة ۱۹۸۵.", lang="ar"), "السنة 1985.")
+        self.assertEqual(
+            numbers_to_digits("خمسة وعشرون كتاباً", lang="ar"), "25 كتاباً")
+
     def test_extract_dual_nouns(self):
         # the dual of common counting nouns carries the value 2 lexically
         for spoken in ["يومين", "يومان", "ساعتين", "ساعتان", "دقيقتين",


### PR DESCRIPTION
Arabic number handling is now robust to two common real-text conditions.

Persian/Urdu digits (U+06F0..U+06F9) are mapped to ASCII 0-9 in the Arabic normalization table alongside the Arabic-Indic digits already handled, so they are converted before any numeric parsing.

A numeric token written immediately next to an Arabic comma, semicolon or question mark, or an ASCII period, is recognised as a number, and when verbalizing digits inside text the adjacent punctuation is carried over onto the emitted digits instead of being dropped.

Clean integers, decimals, thousands separators and negatives keep their existing behavior. Tests cover Persian and Arabic-Indic digits, punctuation-glued numbers, punctuation re-attachment, and clean/decimal/negative regressions. Full suite green.