### PR TITLE
fix: match Catalan fraction words case-insensitively

### DIFF
--- a/ovos_number_parser/numbers_ca.py
+++ b/ovos_number_parser/numbers_ca.py
@@ -518,6 +518,7 @@ def is_fractional_ca(input_str, short_scale=True):
         (bool) or (float): False if not a fraction, otherwise the fraction
 
     """
+    input_str = input_str.lower()
     if input_str.endswith('é', -1):
         input_str = input_str[:len(input_str) - 1] + "è"  # e.g. "cinqué -> cinquè"
     elif input_str.endswith('ena', -3):
@@ -545,7 +546,7 @@ def is_fractional_ca(input_str, short_scale=True):
              "desè", "onzè", "dotzè", "tretzè", "catorzè", "quinzè", "setzè",
              "dissetè", "divuitè", "dinovè"]
 
-    if input_str.lower() in aFrac:
+    if input_str in aFrac:
         return 1.0 / (aFrac.index(input_str) + 2)
     if input_str == "vintè":
         return 1.0 / 20

--- a/tests/test_number_parser_ca.py
+++ b/tests/test_number_parser_ca.py
@@ -1,6 +1,6 @@
 import unittest
 
-from ovos_number_parser import extract_number, pronounce_number
+from ovos_number_parser import extract_number, pronounce_number, is_fractional
 
 
 class TestCatalanPronounce(unittest.TestCase):
@@ -56,6 +56,28 @@ class TestCatalanRoundTrip(unittest.TestCase):
             with self.subTest(number=number):
                 spoken = pronounce_number(number, lang="ca")
                 self.assertEqual(extract_number(spoken, lang="ca"), number)
+
+
+class TestCatalanFractions(unittest.TestCase):
+    """Catalan fraction nouns, gendered/plural and capitalized forms."""
+
+    def test_basic_and_inflected(self):
+        self.assertEqual(is_fractional("mig", lang="ca"), 0.5)
+        self.assertEqual(is_fractional("mitja", lang="ca"), 0.5)
+        self.assertEqual(is_fractional("terç", lang="ca"), 1.0 / 3)
+        self.assertEqual(is_fractional("quart", lang="ca"), 0.25)
+        self.assertEqual(is_fractional("quarta", lang="ca"), 0.25)
+        self.assertEqual(is_fractional("centè", lang="ca"), 0.01)
+
+    def test_capitalized_input_does_not_crash(self):
+        self.assertEqual(is_fractional("Mig", lang="ca"), 0.5)
+        self.assertEqual(is_fractional("QUART", lang="ca"), 0.25)
+        self.assertEqual(is_fractional("Centè", lang="ca"), 0.01)
+
+    def test_non_fraction_returns_false(self):
+        for word in ["", "hola", "cinc"]:
+            with self.subTest(word=word):
+                self.assertFalse(is_fractional(word, lang="ca"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`is_fractional_ca` lowercased the input only for the `in aFrac` membership test, then called `aFrac.index(input_str)` on the original-case string. A capitalized fraction passed the membership test (lowered) but raised `ValueError: 'Mig' is not in list` on the index lookup.

Input -> before -> after:
- `Mig` -> ValueError -> 0.5
- `QUART` -> ValueError -> 0.25
- `Centè` -> False -> 0.01

Lowercasing once at the top fixes the crash and makes the suffix normalization and higher-denominator branches case-insensitive. Adds a Catalan fraction test class (3 tests).