### PR TITLE
fix: Frisian zeroth ordinal raises KeyError

### DIFF
--- a/ovos_number_parser/numbers_fy.py
+++ b/ovos_number_parser/numbers_fy.py
@@ -334,8 +334,10 @@ def pronounce_ordinal_fy(number):
     if number in _SHORT_ORDINAL_STRING_FY:
         return _SHORT_ORDINAL_STRING_FY[number]
     # compounds: cardinal + table-driven last element, mirroring the
-    # cardinal compounding ("ienentweintich" -> "ienentweintichste")
-    if number < 100:
+    # cardinal compounding ("ienentweintich" -> "ienentweintichste").
+    # zero has no compound tens element, so it takes the regular suffix
+    # like the sibling Dutch "nulste"
+    if 0 < number < 100:
         ones = number % 10
         tens = number - ones
         return _NUM_STRING_FY[ones] + "en" + _ORDINAL_STRING_BASE_FY[tens]

--- a/tests/test_number_parser_fy.py
+++ b/tests/test_number_parser_fy.py
@@ -45,6 +45,11 @@ class TestWestFrisianPronounce(unittest.TestCase):
             with self.subTest(number=number):
                 self.assertEqual(pronounce_ordinal(number, lang="fy"), spoken)
 
+    def test_pronounce_ordinal_zero(self):
+        # zeroth previously raised KeyError in the compound branch; it now
+        # takes the regular suffix like the sibling Dutch "nulste"
+        self.assertEqual(pronounce_ordinal(0, lang="fy"), "nulste")
+
 
 class TestWestFrisianExtract(unittest.TestCase):
     """Anchors for extracting numbers from West Frisian text."""


### PR DESCRIPTION
## Problem

pronounce_ordinal(0, 'fy') raised KeyError. Zero fell into the two-digit compound branch, which looks up _ORDINAL_STRING_BASE_FY[0] — a key that does not exist.

## Fix

Restrict the compound branch to 1..99 so zero instead takes the regular cardinal + 'ste' suffix path already used for larger numbers, yielding 'nulste'. This matches the sibling Dutch pronounce_ordinal_nl(0) -> 'nulste'.

## Tests

Added test_pronounce_ordinal_zero. Frisian and generic-fallback suites green.