### PR TITLE
fix: accumulate Slovak million and hundred-thousand groups

### DIFF
--- a/ovos_number_parser/numbers_sk.py
+++ b/ovos_number_parser/numbers_sk.py
@@ -612,7 +612,7 @@ def _extract_whole_number_with_text_sk(tokens, short_scale, ordinals):
                 break
             prev_val = val
 
-            if word in multiplies and next_word not in multiplies:
+            if word in multiplies:
                 # handle long numbers: if all remaining scale words are
                 # smaller than the current one, set the current value aside
                 # and start assembling the next portion
@@ -659,6 +659,14 @@ def _initialize_number_data_sk(short_scale):
 def extract_number_sk(text, short_scale=True, ordinals=False):
     """
     This function extracts a number from a text string
+
+    Numeral structure follows the Rules of Slovak Orthography
+    (Pravidlá slovenského pravopisu, Jazykovedný ústav Ľudovíta Štúra SAV,
+    3rd ed. 2000): the million/milliard groups are separate lexical words that
+    multiply the group before them, while the thousand and hundred groups form
+    their own additive portions ("dvestopäťdesiattritisíc štyristo dvadsaťosem").
+    Each such group is set aside and summed independently, so a millions group
+    followed by a hundred-thousands group accumulates correctly.
 
     Args:
         text (str): the string to normalize
@@ -762,6 +770,11 @@ def pronounce_number_sk(number, places=2, short_scale=True, scientific=False,
     Convert a number to its spoken Slovak equivalent
 
     For example, '5.2' would return 'päť celá dva'
+
+    Word forms follow the Rules of Slovak Orthography (Pravidlá slovenského
+    pravopisu, Jazykovedný ústav Ľudovíta Štúra SAV, 3rd ed. 2000): million and
+    milliard groups are spoken as separate words, so the output round-trips
+    through extract_number_sk.
 
     Args:
         number(float or int): the number to pronounce

--- a/tests/test_number_parser_sk.py
+++ b/tests/test_number_parser_sk.py
@@ -140,5 +140,41 @@ class TestSlovakRoundTrip(unittest.TestCase):
                 self.assertEqual(extract_number(spoken, lang="sk"), number)
 
 
+class TestSlovakScaleAccumulation(unittest.TestCase):
+    """Millions combined with hundred-thousands must accumulate correctly.
+
+    Anchored on the Rules of Slovak Orthography (Pravidlá slovenského
+    pravopisu, JÚĽŠ SAV): million groups are separate words and the
+    thousand/hundred groups form their own additive portions.
+    """
+
+    def test_million_plus_hundred_thousands_anchor(self):
+        # "jeden milión päťsto tisíc" = 1 500 000
+        self.assertEqual(pronounce_number(1500000, lang="sk"),
+                         "jeden milión päťsto tisíc")
+        self.assertEqual(extract_number("jeden milión päťsto tisíc",
+                                        lang="sk"), 1500000)
+
+    def test_million_thousand_hundred_round_trip(self):
+        for number in [1000500, 1100000, 1200000, 1500000, 8186976,
+                       2500000, 9999999, 10000000, 1186976]:
+            with self.subTest(number=number):
+                spoken = pronounce_number(number, lang="sk")
+                self.assertEqual(extract_number(spoken, lang="sk"), number)
+
+    def test_negative_scale_round_trip(self):
+        for number in [-9997, -1499, -1500000, -8186976, -104979, -1000500]:
+            with self.subTest(number=number):
+                spoken = pronounce_number(number, lang="sk")
+                self.assertEqual(extract_number(spoken, lang="sk"), number)
+
+    def test_property_round_trip_both_signs(self):
+        for base in range(0, 10000001, 5417):
+            for number in (base, -base):
+                spoken = pronounce_number(number, lang="sk")
+                self.assertEqual(extract_number(spoken, lang="sk"), number,
+                                 msg=f"round-trip failed for {number}: {spoken!r}")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem

`extract_number(pronounce_number(n))` did not round-trip for Slovak numbers that combine a millions group with a following hundred-thousands group:

| n | pronounce | extracted (before) |
|---|---|---|
| 1500000 | jeden milión päťsto tisíc | 1001500 |
| 8186976 | osem miliónov sto osemdesiatšesť tisíc deväťsto sedemdesiatšesť | 1976 |

## Root cause

The whole-number extractor only set a scale group aside (`to_sum`) when the *next* token was not itself a scale word. When a million group was immediately followed by `päťsto` (a compound hundred word) it was never set aside, so the hundred-thousands and thousands values were folded into the running million sum instead of forming independent additive portions.

## Fix

Set the current scale group aside whenever every remaining scale word is smaller than it (the `time_to_sum` scan already computes exactly this), regardless of whether the very next token is a scale word.

This is the shared extractor-accumulation root also present in the Czech, Turkish and Azerbaijani parsers; each ships as its own PR.

## Source

Numeral structure cross-checked against the Rules of Slovak Orthography (*Pravidlá slovenského pravopisu*, Jazykovedný ústav Ľudovíta Štúra SAV, 3rd ed. 2000): million/milliard groups are separate words that multiply the preceding group, while thousand and hundred groups form their own additive portions ("dvestopäťdesiattritisíc štyristo dvadsaťosem"). Cited in the `extract_number_sk` and `pronounce_number_sk` docstrings.

## Tests

New `TestSlovakScaleAccumulation`: the 1500000 anchor, million+thousand+hundred round-trips, negative-scale round-trips, and a property round-trip over 0..10,000,000 for both signs. Full suite green.