### PR TITLE
fix: match Swedish fraction words case-insensitively

### DIFF
--- a/ovos_number_parser/numbers_sv.py
+++ b/ovos_number_parser/numbers_sv.py
@@ -678,6 +678,7 @@ def is_fractional_sv(input_str, short_scale=True):
         (bool) or (float): False if not a fraction, otherwise the fraction
 
     """
+    input_str = input_str.lower()
     if input_str.endswith('ars', -3):
         input_str = input_str[:len(input_str) - 3]  # e.g. "femtedelar"
     if input_str.endswith('ar', -2):
@@ -690,7 +691,7 @@ def is_fractional_sv(input_str, short_scale=True):
     aFrac = ["hel", "halv", "tredjedel", "fjärdedel", "femtedel", "sjättedel",
              "sjundedel", "åttondel", "niondel", "tiondel", "elftedel",
              "tolftedel"]
-    if input_str.lower() in aFrac:
+    if input_str in aFrac:
         return 1.0 / (aFrac.index(input_str) + 1)
     if input_str == "kvart":
         return 1.0 / 4

--- a/tests/test_number_parser_sv.py
+++ b/tests/test_number_parser_sv.py
@@ -1,7 +1,29 @@
 import unittest
 
-from ovos_number_parser import extract_number, pronounce_number
+from ovos_number_parser import extract_number, pronounce_number, is_fractional
 from ovos_number_parser.numbers_sv import pronounce_ordinal_sv
+
+
+class TestSwedishFractions(unittest.TestCase):
+    """Swedish fraction nouns, including inflected and capitalized forms."""
+
+    def test_basic_and_inflected(self):
+        self.assertEqual(is_fractional("halv", lang="sv"), 0.5)
+        self.assertEqual(is_fractional("halva", lang="sv"), 0.5)
+        self.assertEqual(is_fractional("tredjedel", lang="sv"), 1.0 / 3)
+        self.assertEqual(is_fractional("fjärdedel", lang="sv"), 0.25)
+        self.assertEqual(is_fractional("kvart", lang="sv"), 0.25)
+        self.assertEqual(is_fractional("trekvart", lang="sv"), 0.75)
+
+    def test_capitalized_input_does_not_crash(self):
+        self.assertEqual(is_fractional("Halv", lang="sv"), 0.5)
+        self.assertEqual(is_fractional("HALV", lang="sv"), 0.5)
+        self.assertEqual(is_fractional("Kvart", lang="sv"), 0.25)
+
+    def test_non_fraction_returns_false(self):
+        for word in ["", "hej", "fem"]:
+            with self.subTest(word=word):
+                self.assertFalse(is_fractional(word, lang="sv"))
 
 
 class TestSwedishOrdinals(unittest.TestCase):


### PR DESCRIPTION
`is_fractional_sv` lowercased the input only for the `in aFrac` membership test, then called `aFrac.index(input_str)` and compared `kvart`/`trekvart` against the original-case string.

Input -> before -> after:
- `Halv` -> ValueError -> 0.5
- `HALV` -> ValueError -> 0.5
- `Kvart` -> False -> 0.25

Lowercasing once at the top fixes the crash and the silently-missed `kvart`/`trekvart`. Adds a Swedish fraction test class (3 tests).