### PR TITLE
fix: Basque negative ordinal raises bare KeyError

### DIFF
--- a/ovos_number_parser/numbers_eu.py
+++ b/ovos_number_parser/numbers_eu.py
@@ -312,8 +312,13 @@ def pronounce_ordinal_eu(num):
     1-10 use the attested table (1st suppletive ``lehenengo``). Above ten the
     suffix attaches to the cardinal's final element, with the euphonic
     ``bost`` -> ``bos`` drop (``hamabost`` -> ``hamabosgarren``).
+
+    Raises:
+        ValueError: for negative numbers, which have no ordinal form.
     """
     num = int(num)
+    if num < 0:
+        raise ValueError(f"Basque ordinals are not defined for {num}")
     if num in ORDINAL_BASE_EU:
         return ORDINAL_BASE_EU[num]
     words = _spell_cardinal_eu(num).split()

--- a/tests/test_number_parser_eu.py
+++ b/tests/test_number_parser_eu.py
@@ -66,6 +66,14 @@ class TestBasqueOrdinals(unittest.TestCase):
             with self.subTest(number=number):
                 self.assertEqual(pronounce_ordinal(number, lang="eu"), spoken)
 
+    def test_pronounce_ordinal_negative(self):
+        # negatives previously raised a bare KeyError from the cardinal
+        # speller; they now fail cleanly with a ValueError
+        for number in (-1, -5):
+            with self.subTest(number=number):
+                with self.assertRaises(ValueError):
+                    pronounce_ordinal(number, lang="eu")
+
     def test_is_ordinal(self):
         self.assertEqual(is_ordinal("hamaseigarren", lang="eu"), 16)
         self.assertEqual(is_ordinal("bosgarren", lang="eu"), 5)


### PR DESCRIPTION
## Problem

pronounce_ordinal(-1, 'eu') raised a bare KeyError from the internal cardinal speller instead of failing cleanly.

## Fix

Negatives have no ordinal form, so reject them up front with a ValueError('Basque ordinals are not defined for ...'). Positive and zero behavior is unchanged.

## Tests

Added test_pronounce_ordinal_negative. Basque suite green.