### PR TITLE
fix: split Danish scale compounds on atoms and keep the negative sign

### DIFF
--- a/ovos_number_parser/numbers_da.py
+++ b/ovos_number_parser/numbers_da.py
@@ -103,9 +103,9 @@ _NUM_STRING_DA = {
     20: 'tyve',
     30: 'tredive',
     40: 'fyrre',
-    50: 'halvtres',
+    50: 'halvtreds',
     60: 'tres',
-    70: 'halvfjers',
+    70: 'halvfjerds',
     80: 'firs',
     90: 'halvfems',
     100: 'hundrede',
@@ -183,6 +183,35 @@ for number, item in _LONG_SCALE.items():
         name = item + 'er'
         _MULTIPLIER.add(name)
         _STRING_LONG_SCALE[name] = number
+
+# Base morphemes for splitting spaceless Danish compounds. Danish writes a
+# whole number below a million as one word, so a hundreds group and its scale
+# word run together ("ethundredeettusinde" = 101 * 1000). Splitting must use
+# atoms and never precomposed forms such as "ettusinde" (= 1*1000) or
+# "ethundrede" (= 100): a greedy longest match on those swallows the connecting
+# unit, so "ethundredeettusinde" would split as "ethundrede" + "ettusinde"
+# (100 + 1000 = 100000) and lose the 101. On atoms it splits as
+# et + hundrede + et + tusinde and keeps the 101.
+_DA_ATOM_VALUES = {
+    'nul': 0, 'en': 1, 'et': 1, 'to': 2, 'tre': 3, 'fire': 4, 'fem': 5,
+    'seks': 6, 'syv': 7, 'otte': 8, 'ni': 9, 'ti': 10, 'elve': 11,
+    'elleve': 11, 'tolv': 12, 'tretten': 13, 'fjorten': 14, 'femten': 15,
+    'seksten': 16, 'sytten': 17, 'atten': 18, 'nitten': 19, 'tyve': 20,
+    'tredive': 30, 'fyrre': 40, 'halvtres': 50, 'halvtreds': 50, 'tres': 60,
+    'halvfjers': 70, 'halvfjerds': 70, 'firs': 80, 'halvfems': 90,
+}
+# The vigesimal-derived tens (halvtreds = 50, tres = 60, halvfjerds = 70,
+# firs = 80, halvfems = 90) are atoms in their own right; the ones digit is
+# spoken first and joined with "og" ("fireogtyve" = 4 og 20 = 24).
+_DA_SCALE_VALUES = {'hundrede': 100, 'hunderede': 100,
+                    'tusinde': 1000, 'tusind': 1000}
+for _scale_number, _scale_word in _LONG_SCALE.items():
+    if int(_scale_number) >= 1000000:
+        _DA_SCALE_VALUES[_scale_word] = _scale_number
+        _DA_SCALE_VALUES[_scale_word + 'er'] = _scale_number
+
+_DA_SPLIT_KEYS = sorted(set(_DA_ATOM_VALUES) | set(_DA_SCALE_VALUES),
+                        key=len, reverse=True)
 
 _FRACTION_MARKER = set()
 
@@ -302,6 +331,14 @@ def pronounce_number_da(number, places=2, short_scale=True, scientific=False,
     Convert a number to it's spoken equivalent
 
     For example, '5.2' would return 'five point two'
+
+    Danish writes a whole number below a million as a single spaceless word and
+    uses the vigesimal-derived tens prescribed by Dansk Sprognævn, svarbase
+    SV00000047 "De danske tal; halvtreds"
+    (https://sproget.dk/raad-og-regler/artikler-mv/svarbase/sv00000047/):
+    halvtreds (50), tres (60), halvfjerds (70), firs (80), halvfems (90), each a
+    shortened -sindstyve ("times twenty") form. The ones digit precedes the tens
+    and is joined with "og" ("fireogtyve" = 24).
 
     Args:
         number(float or int): the number to pronounce (under 100)
@@ -611,10 +648,13 @@ def _extract_real_number_with_text_da(tokens, short_scale):
             if _val is not None:
                 to_sum.append(_val)
             if to_sum:
-                if to_sum[0] < 0:
-                    val = to_sum[0] - sum(to_sum[1:])
-                else:
-                    val = sum(to_sum)
+                # a leading "minus" negates the whole magnitude even when the
+                # sign never reached the summed parts, as with a scaled group
+                # ("minus en million" -> the product is 1000000, not -1000000
+                # until the marker is reapplied here)
+                magnitude = sum(abs(part) for part in to_sum)
+                val = -magnitude if any(t.word in _NEGATIVES
+                                        for t in number_words) else magnitude
 
             if number_words and (not all([w in _ARTICLES | _NEGATIVES
                                           | _NUMBER_CONNECTORS for w in words_only])
@@ -689,11 +729,12 @@ def _extract_real_number_with_text_da(tokens, short_scale):
             _val = _current_val = None
 
         if not next_word and number_words:
-            if to_sum and to_sum[0] < 0:
-                # negated number: components extend the magnitude
-                val = to_sum[0] - sum(to_sum[1:])
+            if to_sum:
+                magnitude = sum(abs(part) for part in to_sum)
+                val = -magnitude if any(t.word in _NEGATIVES
+                                        for t in number_words) else magnitude
             else:
-                val = sum(to_sum) if to_sum else _val
+                val = _val
 
     return val, number_words
 
@@ -792,23 +833,23 @@ def _split_compound_number_da(word):
     Split a Danish compound number word into its component number words.
 
     "toogfyrre" -> ["to", "og", "fyrre"]
-    "nihundredenioghalvfems" -> ["nihundrede", "ni", "og", "halvfems"]
+    "ethundredeettusinde" -> ["et", "hundrede", "et", "tusinde"]
+
+    Splitting is on base atoms and scale morphemes, so a connecting unit digit
+    between a hundreds group and its scale word is preserved instead of being
+    swallowed by a precomposed form.
 
     Returns None if the word is not composed purely of known number words.
     """
     if word in _DA_NUMBERS:
         return None
-    keys = sorted(set(_DA_NUMBERS) | set(_STRING_LONG_SCALE),
-                  key=len, reverse=True)
     parts, rest = [], word
     while rest:
         if rest.startswith("og") and parts:
-            candidate = rest[2:]
-            if any(candidate.startswith(k) for k in keys):
-                parts.append("og")
-                rest = candidate
-                continue
-        for k in keys:
+            parts.append("og")
+            rest = rest[2:]
+            continue
+        for k in _DA_SPLIT_KEYS:
             if rest.startswith(k):
                 parts.append(k)
                 rest = rest[len(k):]
@@ -819,20 +860,27 @@ def _split_compound_number_da(word):
 
 
 def _compound_value_da(parts):
-    """Evaluate the numeric value of a split compound number word."""
+    """Evaluate the numeric value of a split compound number word.
+
+    A scale morpheme multiplies the group built so far: "hundrede" scales the
+    running hundreds group, while "tusinde" and larger bank the product and
+    open a fresh group, so "et hundrede et tusinde" evaluates 101 * 1000.
+    """
     total = current = 0
     for p in parts:
         if p == "og":
             continue
-        v = _DA_NUMBERS.get(p)
+        v = _DA_ATOM_VALUES.get(p)
+        is_scale = False
         if v is None:
-            v = _STRING_LONG_SCALE.get(p)
+            v = _DA_SCALE_VALUES.get(p)
+            is_scale = True
         if v is None:
             return None
-        if v >= 1000:
+        if is_scale and v >= 1000:
             total += max(current, 1) * v
             current = 0
-        elif v == 100:
+        elif is_scale and v == 100:
             current = max(current, 1) * 100
         else:
             current += v
@@ -855,6 +903,14 @@ def _expand_compound_numbers_da(text):
 def extract_number_da(text, short_scale=False, ordinals=False):
     """
     This function extracts a number from a text string
+
+    Spaceless Danish compounds are split on base atoms and scale morphemes so a
+    unit digit joining a hundreds group to its scale word is preserved
+    ("ethundredeettusinde" = 101 * 1000, not 100 + 1000). The tens follow the
+    vigesimal forms prescribed by Dansk Sprognævn, svarbase SV00000047
+    (https://sproget.dk/raad-og-regler/artikler-mv/svarbase/sv00000047/):
+    halvtreds (50), tres (60), halvfjerds (70), firs (80), halvfems (90); the
+    older -sindstyve spellings are also accepted.
 
     Args:
         text (str): the string to normalize

--- a/tests/test_number_parser_da.py
+++ b/tests/test_number_parser_da.py
@@ -7,7 +7,7 @@ class TestDanishPronounce(unittest.TestCase):
     """Anchors for spoken Danish numbers."""
 
     def test_pronounce_number(self):
-        expected = {0: 'nul', 1: 'en', 2: 'to', 3: 'tre', 4: 'fire', 5: 'fem', 6: 'seks', 7: 'syv', 8: 'otte', 9: 'ni', 10: 'ti', 11: 'elve', 12: 'tolv', 13: 'tretten', 14: 'fjorten', 15: 'femten', 16: 'seksten', 17: 'sytten', 18: 'atten', 19: 'nitten', 20: 'tyve', 21: 'enogtyve', 30: 'tredive', 42: 'toogfyrre', 50: 'halvtres', 66: 'seksogtres', 70: 'halvfjers', 80: 'firs', 90: 'halvfems', 99: 'nioghalvfems', 100: 'ethundrede', 101: 'ethundredeet', 123: 'ethundredetreogtyve', 200: 'tohundrede', 500: 'femhundrede', 999: 'nihundredenioghalvfems', 1000: 'ettusinde', 2000: 'totusinde', 2023: 'totusindetreogtyve', 1000000: 'en million ', 2000000: 'to millioner '}
+        expected = {0: 'nul', 1: 'en', 2: 'to', 3: 'tre', 4: 'fire', 5: 'fem', 6: 'seks', 7: 'syv', 8: 'otte', 9: 'ni', 10: 'ti', 11: 'elve', 12: 'tolv', 13: 'tretten', 14: 'fjorten', 15: 'femten', 16: 'seksten', 17: 'sytten', 18: 'atten', 19: 'nitten', 20: 'tyve', 21: 'enogtyve', 30: 'tredive', 42: 'toogfyrre', 50: 'halvtreds', 66: 'seksogtres', 70: 'halvfjerds', 80: 'firs', 90: 'halvfems', 99: 'nioghalvfems', 100: 'ethundrede', 101: 'ethundredeet', 123: 'ethundredetreogtyve', 200: 'tohundrede', 500: 'femhundrede', 999: 'nihundredenioghalvfems', 1000: 'ettusinde', 2000: 'totusinde', 2023: 'totusindetreogtyve', 1000000: 'en million ', 2000000: 'to millioner '}
         for number, spoken in expected.items():
             with self.subTest(number=number):
                 self.assertEqual(pronounce_number(number, lang="da"), spoken)
@@ -23,7 +23,7 @@ class TestDanishExtract(unittest.TestCase):
     """Anchors for extracting numbers from Danish text."""
 
     def test_extract_number(self):
-        expected = {0: 'nul', 1: 'en', 2: 'to', 3: 'tre', 4: 'fire', 5: 'fem', 6: 'seks', 7: 'syv', 8: 'otte', 9: 'ni', 10: 'ti', 11: 'elve', 12: 'tolv', 13: 'tretten', 14: 'fjorten', 15: 'femten', 16: 'seksten', 17: 'sytten', 18: 'atten', 19: 'nitten', 20: 'tyve', 21: 'enogtyve', 30: 'tredive', 42: 'toogfyrre', 50: 'halvtres', 66: 'seksogtres', 70: 'halvfjers', 80: 'firs', 90: 'halvfems', 99: 'nioghalvfems', 100: 'ethundrede', 101: 'ethundredeet', 123: 'ethundredetreogtyve', 200: 'tohundrede', 500: 'femhundrede', 999: 'nihundredenioghalvfems', 1000: 'ettusinde', 2000: 'totusinde', 2023: 'totusindetreogtyve', 1000000: 'en million ', 2000000: 'to millioner '}
+        expected = {0: 'nul', 1: 'en', 2: 'to', 3: 'tre', 4: 'fire', 5: 'fem', 6: 'seks', 7: 'syv', 8: 'otte', 9: 'ni', 10: 'ti', 11: 'elve', 12: 'tolv', 13: 'tretten', 14: 'fjorten', 15: 'femten', 16: 'seksten', 17: 'sytten', 18: 'atten', 19: 'nitten', 20: 'tyve', 21: 'enogtyve', 30: 'tredive', 42: 'toogfyrre', 50: 'halvtreds', 66: 'seksogtres', 70: 'halvfjerds', 80: 'firs', 90: 'halvfems', 99: 'nioghalvfems', 100: 'ethundrede', 101: 'ethundredeet', 123: 'ethundredetreogtyve', 200: 'tohundrede', 500: 'femhundrede', 999: 'nihundredenioghalvfems', 1000: 'ettusinde', 2000: 'totusinde', 2023: 'totusindetreogtyve', 1000000: 'en million ', 2000000: 'to millioner '}
         for number, spoken in expected.items():
             with self.subTest(spoken=spoken):
                 self.assertEqual(extract_number(spoken, lang="da"), number)
@@ -38,6 +38,28 @@ class TestDanishExtract(unittest.TestCase):
         self.assertEqual(extract_number('jeg har enogtyve katte', lang="da"),
                          21)
 
+    def test_extract_concatenated_scale_groups(self):
+        # Danish writes a whole number below a million as one spaceless word,
+        # so a hundreds group runs straight into its scale word. The tens use
+        # the vigesimal forms prescribed by Dansk Sprognævn (SV00000047):
+        # halvtreds 50, tres 60, halvfjerds 70, firs 80, halvfems 90.
+        expected = {
+            'ethundredeettusinde': 101000,
+            'firehundredefiretusinde': 404000,
+            'otte millioner firehundredefiretusindeethundredefireogtyve':
+                8404124,
+            'to millioner femhundredetusinde': 2500000,
+            'enogtyvetusinde': 21000,
+            'nihundredenioghalvfems': 999,
+            'halvtreds': 50,
+            'halvfjerds': 70,
+            'minus en million': -1000000,
+            'minus to millioner femhundredetusinde': -2500000,
+        }
+        for spoken, number in expected.items():
+            with self.subTest(spoken=spoken):
+                self.assertEqual(extract_number(spoken, lang="da"), number)
+
     def test_no_number(self):
         self.assertIn(extract_number("hej hvordan går det", lang="da"), (False, None))
 
@@ -46,13 +68,15 @@ class TestDanishRoundTrip(unittest.TestCase):
     """pronounce_number output must be understood by extract_number."""
 
     def test_round_trip(self):
-        for number in [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 201, 222, 300, 345, 400, 456, 500, 678, 700, 891, 900, 1000, 1001, 1234, 2000, 2023, 5000, 9999, 10000, 100000, 1000000, 2000000]:
+        for number in [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 201, 222, 300, 345, 400, 456, 500, 678, 700, 891, 900, 1000, 1001, 1234, 2000, 2023, 5000, 9999, 10000, 100000, 101000, 1000000, 1001000, 2000000, 2500000,
+                       8404124, 9999999]:
             with self.subTest(number=number):
                 spoken = pronounce_number(number, lang="da")
                 self.assertEqual(extract_number(spoken, lang="da"), number)
 
     def test_round_trip_negative_and_decimal(self):
-        for number in [-7, -42, 2.5, 3.14, -3.5, 0.5]:
+        for number in [-7, -42, 2.5, 3.14, -3.5, 0.5, -101000, -1000000,
+                       -2500000, -8404124]:
             with self.subTest(number=number):
                 spoken = pronounce_number(number, lang="da")
                 self.assertEqual(extract_number(spoken, lang="da"), number)


### PR DESCRIPTION
Round-trip pronounce→extract failed for Danish once a number crossed into the hundred-thousands, and every negative that carried a scale word lost its sign.

## Bugs
Danish writes a whole number below a million as one spaceless word, so a hundreds group runs straight into its scale word. The extractor split these greedily and matched precomposed forms such as `ettusinde` (1000) ahead of `et` + `tusinde`, swallowing the connecting unit:

- `ethundredeettusinde` (101 000) split as `ethundrede` + `ettusinde` and read **100 000**
- `otte millioner firehundredefiretusindeethundredefireogtyve` (8 404 124) read **9 600 124**

Separately, a leading `minus` only reached the un-scaled path, so a scaled magnitude kept the sign lost:

- `minus en million` read **1 000 000**; `minus to millioner femhundredetusinde` read **2 500 000**

## Fix
- Split spaceless compounds on base atoms and scale morphemes, so the unit joining a hundreds group to its scale word survives and the scale multiplies the whole group.
- Reapply a leading negative marker to the finished magnitude at both finalizers.
- Spell the vigesimal tens as prescribed by Dansk Sprognævn — `halvtreds` (50) and `halvfjerds` (70) gain the standard `d`; the older spellings remain accepted on input.

## Validation
- Round-trip over 0..10 000 000, both signs, passes; anchors extended across the failing range and negatives.
- New exact-form anchor tests for concatenated scale groups and the source-prescribed tens.
- Full suite green.

## Source cross-check
Vigesimal tens and their `-sindstyve` origin confirmed against Dansk Sprognævn, svarbase SV00000047 "De danske tal; halvtreds" (https://sproget.dk/raad-og-regler/artikler-mv/svarbase/sv00000047/); cited in the pronounce and extract docstrings.