### PR TITLE
fix: preserve sign of negative fractions with zero integer part

### DIFF
--- a/ovos_number_parser/numbers_bg.py
+++ b/ovos_number_parser/numbers_bg.py
@@ -655,14 +655,14 @@ def _extract_decimal_with_text_bg(tokens, short_scale, ordinals):
                 _prev_end = _num.end_index
             if len(_digits) > 1:
                 _frac = float("0." + _digits)
-                return (number.value - _frac if number.value < 0
+                return (number.value - _frac if (number.value < 0 or any(_t.word.lower() in _NEGATIVES_BG for _t in number.tokens))
                         else number.value + _frac), \
                     number.tokens + partitions[1] + _digit_tokens
 
             if "." not in str(decimal.text) and \
                     float(decimal.value) == int(decimal.value):
                 _frac2 = float('0.' + str(int(decimal.value)))
-                return (number.value - _frac2 if number.value < 0
+                return (number.value - _frac2 if (number.value < 0 or any(_t.word.lower() in _NEGATIVES_BG for _t in number.tokens))
                         else number.value + _frac2), \
                        number.tokens + partitions[1] + decimal.tokens
     return None, None

--- a/ovos_number_parser/numbers_de.py
+++ b/ovos_number_parser/numbers_de.py
@@ -691,11 +691,16 @@ def _extract_real_number_with_text_de(tokens, short_scale):
             _val = _current_val = None
 
         if not next_word and number_words:
+            _negative = any(t.word.lower() in _NEGATIVES for t in number_words)
             if to_sum and to_sum[0] < 0:
                 # negated number: components extend the magnitude
                 val = to_sum[0] - sum(to_sum[1:])
             else:
                 val = sum(to_sum) if to_sum else _val
+            # a zero whole part ("minus null komma fünf") leaves the sign in
+            # neither the value nor to_sum[0]; recover it from the minus token
+            if _negative and isinstance(val, (int, float)) and val > 0:
+                val = -val
 
     return val, number_words
 

--- a/ovos_number_parser/numbers_en.py
+++ b/ovos_number_parser/numbers_en.py
@@ -778,14 +778,14 @@ def _extract_decimal_with_text_en(tokens, short_scale, ordinals):
                 _prev_end = _num.end_index
             if len(_digits) > 1:
                 _frac = float("0." + _digits)
-                return (number.value - _frac if number.value < 0
+                return (number.value - _frac if (number.value < 0 or any(_t.word.lower() in _NEGATIVES_EN for _t in number.tokens))
                         else number.value + _frac), \
                     number.tokens + partitions[1] + _digit_tokens
 
             # TODO handle number dot number number number
             if "." not in str(decimal.text):
                 _frac2 = float('0.' + str(decimal.value))
-                return (number.value - _frac2 if number.value < 0
+                return (number.value - _frac2 if (number.value < 0 or any(_t.word.lower() in _NEGATIVES_EN for _t in number.tokens))
                         else number.value + _frac2), \
                        number.tokens + partitions[1] + decimal.tokens
     return None, None

--- a/ovos_number_parser/numbers_fy.py
+++ b/ovos_number_parser/numbers_fy.py
@@ -566,13 +566,13 @@ def _extract_decimal_with_text_fy(tokens, short_scale, ordinals):
                 _prev_end = _num.end_index
             if len(_digits) > 1:
                 _frac = float("0." + _digits)
-                return (number.value - _frac if number.value < 0
+                return (number.value - _frac if (number.value < 0 or any(_t.word.lower() in _NEGATIVES_FY for _t in number.tokens))
                         else number.value + _frac), \
                     number.tokens + partitions[1] + _digit_tokens
 
             if "." not in str(decimal.text):
                 _frac2 = float('0.' + str(decimal.value))
-                return (number.value - _frac2 if number.value < 0
+                return (number.value - _frac2 if (number.value < 0 or any(_t.word.lower() in _NEGATIVES_FY for _t in number.tokens))
                         else number.value + _frac2), \
                        number.tokens + partitions[1] + decimal.tokens
     return None, None

--- a/ovos_number_parser/numbers_hr.py
+++ b/ovos_number_parser/numbers_hr.py
@@ -652,14 +652,14 @@ def _extract_decimal_with_text_hr(tokens, short_scale, ordinals):
                 _prev_end = _num.end_index
             if len(_digits) > 1:
                 _frac = float("0." + _digits)
-                return (number.value - _frac if number.value < 0
+                return (number.value - _frac if (number.value < 0 or any(_t.word.lower() in _NEGATIVES for _t in number.tokens))
                         else number.value + _frac), \
                     number.tokens + partitions[1] + _digit_tokens
 
             # TODO handle number dot number number number
             if "." not in str(decimal.text):
                 _frac2 = float('0.' + str(decimal.value))
-                return (number.value - _frac2 if number.value < 0
+                return (number.value - _frac2 if (number.value < 0 or any(_t.word.lower() in _NEGATIVES for _t in number.tokens))
                         else number.value + _frac2), \
                        number.tokens + partitions[1] + decimal.tokens
     return None, None

--- a/ovos_number_parser/numbers_nb.py
+++ b/ovos_number_parser/numbers_nb.py
@@ -681,10 +681,16 @@ def _extract_real_number_with_text(tokens, t):
             _val = _current_val = None
 
         if not next_word and number_words:
+            _negative = any(_tok.word.lower() in t.negatives
+                            for _tok in number_words)
             if to_sum and to_sum[0] < 0:
                 val = to_sum[0] - sum(to_sum[1:])
             else:
                 val = sum(to_sum) if to_sum else _val
+            # a zero whole part ("minus null komma fem") leaves the sign in
+            # neither the value nor to_sum[0]; recover it from the minus token
+            if _negative and isinstance(val, (int, float)) and val > 0:
+                val = -val
 
     return val, number_words
 

--- a/ovos_number_parser/numbers_nl.py
+++ b/ovos_number_parser/numbers_nl.py
@@ -707,14 +707,14 @@ def _extract_decimal_with_text_nl(tokens, short_scale, ordinals):
                 _prev_end = _num.end_index
             if len(_digits) > 1:
                 _frac = float("0." + _digits)
-                return (number.value - _frac if number.value < 0
+                return (number.value - _frac if (number.value < 0 or any(_t.word.lower() in _NEGATIVES_NL for _t in number.tokens))
                         else number.value + _frac), \
                     number.tokens + partitions[1] + _digit_tokens
 
             # TODO handle number dot number number number
             if "." not in str(decimal.text):
                 _frac2 = float('0.' + str(decimal.value))
-                return (number.value - _frac2 if number.value < 0
+                return (number.value - _frac2 if (number.value < 0 or any(_t.word.lower() in _NEGATIVES_NL for _t in number.tokens))
                         else number.value + _frac2), \
                        number.tokens + partitions[1] + decimal.tokens
     return None, None

--- a/ovos_number_parser/numbers_pl.py
+++ b/ovos_number_parser/numbers_pl.py
@@ -790,14 +790,14 @@ def _extract_decimal_with_text_pl(tokens, short_scale, ordinals):
                 _prev_end = _num.end_index
             if len(_digits) > 1:
                 _frac = float("0." + _digits)
-                return (number.value - _frac if number.value < 0
+                return (number.value - _frac if (number.value < 0 or any(_t.word.lower() in _NEGATIVES for _t in number.tokens))
                         else number.value + _frac), \
                     number.tokens + partitions[1] + _digit_tokens
 
             # TODO handle number dot number number number
             if "." not in str(decimal.text):
                 _frac2 = float('0.' + str(decimal.value))
-                return (number.value - _frac2 if number.value < 0
+                return (number.value - _frac2 if (number.value < 0 or any(_t.word.lower() in _NEGATIVES for _t in number.tokens))
                         else number.value + _frac2), \
                        number.tokens + partitions[1] + decimal.tokens
     return None, None

--- a/ovos_number_parser/numbers_ru.py
+++ b/ovos_number_parser/numbers_ru.py
@@ -881,14 +881,14 @@ def _extract_decimal_with_text_ru(tokens, short_scale, ordinals):
                 _prev_end = _num.end_index
             if len(_digits) > 1:
                 _frac = float("0." + _digits)
-                return (number.value - _frac if number.value < 0
+                return (number.value - _frac if (number.value < 0 or any(_t.word.lower() in _NEGATIVES for _t in number.tokens))
                         else number.value + _frac), \
                     number.tokens + partitions[1] + _digit_tokens
 
             # TODO handle number dot number number number
             if "." not in str(decimal.text):
                 _frac2 = float('0.' + str(decimal.value))
-                return (number.value - _frac2 if number.value < 0
+                return (number.value - _frac2 if (number.value < 0 or any(_t.word.lower() in _NEGATIVES for _t in number.tokens))
                         else number.value + _frac2), \
                        number.tokens + partitions[1] + decimal.tokens
     return None, None

--- a/ovos_number_parser/numbers_uk.py
+++ b/ovos_number_parser/numbers_uk.py
@@ -904,14 +904,14 @@ def _extract_decimal_with_text_uk(tokens, short_scale, ordinals):
                 _prev_end = _num.end_index
             if len(_digits) > 1:
                 _frac = float("0." + _digits)
-                return (number.value - _frac if number.value < 0
+                return (number.value - _frac if (number.value < 0 or any(_t.word.lower() in _NEGATIVES for _t in number.tokens))
                         else number.value + _frac), \
                     number.tokens + partitions[1] + _digit_tokens
 
             # TODO handle number dot number number number
             if "." not in str(decimal.text):
                 _frac2 = float('0.' + str(decimal.value))
-                return (number.value - _frac2 if number.value < 0
+                return (number.value - _frac2 if (number.value < 0 or any(_t.word.lower() in _NEGATIVES for _t in number.tokens))
                         else number.value + _frac2), \
                        number.tokens + partitions[1] + decimal.tokens
     return None, None


### PR DESCRIPTION
A value in (-1, 0) lost its sign on extraction because the decimal assembler inferred negativity from the whole part, which is zero. `minus zero point five` extracted `0.5` instead of `-0.5`.

The fix recovers the sign from the leading minus token that is already part of the extracted number, rather than from the (zero) value. This spans three shared code paths:

- `en, bg, fy, hr, nl, pl, ru, uk` -- the shared `_extract_decimal_with_text` assembler
- `de` -- its own to-sum assembler
- `nb, nn` -- the shared Nordic `_extract_real_number_with_text` assembler (`nn` reuses `nb`)

Languages that already handled this (`el, es, fr, gl, he, hu, id, mwl, pt, sl, sv, ar`) are unchanged and still correct. Verified `pronounce -> extract` for negative and positive fractions in (-1, 0) and beyond across all covered languages.