### PR TITLE
fix: accumulate Czech million and thousand groups

### DIFF
--- a/ovos_number_parser/numbers_cs.py
+++ b/ovos_number_parser/numbers_cs.py
@@ -736,7 +736,7 @@ def _extract_whole_number_with_text_cs(tokens, short_scale, ordinals):
                 break
             prev_val = val
 
-            if word in multiplies and next_word not in multiplies:
+            if word in multiplies:
                 # handle long numbers
                 # six hundred sixty six
                 # two million five hundred thousand
@@ -848,6 +848,15 @@ def extract_number_cs(text, short_scale=True, ordinals=False):
     handles pronunciations in long scale and short scale
 
     https://en.wikipedia.org/wiki/Names_of_large_numbers
+
+    Numeral structure follows the Internetová jazyková příručka of the
+    Ústav pro jazyk český AV ČR (§791, "Členění čísel, víceslovné číslovkové
+    výrazy"): a spelled-out number splits into groups written as separate
+    words (tisíc devět set sedmdesát dva), where million groups multiply the
+    group before them and the thousand and hundred groups form their own
+    additive portions. Each such group is set aside and summed independently,
+    so a millions group followed by a hundred-thousands group accumulates
+    correctly.
 
     Args:
         text (str): the string to normalize
@@ -1054,6 +1063,10 @@ def pronounce_number_cs(number, places=2, short_scale=True, scientific=False,
     Convert a number to it's spoken equivalent
 
     For example, '5.2' would return 'five point two'
+
+    Word forms follow the Internetová jazyková příručka of the Ústav pro jazyk
+    český AV ČR (§791): each numeral group is spoken as separate words, so the
+    output round-trips through extract_number_cs.
 
     Args:
         num(float or int): the number to pronounce (under 100)

--- a/tests/test_number_parser_cs.py
+++ b/tests/test_number_parser_cs.py
@@ -139,5 +139,37 @@ class TestCzechAdversarial(unittest.TestCase):
         self.assertEqual(extract_number("Dvacet Jedna", lang="cs"), 21)
 
 
+class TestCzechScaleAccumulation(unittest.TestCase):
+    """Millions combined with thousands must accumulate correctly.
+
+    Anchored on the Internetová jazyková příručka (ÚJČ AV ČR, §791): each
+    numeral group is written as separate words and forms its own portion.
+    """
+
+    def test_million_plus_thousands_anchor(self):
+        spoken = pronounce_number(8186976, lang="cs")
+        self.assertEqual(extract_number(spoken, lang="cs"), 8186976)
+
+    def test_million_thousand_hundred_round_trip(self):
+        for number in [1000500, 1100000, 1200000, 1500000, 8186976,
+                       2500000, 8100000, 9999999, 10000000, 1186976]:
+            with self.subTest(number=number):
+                spoken = pronounce_number(number, lang="cs")
+                self.assertEqual(extract_number(spoken, lang="cs"), number)
+
+    def test_negative_scale_round_trip(self):
+        for number in [-9997, -1499, -1500000, -8186976, -104979, -1000500]:
+            with self.subTest(number=number):
+                spoken = pronounce_number(number, lang="cs")
+                self.assertEqual(extract_number(spoken, lang="cs"), number)
+
+    def test_property_round_trip_both_signs(self):
+        for base in range(0, 10000001, 5417):
+            for number in (base, -base):
+                spoken = pronounce_number(number, lang="cs")
+                self.assertEqual(extract_number(spoken, lang="cs"), number,
+                                 msg=f"round-trip failed for {number}: {spoken!r}")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem

`extract_number(pronounce_number(n))` did not round-trip for Czech numbers that combine a millions group with a following thousands group:

| n | pronounce | extracted (before) |
|---|---|---|
| 8186976 | osm million, sto osmdesát šest tisíc, devět set sedmdesát šest | 1976 |
| 8100000 | osm million, sto tisíc | 4096102400704000800000000000 |

## Root cause

The whole-number extractor only set a scale group aside (`to_sum`) when the *next* token was not itself a scale word. When a million group was immediately followed by `sto` (hundred) the million was never set aside, so the following hundred was both summed to and then multiplied by the running million value, cascading into astronomically wrong results.

## Fix

Set the current scale group aside whenever every remaining scale word is smaller than it (the `time_to_sum` scan already computes exactly this), regardless of whether the very next token is a scale word.

This is the shared extractor-accumulation root also present in the Slovak, Turkish and Azerbaijani parsers; each ships as its own PR.

## Source

Numeral structure cross-checked against the *Internetová jazyková příručka* of the Ústav pro jazyk český AV ČR, §791 ("Členění čísel, víceslovné číslovkové výrazy"): a spelled-out number splits into groups written as separate words (tisíc devět set sedmdesát dva), million groups multiplying the preceding group and thousand/hundred groups forming their own additive portions. Cited in the `extract_number_cs` and `pronounce_number_cs` docstrings.

## Tests

New `TestCzechScaleAccumulation`: an 8186976 anchor, million+thousand+hundred round-trips, negative-scale round-trips, and a property round-trip over 0..10,000,000 for both signs. Full suite green.