### PR TITLE
fix: accumulate Azerbaijani million and thousand groups

### DIFF
--- a/ovos_number_parser/numbers_az.py
+++ b/ovos_number_parser/numbers_az.py
@@ -347,6 +347,10 @@ def pronounce_number_az(number, places=2, short_scale=True, scientific=False,
 
     For example, '5.2' would return 'beş nöqtə iki'
 
+    Word forms follow standard Azerbaijani cardinal structure (yüz, min,
+    milyon spoken as separate words; see "Say (dilçilik)", az.wikipedia), so
+    the output round-trips through extract_number_az.
+
     Args:
         num(float or int): the number to pronounce (under 100)
         places(int): maximum decimal places to speak
@@ -967,7 +971,7 @@ def _extract_whole_number_with_text_az(tokens, short_scale, ordinals):
                 break
             prev_val = val
 
-            if word in multiplies and next_word not in multiplies:
+            if word in multiplies:
                 # handle long numbers
                 # six hundred sixty six
                 # two million five hundred thousand
@@ -1104,6 +1108,13 @@ def extract_number_az(text, short_scale=True, ordinals=False):
     handles pronunciations in long scale and short scale
 
     https://en.wikipedia.org/wiki/Names_of_large_numbers
+
+    Azerbaijani cardinals are written as separate words (yüz = 100, min =
+    1000, milyon = 1e6): the million group multiplies the group before it,
+    while the thousand and hundred groups form their own additive portions
+    (yüz on = 110, yüz iyirmi beş = 125). Each such group is set aside and
+    summed independently, so a millions group followed by a thousands group
+    accumulates correctly. See "Say (dilçilik)", az.wikipedia.
 
     Args:
         text (str): the string to normalize

--- a/tests/test_number_parser_az.py
+++ b/tests/test_number_parser_az.py
@@ -260,5 +260,37 @@ class TestAzerbaijaniRoundTripSweep(unittest.TestCase):
                 self.assertEqual(extract_number_az(spoken), number)
 
 
+class TestAzerbaijaniScaleAccumulation(unittest.TestCase):
+    """Millions combined with thousands must accumulate correctly.
+
+    Anchored on standard Azerbaijani cardinal structure (yüz, min, milyon as
+    separate words; "Say (dilçilik)", az.wikipedia).
+    """
+
+    def test_million_plus_thousands_anchor(self):
+        spoken = pronounce_number_az(8186976)
+        self.assertEqual(extract_number_az(spoken), 8186976)
+
+    def test_million_thousand_hundred_round_trip(self):
+        for number in [1000976, 1100000, 1200000, 1500000, 8186976,
+                       2500000, 8100000, 9999999, 10000000, 1186976]:
+            with self.subTest(number=number):
+                spoken = pronounce_number_az(number)
+                self.assertEqual(extract_number_az(spoken), number)
+
+    def test_negative_scale_round_trip(self):
+        for number in [-9997, -104979, -1500000, -8186976, -1000976]:
+            with self.subTest(number=number):
+                spoken = pronounce_number_az(number)
+                self.assertEqual(extract_number_az(spoken), number)
+
+    def test_property_round_trip_both_signs(self):
+        for base in range(0, 10000001, 5417):
+            for number in (base, -base):
+                spoken = pronounce_number_az(number)
+                self.assertEqual(extract_number_az(spoken), number,
+                                 msg=f"round-trip failed for {number}: {spoken!r}")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem

`extract_number(pronounce_number(n))` did not round-trip for Azerbaijani numbers combining a millions group with a following thousands group:

| n | pronounce | extracted (before) |
|---|---|---|
| 8186976 | səkkiz milyon, yüz səksən altı min, doqquz yüz yetmiş altı | 1976 |

## Root cause

The whole-number extractor only set a scale group aside (`to_sum`) when the *next* token was not itself a scale word. When a million group was immediately followed by `yüz` (hundred) the million was never set aside, and the earlier groups dropped out of the running total, leaving only a tail value.

## Fix

Set the current scale group aside whenever every remaining scale word is smaller than it (the `time_to_sum` scan already computes exactly this), regardless of whether the very next token is a scale word.

This is the shared extractor-accumulation root also present in the Slovak, Czech and Turkish parsers; each ships as its own PR.

## Source

Cross-checked against standard Azerbaijani cardinal structure ("Say (dilçilik)", az.wikipedia): yüz (100), min (1000), milyon (1e6) are written as separate words; the million group multiplies the preceding group and the thousand/hundred groups form their own additive portions (yüz on = 110, yüz iyirmi beş = 125). Cited in the `extract_number_az` and `pronounce_number_az` docstrings.

## Tests

New `TestAzerbaijaniScaleAccumulation`: an 8186976 anchor, million+thousand+hundred round-trips, negative-scale round-trips, and a property round-trip over 0..10,000,000 for both signs. Full suite green.