### PR TITLE
fix: accumulate Turkish million and thousand groups

### DIFF
--- a/ovos_number_parser/numbers_tr.py
+++ b/ovos_number_parser/numbers_tr.py
@@ -301,6 +301,10 @@ def pronounce_number_tr(number, places=2, short_scale=True, scientific=False,
 
     For example, '5.2' would return 'beş virgül iki'
 
+    Word forms follow the Türk Dil Kurumu spelling rules ("Sayıların
+    Yazılışı"): each numeral group (yüz, bin, milyon) is spoken as separate
+    words, so the output round-trips through extract_number_tr.
+
     Args:
         num(float or int): the number to pronounce (under 100)
         places(int): maximum decimal places to speak
@@ -848,7 +852,7 @@ def _extract_whole_number_with_text_tr(tokens, short_scale, ordinals):
                 break
             prev_val = val
 
-            if word in multiplies and next_word not in multiplies:
+            if word in multiplies:
                 # handle long numbers
                 # altı yüz altmış altı
                 # iki milyon beş yüz bin
@@ -931,6 +935,14 @@ def is_fractional_tr(input_str, short_scale=True, spoken=True):
 def extract_number_tr(text, short_scale=True, ordinals=False):
     """
     This function extracts a number from a text string
+
+    Numeral structure follows the Türk Dil Kurumu spelling rules
+    ("Sayıların Yazılışı"): multi-word numbers are written separately
+    (bin iki yüz elli bir = 1251, üç yüz altmış beş = 365), where bin and
+    milyon multiply the group before them and the yüz/tens/units groups form
+    their own additive portions. Each such group is set aside and summed
+    independently, so a millions group followed by a thousands group
+    accumulates correctly.
 
     Args:
         text (str): the string to normalize

--- a/tests/test_number_parser_tr.py
+++ b/tests/test_number_parser_tr.py
@@ -80,5 +80,38 @@ class TestTurkishHelpers(unittest.TestCase):
                          '21 kedi')
 
 
+class TestTurkishScaleAccumulation(unittest.TestCase):
+    """Millions combined with thousands must accumulate correctly.
+
+    Anchored on the Türk Dil Kurumu spelling rules ("Sayıların Yazılışı"):
+    multi-word numbers are written separately and each group forms its own
+    portion.
+    """
+
+    def test_million_plus_thousands_anchor(self):
+        spoken = pronounce_number(8186976, lang="tr")
+        self.assertEqual(extract_number(spoken, lang="tr"), 8186976)
+
+    def test_million_thousand_hundred_round_trip(self):
+        for number in [1000976, 1100000, 1200000, 1500000, 8186976,
+                       2500000, 8100000, 9999999, 10000000, 1186976]:
+            with self.subTest(number=number):
+                spoken = pronounce_number(number, lang="tr")
+                self.assertEqual(extract_number(spoken, lang="tr"), number)
+
+    def test_negative_scale_round_trip(self):
+        for number in [-9997, -104979, -1500000, -8186976, -1000976]:
+            with self.subTest(number=number):
+                spoken = pronounce_number(number, lang="tr")
+                self.assertEqual(extract_number(spoken, lang="tr"), number)
+
+    def test_property_round_trip_both_signs(self):
+        for base in range(0, 10000001, 5417):
+            for number in (base, -base):
+                spoken = pronounce_number(number, lang="tr")
+                self.assertEqual(extract_number(spoken, lang="tr"), number,
+                                 msg=f"round-trip failed for {number}: {spoken!r}")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem

`extract_number(pronounce_number(n))` did not round-trip for Turkish numbers combining a millions group with a following thousands group:

| n | pronounce | extracted (before) |
|---|---|---|
| 8186976 | sekiz milyon yüz seksen altı bin dokuz yüz yetmiş altı | 1976 |

## Root cause

The whole-number extractor only set a scale group aside (`to_sum`) when the *next* token was not itself a scale word. When a million group was immediately followed by `yüz` (hundred) the million was never set aside, and the earlier groups dropped out of the running total, leaving only a tail value.

## Fix

Set the current scale group aside whenever every remaining scale word is smaller than it (the `time_to_sum` scan already computes exactly this), regardless of whether the very next token is a scale word.

This is the shared extractor-accumulation root also present in the Slovak, Czech and Azerbaijani parsers; each ships as its own PR.

## Source

Cross-checked against the Türk Dil Kurumu spelling rules (*Yazım Kuralları*, "Sayıların Yazılışı"): multi-word numbers are written separately (bin iki yüz elli bir = 1251, üç yüz altmış beş = 365), where bin and milyon multiply the preceding group and the yüz/tens/units groups form their own additive portions. Cited in the `extract_number_tr` and `pronounce_number_tr` docstrings.

## Tests

New `TestTurkishScaleAccumulation`: an 8186976 anchor, million+thousand+hundred round-trips, negative-scale round-trips, and a property round-trip over 0..10,000,000 for both signs. Full suite green.