### PR TITLE
fix: default number scale to each language's canonical convention

### DIFF
--- a/ovos_number_parser/__init__.py
+++ b/ovos_number_parser/__init__.py
@@ -96,6 +96,58 @@ from ovos_number_parser.numbers_uk import nice_number_uk
 from ovos_number_parser.util import Scale, GrammaticalGender, DigitPronunciation
 
 
+# --- canonical short/long scale convention per language --------------------
+#
+# Short scale: 10^9 = "billion", 10^12 = "trillion".
+# Long scale:  10^9 = "thousand million / milliard", 10^12 = "billion".
+# Getting the default wrong mis-scales every number >= 10^9 by 1000x.
+#
+# The convention each language uses is a fixed property of that language, not a
+# caller preference, so a caller that passes no ``scale=`` must get the
+# language's canonical convention. Sources: Wikipedia "Long and short scales"
+# (https://en.wikipedia.org/wiki/Long_and_short_scales), which tabulates the
+# convention per country/language and cites the national language academies,
+# cross-referenced with those academies where they legislate cardinal-numeral
+# spelling (e.g. Euskaltzaindia Araua 7 for Basque, which makes Basque long
+# scale: 10^9 = "mila milioi", "bilioi" = 10^12).
+#
+# Languages absent from this set default to the short scale (en, ru, uk, bg,
+# el, tr, id, ms, az, ...), matching their modern standard usage.
+_LONG_SCALE_LANGS = {
+    "de", "fr", "es", "it", "nl", "pl", "sv", "da", "nb", "nn", "no",
+    "gl", "ca", "eu", "cs", "sl", "sk", "hr", "hu", "fi", "et", "ro",
+    "ast", "oc", "an", "mwl", "fy",
+}
+
+
+def _canonical_scale(lang: str) -> Scale:
+    """The scale convention a language uses when the caller specifies none.
+
+    European Portuguese is long scale (10^9 = "mil milhões") while Brazilian
+    Portuguese is short scale (10^9 = "um bilhão"), so ``pt`` is resolved by
+    region rather than by the bare language code.
+    """
+    lang2 = lang.lower().split("-")[0]
+    if lang2 == "pt":
+        return Scale.SHORT if "br" in lang.lower() else Scale.LONG
+    return Scale.LONG if lang2 in _LONG_SCALE_LANGS else Scale.SHORT
+
+
+def _resolve_scale(lang: str,
+                   scale: Optional[Scale],
+                   short_scale: Optional[bool] = None) -> Scale:
+    """Resolve the effective scale for a dispatch call.
+
+    An explicit ``scale`` wins; the deprecated ``short_scale`` flag is honoured
+    next for backward compatibility; otherwise the language's canonical
+    convention applies. This keeps pronounce/extract/ordinal/numbers_to_digits
+    consistent about what "no scale given" means.
+    """
+    if scale is not None:
+        return scale
+    if short_scale is not None:
+        return Scale.SHORT if short_scale else Scale.LONG
+    return _canonical_scale(lang)
 
 
 # --- generic language fallbacks -------------------------------------------
@@ -299,6 +351,7 @@ def numbers_to_digits(utterance: str, lang: str, scale: Optional[Scale] = None) 
     Raises:
         NotImplementedError: If the specified language is not supported.
     """
+    scale = _resolve_scale(lang, scale)
     if lang.startswith("ast"):
         return AST.numbers_to_digits(utterance)
     if lang.startswith("oc"):
@@ -353,11 +406,16 @@ def pronounce_number(number: Union[int, float], lang: str,
         number (int or float): The number to pronounce.
         lang (str): BCP-47 language code specifying the language for pronunciation.
         places (int, optional): Number of decimal places to include (default is 3).
-        short_scale (bool, optional): Whether to use the short scale for large numbers (default is True).
+        short_scale (bool, optional): DEPRECATED, use the ``scale`` enum instead.
         scientific (bool, optional): If True, pronounce the number in scientific notation.
         ordinals (bool, optional): If True, pronounce the number as an ordinal (e.g., "first" instead of "one").
         digits (DigitPronunciation, optional): Style for pronouncing digits (default is FULL_NUMBER).
         gender (GrammaticalGender, optional): Grammatical gender for languages that require it (default is MASCULINE).
+        scale (Scale, optional): Short or long scale for large numbers. When
+            omitted, the language's canonical convention applies (see
+            ``_canonical_scale``), per Wikipedia "Long and short scales"
+            (https://en.wikipedia.org/wiki/Long_and_short_scales); an explicit
+            value always overrides it.
      
     Returns:
         str: The pronounced form of the number.
@@ -374,10 +432,7 @@ def pronounce_number(number: Union[int, float], lang: str,
         formatting does ``"%E" % nan`` -> ``"NAN"`` and then fails to split off an
         exponent, while cardinal formatting fails converting NaN to ``int``.
     """
-    scale = scale or Scale.SHORT
-    if short_scale is not None:
-        # TODO log warning
-        pass
+    scale = _resolve_scale(lang, scale, short_scale)
     short_scale = scale == Scale.SHORT
     if isinstance(number, float) and number != number:
         raise ValueError("cannot pronounce NaN (not a number)")
@@ -524,10 +579,7 @@ def pronounce_ordinal(number: Union[int, float], lang: str,
     Raises:
         NotImplementedError: If the language is not supported.
     """
-    scale = scale or Scale.SHORT
-    if short_scale is not None:
-        # TODO log warning
-        pass
+    scale = _resolve_scale(lang, scale, short_scale)
     short_scale = scale == Scale.SHORT
     if lang.startswith("pt"):
         return PT_BR.pronounce_ordinal(number, scale=scale, gender=gender) if "br" in lang.lower() \
@@ -615,10 +667,12 @@ def extract_number(text: str, lang: str,
 
     Args:
         text (str): the string to extract a number from
-        short_scale (bool): Use "short scale" or "long scale" for large
-            numbers -- over a million.  The default is short scale, which
-            is now common in most English speaking countries.
-            See https://en.wikipedia.org/wiki/Names_of_large_numbers
+        short_scale (bool): DEPRECATED, use the ``scale`` enum instead.
+            When neither ``scale`` nor this flag is given, the language's
+            canonical short/long convention applies, per Wikipedia "Long and
+            short scales" (https://en.wikipedia.org/wiki/Long_and_short_scales).
+            Short scale: 10^9 = "billion". Long scale: 10^9 = "milliard",
+            10^12 = "billion".
         ordinals (bool): consider ordinal numbers, e.g. third=3 instead of 1/3
         lang (str, optional): an optional BCP-47 language code, if omitted
                               the default language will be used.
@@ -629,10 +683,7 @@ def extract_number(text: str, lang: str,
     if not isinstance(text, str):
         # non-string input carries no number to extract
         return False
-    scale = scale or Scale.SHORT
-    if short_scale is not None:
-        # TODO log warning
-        pass
+    scale = _resolve_scale(lang, scale, short_scale)
     short_scale = scale == Scale.SHORT
     if lang.startswith("en"):
         return extract_number_en(text, short_scale, ordinals)
@@ -739,10 +790,7 @@ def is_fractional(input_str: str, lang: str,
     if not isinstance(input_str, str):
         # non-string input cannot be a fraction
         return False
-    scale = scale or Scale.SHORT
-    if short_scale is not None:
-        # TODO log warning
-        pass
+    scale = _resolve_scale(lang, scale, short_scale)
     short_scale = scale == Scale.SHORT
     if lang.startswith("en"):
         return is_fractional_en(input_str, short_scale)

--- a/tests/test_number_parser_cs.py
+++ b/tests/test_number_parser_cs.py
@@ -7,7 +7,7 @@ class TestCzechPronounce(unittest.TestCase):
     """Anchors for spoken Czech numbers."""
 
     def test_pronounce_number(self):
-        expected = {0: 'nula', 1: 'jedna', 2: 'dva', 3: 'tři', 4: 'čtyři', 5: 'pět', 6: 'šest', 7: 'sedm', 8: 'osm', 9: 'devět', 10: 'deset', 11: 'jedenáct', 12: 'dvanáct', 13: 'třináct', 14: 'čtrnáct', 15: 'patnáct', 16: 'šestnáct', 17: 'sedmnáct', 18: 'osmnáct', 19: 'devatenáct', 20: 'dvacet', 21: 'dvacet jedna', 30: 'třicet', 42: 'čtyřicet dva', 50: 'padesát', 66: 'šedesát šest', 70: 'sedmdesát', 80: 'osmdesát', 90: 'devadesát', 99: 'devadesát devět', 100: 'sto', 101: 'sto jedna', 123: 'sto dvacet tři', 200: 'dvě stě', 500: 'pět set', 999: 'devět set devadesát devět', 1000: 'tisíc', 2000: 'dva tisíc', 2023: 'dva tisíc, dvacet tři', 1000000: 'million', 2000000: 'dva million'}
+        expected = {0: 'nula', 1: 'jedna', 2: 'dva', 3: 'tři', 4: 'čtyři', 5: 'pět', 6: 'šest', 7: 'sedm', 8: 'osm', 9: 'devět', 10: 'deset', 11: 'jedenáct', 12: 'dvanáct', 13: 'třináct', 14: 'čtrnáct', 15: 'patnáct', 16: 'šestnáct', 17: 'sedmnáct', 18: 'osmnáct', 19: 'devatenáct', 20: 'dvacet', 21: 'dvacet jedna', 30: 'třicet', 42: 'čtyřicet dva', 50: 'padesát', 66: 'šedesát šest', 70: 'sedmdesát', 80: 'osmdesát', 90: 'devadesát', 99: 'devadesát devět', 100: 'sto', 101: 'sto jedna', 123: 'sto dvacet tři', 200: 'dvě stě', 500: 'pět set', 999: 'devět set devadesát devět', 1000: 'tisíc', 2000: 'dva tisíc', 2023: 'dva tisíc, dvacet tři', 1000000: 'milion', 2000000: 'dva milion'}
         for number, spoken in expected.items():
             with self.subTest(number=number):
                 self.assertEqual(pronounce_number(number, lang="cs"), spoken)
@@ -23,7 +23,7 @@ class TestCzechExtract(unittest.TestCase):
     """Anchors for extracting numbers from Czech text."""
 
     def test_extract_number(self):
-        expected = {0: 'nula', 1: 'jedna', 2: 'dva', 3: 'tři', 4: 'čtyři', 5: 'pět', 6: 'šest', 7: 'sedm', 8: 'osm', 9: 'devět', 10: 'deset', 11: 'jedenáct', 12: 'dvanáct', 13: 'třináct', 14: 'čtrnáct', 15: 'patnáct', 16: 'šestnáct', 17: 'sedmnáct', 18: 'osmnáct', 19: 'devatenáct', 20: 'dvacet', 21: 'dvacet jedna', 30: 'třicet', 42: 'čtyřicet dva', 50: 'padesát', 66: 'šedesát šest', 70: 'sedmdesát', 80: 'osmdesát', 90: 'devadesát', 99: 'devadesát devět', 100: 'sto', 101: 'sto jedna', 123: 'sto dvacet tři', 200: 'dvě stě', 500: 'pět set', 999: 'devět set devadesát devět', 1000: 'tisíc', 2000: 'dva tisíc', 2023: 'dva tisíc, dvacet tři', 1000000: 'million', 2000000: 'dva million'}
+        expected = {0: 'nula', 1: 'jedna', 2: 'dva', 3: 'tři', 4: 'čtyři', 5: 'pět', 6: 'šest', 7: 'sedm', 8: 'osm', 9: 'devět', 10: 'deset', 11: 'jedenáct', 12: 'dvanáct', 13: 'třináct', 14: 'čtrnáct', 15: 'patnáct', 16: 'šestnáct', 17: 'sedmnáct', 18: 'osmnáct', 19: 'devatenáct', 20: 'dvacet', 21: 'dvacet jedna', 30: 'třicet', 42: 'čtyřicet dva', 50: 'padesát', 66: 'šedesát šest', 70: 'sedmdesát', 80: 'osmdesát', 90: 'devadesát', 99: 'devadesát devět', 100: 'sto', 101: 'sto jedna', 123: 'sto dvacet tři', 200: 'dvě stě', 500: 'pět set', 999: 'devět set devadesát devět', 1000: 'tisíc', 2000: 'dva tisíc', 2023: 'dva tisíc, dvacet tři', 1000000: 'milion', 2000000: 'dva milion'}
         for number, spoken in expected.items():
             with self.subTest(spoken=spoken):
                 self.assertEqual(extract_number(spoken, lang="cs"), number)

--- a/tests/test_number_parser_it.py
+++ b/tests/test_number_parser_it.py
@@ -7,7 +7,7 @@ class TestItalianPronounce(unittest.TestCase):
     """Anchors for spoken Italian numbers."""
 
     def test_pronounce_number(self):
-        expected = {0: 'zero', 1: 'uno', 2: 'due', 3: 'tre', 4: 'quattro', 5: 'cinque', 6: 'sei', 7: 'sette', 8: 'otto', 9: 'nove', 10: 'dieci', 11: 'undici', 12: 'dodici', 13: 'tredici', 14: 'quattordici', 15: 'quindici', 16: 'sedici', 17: 'diciassette', 18: 'diciotto', 19: 'diciannove', 20: 'venti', 21: 'ventuno', 30: 'trenta', 42: 'quarantadue', 50: 'cinquanta', 66: 'sessantasei', 70: 'settanta', 80: 'ottanta', 90: 'novanta', 99: 'novantanove', 100: 'cento', 101: 'cento uno', 123: 'cento ventitre', 200: 'duecento', 500: 'cinquecento', 999: 'novecento novantanove', 1000: 'mille', 2000: 'duemila', 2023: 'duemila, ventitre', 1000000: 'un milione', 2000000: 'duemilioni'}
+        expected = {0: 'zero', 1: 'uno', 2: 'due', 3: 'tre', 4: 'quattro', 5: 'cinque', 6: 'sei', 7: 'sette', 8: 'otto', 9: 'nove', 10: 'dieci', 11: 'undici', 12: 'dodici', 13: 'tredici', 14: 'quattordici', 15: 'quindici', 16: 'sedici', 17: 'diciassette', 18: 'diciotto', 19: 'diciannove', 20: 'venti', 21: 'ventuno', 30: 'trenta', 42: 'quarantadue', 50: 'cinquanta', 66: 'sessantasei', 70: 'settanta', 80: 'ottanta', 90: 'novanta', 99: 'novantanove', 100: 'cento', 101: 'cento uno', 123: 'cento ventitre', 200: 'duecento', 500: 'cinquecento', 999: 'novecento novantanove', 1000: 'mille', 2000: 'duemila', 2023: 'duemila, ventitre', 1000000: 'un milione', 2000000: 'due milioni'}
         for number, spoken in expected.items():
             with self.subTest(number=number):
                 self.assertEqual(pronounce_number(number, lang="it"), spoken)
@@ -23,7 +23,7 @@ class TestItalianExtract(unittest.TestCase):
     """Anchors for extracting numbers from Italian text."""
 
     def test_extract_number(self):
-        expected = {0: 'zero', 1: 'uno', 2: 'due', 3: 'tre', 4: 'quattro', 5: 'cinque', 6: 'sei', 7: 'sette', 8: 'otto', 9: 'nove', 10: 'dieci', 11: 'undici', 12: 'dodici', 13: 'tredici', 14: 'quattordici', 15: 'quindici', 16: 'sedici', 17: 'diciassette', 18: 'diciotto', 19: 'diciannove', 20: 'venti', 21: 'ventuno', 30: 'trenta', 42: 'quarantadue', 50: 'cinquanta', 66: 'sessantasei', 70: 'settanta', 80: 'ottanta', 90: 'novanta', 99: 'novantanove', 100: 'cento', 101: 'cento uno', 123: 'cento ventitre', 200: 'duecento', 500: 'cinquecento', 999: 'novecento novantanove', 1000: 'mille', 2000: 'duemila', 2023: 'duemila, ventitre', 1000000: 'un milione', 2000000: 'duemilioni'}
+        expected = {0: 'zero', 1: 'uno', 2: 'due', 3: 'tre', 4: 'quattro', 5: 'cinque', 6: 'sei', 7: 'sette', 8: 'otto', 9: 'nove', 10: 'dieci', 11: 'undici', 12: 'dodici', 13: 'tredici', 14: 'quattordici', 15: 'quindici', 16: 'sedici', 17: 'diciassette', 18: 'diciotto', 19: 'diciannove', 20: 'venti', 21: 'ventuno', 30: 'trenta', 42: 'quarantadue', 50: 'cinquanta', 66: 'sessantasei', 70: 'settanta', 80: 'ottanta', 90: 'novanta', 99: 'novantanove', 100: 'cento', 101: 'cento uno', 123: 'cento ventitre', 200: 'duecento', 500: 'cinquecento', 999: 'novecento novantanove', 1000: 'mille', 2000: 'duemila', 2023: 'duemila, ventitre', 1000000: 'un milione', 2000000: 'due milioni'}
         for number, spoken in expected.items():
             with self.subTest(spoken=spoken):
                 self.assertEqual(extract_number(spoken, lang="it"), number)

--- a/tests/test_scale_defaults.py
+++ b/tests/test_scale_defaults.py
@@ -1,0 +1,128 @@
+"""Canonical short/long scale defaults for the top-level dispatch API.
+
+A caller that passes no ``scale=`` must get the language's canonical
+convention, not a hard-coded short scale. Short scale: 10^9 = "billion",
+10^12 = "trillion". Long scale: 10^9 = "thousand million / milliard",
+10^12 = "billion".
+
+Conventions verified against Wikipedia "Long and short scales"
+(https://en.wikipedia.org/wiki/Long_and_short_scales), which tabulates the
+convention per language/country and cites the national language academies.
+"""
+import unittest
+
+from ovos_number_parser import pronounce_number, extract_number
+from ovos_number_parser.util import Scale
+
+
+class TestCanonicalScaleWords(unittest.TestCase):
+    # canonical 10^9 / 10^12 spoken word per language, from the source above.
+    # LONG-scale languages say a "thousand-million" phrase or a dedicated
+    # "milliard" word at 10^9 and reuse the "billion" cognate for 10^12.
+    LONG = {
+        "pt": ("mil milhões", "um bilião"),      # European Portuguese
+        "mwl": ("mil milhones", "un bilion"),    # Mirandese
+        "gl": ("mil millóns", "un billón"),      # Galician
+        "cs": ("miliarda", "bilion"),            # Czech
+        "sl": ("milijarda", "bilijon"),          # Slovene
+        "sk": ("miliarda", "bilión"),            # Slovak
+        "hr": ("milijarda", "bilijun"),          # Croatian
+        "hu": ("egymilliárd", "egybillió"),      # Hungarian
+        "pl": ("miliard", "bilion"),             # Polish
+        "de": ("eine Milliarde", "eine Billion"),  # German
+        "nl": ("één miljard", "één biljoen"),    # Dutch
+        "sv": ("en miljard", "en biljon"),       # Swedish
+        "da": ("en milliard", "en billion"),     # Danish
+        "ro": ("un miliard", "un bilion"),       # Romanian
+    }
+    # SHORT-scale languages reach the "billion" cognate already at 10^9 and
+    # the "trillion" cognate at 10^12.
+    SHORT = {
+        "pt-BR": ("um bilhão", "um trilhão"),    # Brazilian Portuguese
+        "en": ("one billion", "one trillion"),
+        "ru": ("миллиард", "триллион"),
+        "tr": ("bir milyar", "bir trilyon"),
+        "id": ("satu miliar", "satu triliun"),
+        "az": ("bir milyard", "bir trilyon"),
+        "bg": ("един милиард", "един трилион"),
+    }
+
+    def test_long_scale_default_words(self):
+        for lang, (w9, w12) in self.LONG.items():
+            with self.subTest(lang=lang):
+                self.assertEqual(pronounce_number(10 ** 9, lang).strip(), w9)
+                self.assertEqual(pronounce_number(10 ** 12, lang).strip(), w12)
+
+    def test_short_scale_default_words(self):
+        for lang, (w9, w12) in self.SHORT.items():
+            with self.subTest(lang=lang):
+                self.assertEqual(pronounce_number(10 ** 9, lang).strip(), w9)
+                self.assertEqual(pronounce_number(10 ** 12, lang).strip(), w12)
+
+    def test_round_trip_at_canonical_default(self):
+        # pronounce -> extract returns the same value in both scale families,
+        # with no scale argument on either call.
+        roundtrip = {
+            "pt": (10 ** 9, 10 ** 12), "pt-BR": (10 ** 9, 10 ** 12),
+            "mwl": (10 ** 9, 10 ** 12), "gl": (10 ** 9, 10 ** 12),
+            "cs": (10 ** 9, 10 ** 12), "sl": (10 ** 9, 10 ** 12),
+            "sk": (10 ** 9, 10 ** 12), "hr": (10 ** 9, 10 ** 12),
+            "hu": (10 ** 9, 10 ** 12), "pl": (10 ** 9, 10 ** 12),
+            "de": (10 ** 9, 10 ** 12), "sv": (10 ** 9, 10 ** 12),
+            "da": (10 ** 9, 10 ** 12), "ro": (10 ** 9, 10 ** 12),
+            "en": (10 ** 9, 10 ** 12), "ru": (10 ** 9, 10 ** 12),
+            "tr": (10 ** 9, 10 ** 12), "id": (10 ** 9, 10 ** 12),
+            "az": (10 ** 9, 10 ** 12), "bg": (10 ** 9, 10 ** 12),
+        }
+        for lang, values in roundtrip.items():
+            for n in values:
+                with self.subTest(lang=lang, n=n):
+                    spoken = pronounce_number(n, lang)
+                    self.assertEqual(extract_number(spoken, lang), n)
+
+
+class TestScaleOverrideStillHonoured(unittest.TestCase):
+    """An explicit ``scale=`` overrides the canonical default in both directions."""
+
+    def test_explicit_short_scale_on_long_language(self):
+        # forcing short scale on European Portuguese reuses the "bilião"
+        # cognate at 10^9
+        self.assertEqual(
+            pronounce_number(10 ** 9, "pt", scale=Scale.SHORT).strip(),
+            "um bilião")
+        self.assertEqual(
+            extract_number("um bilião", "pt", scale=Scale.SHORT), 10 ** 9)
+
+    def test_explicit_long_scale_on_short_language_pt_br(self):
+        # forcing long scale on Brazilian Portuguese pushes "bilhão" out to 10^12
+        self.assertEqual(
+            pronounce_number(10 ** 9, "pt-BR", scale=Scale.LONG).strip(),
+            "mil milhões")
+
+    def test_deprecated_short_scale_flag_still_selects_scale(self):
+        # the legacy boolean is honoured when no scale enum is given
+        self.assertEqual(
+            pronounce_number(10 ** 9, "pt", short_scale=True).strip(),
+            "um bilião")
+        self.assertEqual(
+            pronounce_number(10 ** 9, "pt", short_scale=False).strip(),
+            "mil milhões")
+
+
+class TestShortScaleLanguagesUnchanged(unittest.TestCase):
+    """The clean short-scale languages keep their pre-existing behaviour."""
+
+    def test_english_unchanged(self):
+        self.assertEqual(pronounce_number(10 ** 9, "en"), "one billion")
+        self.assertEqual(pronounce_number(10 ** 12, "en"), "one trillion")
+        self.assertEqual(extract_number("one billion", "en"), 10 ** 9)
+        self.assertEqual(extract_number("one trillion", "en"), 10 ** 12)
+
+    def test_russian_turkish_indonesian_unchanged(self):
+        self.assertEqual(pronounce_number(10 ** 12, "ru"), "триллион")
+        self.assertEqual(pronounce_number(10 ** 12, "tr"), "bir trilyon")
+        self.assertEqual(pronounce_number(10 ** 12, "id"), "satu triliun")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Systemic root fix: the top-level dispatch forced Scale.SHORT for every language when the caller passed no scale, mis-scaling every long-scale language by 1000x at/above 10^9 (pt-PT said 'um bilião' for 10^9, Czech emitted English 'billion'). A per-language resolver now applies each language's canonical short/long convention (sourced from Wikipedia 'Long and short scales', cited in code) when none is given; an explicit scale still overrides. Fixes pt-PT, pt-BR, mwl, gl, cs, sl end to end; short-scale languages unchanged. New tests/test_scale_defaults.py covers the 10^9/10^12 word table, round-trips, override honouring and short-scale-unchanged. Follow-up PRs build on this default for the remaining 10^12-path module bugs (fr/fi/et pronounce, es/ca extract, eu academy scale).