### PR TITLE
fix: parse Spanish long-scale large numbers

### DIFF
--- a/ovos_number_parser/numbers_es.py
+++ b/ovos_number_parser/numbers_es.py
@@ -1,3 +1,4 @@
+import math
 from collections import OrderedDict
 from typing import List
 
@@ -237,6 +238,38 @@ _SHORT_SCALE_ES = OrderedDict([
     (1e3003, "millinillones")
 ])
 
+def _es_scale_words(short_scale):
+    """Map large-magnitude Spanish scale words to their numeric value.
+
+    Spain and most Spanish-speaking regions use the *long scale*, where
+    ``billón`` is 10^12 (a million millions) and ``millardo`` is 10^9, in
+    contrast to the English short scale where "billion" is 10^9.
+    See https://en.wikipedia.org/wiki/Long_and_short_scales.
+
+    Both the plural forms listed in the pronunciation tables (``billones``)
+    and their singular counterparts (``billón``) are included so extraction
+    round-trips with :func:`pronounce_number_es`.
+    """
+    table = _SHORT_SCALE_ES if short_scale else _LONG_SCALE_ES
+    words = {}
+    for magnitude, plural in table.items():
+        if not math.isfinite(magnitude):
+            # magnitudes beyond float range (1e309+) cannot be represented
+            continue
+        magnitude = int(magnitude)
+        if magnitude < 1000000:
+            # "cien"/"mil" are handled by the base number vocabulary
+            continue
+        words[plural] = magnitude
+        # derive the singular: "billones" -> "billón", "millardos" -> "millardo"
+        if plural.endswith("ones"):
+            words[plural[:-4] + "ón"] = magnitude
+            words[plural[:-4] + "on"] = magnitude  # unaccented variant
+        elif plural.endswith("s"):
+            words[plural[:-1]] = magnitude
+    return words
+
+
 # TODO: female forms.
 _ORDINAL_STRING_BASE_ES = {
     1: 'primero',
@@ -340,21 +373,29 @@ def extract_number_es(text, short_scale=True, ordinals=False):
     """
     This function prepares the given text for parsing by making
     numbers consistent, getting rid of contractions, etc.
+
+    Large-magnitude words follow the requested scale. Spanish (Spain and
+    most of Latin America) conventionally uses the *long scale*, in which
+    ``billón`` is 10^12 and ``millardo`` is 10^9, whereas the short scale
+    reads ``billón`` as 10^9. See
+    https://en.wikipedia.org/wiki/Long_and_short_scales.
+
     Args:
         text (str): the string to normalize
+        short_scale (bool): interpret ``billón`` and larger words on the
+            short scale (10^9) when True, long scale (10^12) when False.
     Returns:
         (int) or (float): The value of extracted number
 
     """
-    # TODO: short_scale and ordinals don't do anything here.
-    # The parameters are present in the function signature for API compatibility
-    # reasons.
+    # TODO: ordinals don't do anything here.
     #
     # Returns incorrect output on certain fractional phrases like, "cuarto de dos"
     #  TODO: numbers greater than 999999
     if not text:
         return False
     aWords = text.lower().split()
+    scale_words = _es_scale_words(short_scale)
     negative = False
     while aWords and aWords[0] in ['menos']:
         negative = True
@@ -381,7 +422,9 @@ def extract_number_es(text, short_scale=True, ordinals=False):
             next_word = None
 
         # is current word a number?
-        if word in _STRING_NUM_ES:
+        if word in scale_words:
+            val = scale_words[word]
+        elif word in _STRING_NUM_ES:
             val = _STRING_NUM_ES[word]
         elif word.isdigit():  # doesn't work with decimals
             val = int(word)
@@ -802,7 +845,13 @@ def pronounce_number_es(number, places=2, short_scale=False):
             result += "cero"
         result += " coma"
         _num_str = str(number)
-        _num_str = _num_str.split(".")[1][0:places]
+        if "." in _num_str:
+            _num_str = _num_str.split(".")[1][0:places]
+        else:
+            # tiny/large floats stringify in scientific notation ("1e-09"),
+            # which has no decimal point to split on; expand to fixed notation
+            _num_str = "{:.{places}f}".format(number, places=places
+                                              ).split(".")[1][0:places]
         for char in _num_str:
             result += " " + _NUM_STRING_ES[int(char)]
     return result

--- a/tests/test_number_parser_es.py
+++ b/tests/test_number_parser_es.py
@@ -1,6 +1,7 @@
 import unittest
 
 from ovos_number_parser import extract_number, pronounce_number, is_fractional
+from ovos_number_parser.util import Scale
 
 
 class TestSpanishPronounce(unittest.TestCase):
@@ -179,6 +180,78 @@ class TestSpanishFractions(unittest.TestCase):
         for word in ["", "hola", "cinco"]:
             with self.subTest(word=word):
                 self.assertFalse(is_fractional(word, lang="es"))
+
+
+class TestSpanishLongScale(unittest.TestCase):
+    """Spanish is a long-scale language: billón = 10^12, millardo = 10^9.
+
+    See https://en.wikipedia.org/wiki/Long_and_short_scales.
+    """
+
+    def test_long_scale_words_extract(self):
+        cases = {
+            "un millón": 10 ** 6,
+            "un millardo": 10 ** 9,
+            "un billón": 10 ** 12,
+            "dos billones": 2 * 10 ** 12,
+            "tres billones": 3 * 10 ** 12,
+        }
+        for spoken, value in cases.items():
+            with self.subTest(spoken=spoken):
+                self.assertEqual(
+                    extract_number(spoken, lang="es", scale=Scale.LONG), value)
+
+    def test_short_scale_billon_is_1e9(self):
+        # under the short scale, "billón" means 10^9, not 10^12
+        self.assertEqual(
+            extract_number("un billón", lang="es", scale=Scale.SHORT), 10 ** 9)
+
+    def test_pronounce_to_extract_roundtrip_long(self):
+        for magnitude in (10 ** 6, 10 ** 9, 10 ** 12):
+            with self.subTest(magnitude=magnitude):
+                spoken = pronounce_number(magnitude, lang="es", scale=Scale.LONG)
+                self.assertEqual(
+                    extract_number(spoken, lang="es", scale=Scale.LONG),
+                    magnitude, spoken)
+
+    def test_extract_to_pronounce_roundtrip_long(self):
+        for spoken in ("un millón", "un millardo", "un billón"):
+            with self.subTest(spoken=spoken):
+                value = extract_number(spoken, lang="es", scale=Scale.LONG)
+                self.assertEqual(
+                    pronounce_number(value, lang="es", scale=Scale.LONG), spoken)
+
+    def test_scale_default_short_still_reads_million(self):
+        # unrelated smaller magnitudes must not regress on either scale
+        for scale in (Scale.SHORT, Scale.LONG):
+            with self.subTest(scale=scale):
+                self.assertEqual(
+                    extract_number("un millón", lang="es", scale=scale), 10 ** 6)
+
+    def test_boundary_billon_not_confused_with_millardo(self):
+        # long scale: millardo (10^9) and billón (10^12) are distinct
+        self.assertNotEqual(
+            extract_number("un millardo", lang="es", scale=Scale.LONG),
+            extract_number("un billón", lang="es", scale=Scale.LONG))
+
+    def test_bare_scale_word_without_multiplier(self):
+        # "billón" with no leading unit implies one
+        self.assertEqual(
+            extract_number("billón", lang="es", scale=Scale.LONG), 10 ** 12)
+
+
+class TestSpanishTinyFloatNoCrash(unittest.TestCase):
+    """Scientific-notation floats must not raise when pronounced."""
+
+    def test_tiny_float_does_not_crash(self):
+        for number in (1e-9, -1e-9, 1e-12, 1e20):
+            with self.subTest(number=number):
+                spoken = pronounce_number(number, lang="es")
+                self.assertIsInstance(spoken, str)
+                self.assertTrue(spoken)
+
+    def test_ordinary_decimal_unregressed(self):
+        self.assertEqual(pronounce_number(5.2, lang="es"), "cinco coma dos")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Spanish is a long-scale language: `billón` is 10^12 and `millardo` is 10^9 (see https://en.wikipedia.org/wiki/Long_and_short_scales). `extract_number_es` ignored the requested scale and had no entry for `billón`, so `extract_number("un billón", scale=Scale.LONG)` returned `1` instead of `10^12`, breaking the round-trip against `pronounce_number_es` (which already spoke `un billón` correctly).

## Changes
- Build a scale-aware vocabulary of large-magnitude words from the existing pronunciation tables, covering both plural (`billones`) and singular (`billón`) forms, so long- and short-scale extraction round-trip with pronunciation. Short-scale reads `billón` as 10^9; long-scale as 10^12.
- Guard `pronounce_number_es` against tiny/large floats that stringify in scientific notation (`1e-09`), which previously raised `IndexError`; they now expand to a sensible spoken form.

## Tests
- Long-scale extraction of `millón`/`millardo`/`billón`, both-direction round-trips at 10^6/10^9/10^12, short-scale disambiguation, boundary and bare-word cases, and a no-crash case for scientific-notation floats.

Builds on the scale-default root change (#165). Ordinary decimals and short-scale magnitudes are unaffected; full suite green.