### PR TITLE
fix: pronounce French long-scale billion (10^12)

### DIFF
--- a/ovos_number_parser/numbers_fr.py
+++ b/ovos_number_parser/numbers_fr.py
@@ -45,7 +45,9 @@ _NUMBERS_FR = {
     "million": 1000000,
     "millions": 1000000,
     "milliard": 1000000000,
-    "milliards": 1000000000}
+    "milliards": 1000000000,
+    "billion": 1000000000000,
+    "billions": 1000000000000}
 
 _ORDINAL_ENDINGS_FR = ("er", "re", "ère", "nd", "nde", "ième", "ème", "e")
 
@@ -187,7 +189,14 @@ def _pronounce_sub_thousand_fr(n):
 
 
 def _pronounce_whole_number_fr(n):
-    """Spoken form of any whole number below 10^12."""
+    """Spoken form of any whole number below 10^15.
+
+    French uses the long scale, where each new named magnitude is 10^6
+    times the previous one: million = 10^6, milliard = 10^9,
+    billion = 10^12 (see Wikipedia, "Long and short scales",
+    https://en.wikipedia.org/wiki/Long_and_short_scales). This differs
+    from the short scale where "billion" means 10^9.
+    """
     assert n >= 0
     if n < 1000:
         return _pronounce_sub_thousand_fr(n)
@@ -205,9 +214,16 @@ def _pronounce_whole_number_fr(n):
         if rest:
             part += " " + _pronounce_whole_number_fr(rest)
         return part
-    milliards, rest = divmod(n, 10 ** 9)
-    part = "un milliard" if milliards == 1 \
-        else _pronounce_whole_number_fr(milliards) + " milliards"
+    if n < 10 ** 12:
+        milliards, rest = divmod(n, 10 ** 9)
+        part = "un milliard" if milliards == 1 \
+            else _pronounce_whole_number_fr(milliards) + " milliards"
+        if rest:
+            part += " " + _pronounce_whole_number_fr(rest)
+        return part
+    billions, rest = divmod(n, 10 ** 12)
+    part = "un billion" if billions == 1 \
+        else _pronounce_whole_number_fr(billions) + " billions"
     if rest:
         part += " " + _pronounce_whole_number_fr(rest)
     return part
@@ -230,8 +246,15 @@ def pronounce_number_fr(number, places=2):
         result = "moins "
     number = abs(number)
 
+    # Scientific-notation floats (very small or very large magnitudes) have
+    # no long-scale word form and str() renders them with an exponent, which
+    # has no "." to split for the decimal part. Return the numeric string
+    # rather than raising.
+    if number != 0 and (number >= 10 ** 15 or number < 1e-4):
+        return result + str(number)
+
     if number >= 100:
-        if number >= 10 ** 12 or int(number) != number and number >= 1000:
+        if number >= 10 ** 15 or int(number) != number and number >= 1000:
             return result + str(number)
         result += _pronounce_whole_number_fr(int(number))
         if number != int(number) and places > 0:
@@ -485,8 +508,8 @@ def _number_parse_fr(words, i):
             val1, i1 = result1
         else:
             val1, i1 = 1, i
-        # check for million(s) / milliard(s)
-        result2 = number_word_fr(i1, 1000000, 1000000000)
+        # check for million(s) / milliard(s) / billion(s)
+        result2 = number_word_fr(i1, 1000000, 1000000000000)
         if result2:
             scale, i2 = result2
             result3 = number_1_billions_fr(i2)

--- a/tests/test_number_parser_fr.py
+++ b/tests/test_number_parser_fr.py
@@ -162,6 +162,43 @@ class TestNumberParserFr(unittest.TestCase):
         self.assertEqual(normalize_fr("le chat", remove_articles=False),
                          "le chat")
 
+    def test_long_scale_billion_words(self):
+        # French is long scale: milliard = 10^9, billion = 10^12.
+        self.assertEqual(pronounce_number_fr(10 ** 6), "un million")
+        self.assertEqual(pronounce_number_fr(10 ** 9), "un milliard")
+        self.assertEqual(pronounce_number_fr(10 ** 12), "un billion")
+        self.assertEqual(pronounce_number_fr(2 * 10 ** 12), "deux billions")
+        self.assertEqual(extract_number_fr("un billion"), 10 ** 12)
+        self.assertEqual(extract_number_fr("deux billions"), 2 * 10 ** 12)
+
+    def test_long_scale_round_trip_both_directions(self):
+        # word -> number and number -> word must agree at each magnitude.
+        for n in [10 ** 6, 10 ** 9, 10 ** 12]:
+            word = pronounce_number_fr(n)
+            self.assertEqual(extract_number_fr(word), n, n)
+        for word, n in [("un million", 10 ** 6),
+                        ("un milliard", 10 ** 9),
+                        ("un billion", 10 ** 12)]:
+            self.assertEqual(extract_number_fr(word), n, word)
+            self.assertEqual(extract_number_fr(pronounce_number_fr(n)), n, n)
+
+    def test_long_scale_mixed_magnitudes(self):
+        # Adversarial nesting: billions must combine with lower scales.
+        self.assertEqual(
+            extract_number_fr(pronounce_number_fr(10 ** 12 + 3 * 10 ** 9)),
+            10 ** 12 + 3 * 10 ** 9)
+        self.assertEqual(
+            pronounce_number_fr(10 ** 12 + 3 * 10 ** 9),
+            "un billion trois milliards")
+
+    def test_scientific_notation_does_not_crash(self):
+        # Very small / very large / scientific floats must not raise.
+        for value in [1e-9, 1e-5, 6.022e23, 1e15, -1e-9]:
+            try:
+                pronounce_number_fr(value)
+            except Exception as error:  # noqa: BLE001
+                self.fail(f"pronounce_number_fr({value!r}) raised {error!r}")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
French uses the long scale, so `billion` denotes 10^12 while `milliard` denotes 10^9. `pronounce_number(10**12, 'fr')` returned the raw digit string because the spoken-form builder stopped at milliards and the entry point capped at 10^12. This adds the `billion(s)` magnitude to both the spoken form and the extractor, so values at and above 10^12 render as words and round-trip through `extract_number` in both directions at 10^6, 10^9, and 10^12.

Also guards scientific-notation floats: very small or very large magnitudes render with an exponent whose string has no decimal point to split, which raised `IndexError` (e.g. `1e-9`). Those inputs now return a numeric string instead of crashing.

Builds on the systemic scale-default root fix in #165.

Source: Wikipedia, "Long and short scales" (https://en.wikipedia.org/wiki/Long_and_short_scales) — French: milliard = 10^9, billion = 10^12.