### PR TITLE
fix: pronounce Finnish/Estonian long-scale trillions

### DIFF
--- a/ovos_number_parser/numbers_et.py
+++ b/ovos_number_parser/numbers_et.py
@@ -112,7 +112,8 @@ def _pronounce_int_et(num):
     if num == 0:
         return _NUM_STRING_ET[0]
     words = []
-    for value, name, partitive in ((10 ** 9, 'miljard', 'miljardit'),
+    for value, name, partitive in ((10 ** 12, 'biljon', 'biljonit'),
+                                   (10 ** 9, 'miljard', 'miljardit'),
                                    (10 ** 6, 'miljon', 'miljonit')):
         count = num // value
         if count:
@@ -140,6 +141,10 @@ def pronounce_number_et(number, places=2, short_scale=True, scientific=False,
 
     For example, 5.2 becomes "viis koma kaks".
 
+    Estonian uses the long scale (Wikipedia, "Long and short scales",
+    https://en.wikipedia.org/wiki/Long_and_short_scales): the milliard-cognate
+    "miljard" names 10^9 and the billion-cognate "biljon" names 10^12.
+
     Args:
         number(float or int): the number to pronounce
         places(int): maximum decimal places to speak
@@ -151,7 +156,7 @@ def pronounce_number_et(number, places=2, short_scale=True, scientific=False,
     """
     if ordinals:
         return pronounce_ordinal_et(number)
-    if abs(number) >= 10 ** 12:  # beyond the supported scale words
+    if abs(number) >= 10 ** 15:  # beyond the supported scale words
         return str(number)
     if number < 0:
         return "miinus " + pronounce_number_et(abs(number), places)
@@ -271,6 +276,8 @@ _SCALE_WORDS_ET = {
     'miljonit': 10 ** 6,
     'miljard': 10 ** 9,
     'miljardit': 10 ** 9,
+    'biljon': 10 ** 12,
+    'biljonit': 10 ** 12,
 }
 
 

--- a/ovos_number_parser/numbers_fi.py
+++ b/ovos_number_parser/numbers_fi.py
@@ -124,7 +124,8 @@ def _pronounce_int_fi(num):
     if num == 0:
         return _NUM_STRING_FI[0]
     words = []
-    for value, name in ((10 ** 9, 'miljardi'), (10 ** 6, 'miljoona')):
+    for value, name in ((10 ** 12, 'biljoona'), (10 ** 9, 'miljardi'),
+                        (10 ** 6, 'miljoona')):
         count = num // value
         if count:
             if count == 1:
@@ -158,6 +159,10 @@ def pronounce_number_fi(number, places=2, short_scale=True, scientific=False,
     allomorphs "sataa"/"tuhatta" when the multiplier exceeds one, while
     miljoona/miljardi are separate nouns in the partitive ("kaksi miljoonaa").
 
+    Finnish uses the long scale (Wikipedia, "Long and short scales",
+    https://en.wikipedia.org/wiki/Long_and_short_scales): the milliard-cognate
+    "miljardi" names 10^9 and the billion-cognate "biljoona" names 10^12.
+
     Args:
         number(float or int): the number to pronounce
         places(int): maximum decimal places to speak
@@ -169,7 +174,7 @@ def pronounce_number_fi(number, places=2, short_scale=True, scientific=False,
     """
     if ordinals:
         return pronounce_ordinal_fi(number)
-    if abs(number) >= 10 ** 12:  # beyond the supported scale words
+    if abs(number) >= 10 ** 15:  # beyond the supported scale words
         return str(number)
     if number < 0:
         return "miinus " + pronounce_number_fi(abs(number), places)
@@ -316,6 +321,8 @@ _SCALE_WORDS_FI = {
     'miljoonaa': 10 ** 6,
     'miljardi': 10 ** 9,
     'miljardia': 10 ** 9,
+    'biljoona': 10 ** 12,
+    'biljoonaa': 10 ** 12,
 }
 
 

--- a/tests/test_number_parser_et.py
+++ b/tests/test_number_parser_et.py
@@ -106,6 +106,38 @@ class TestExtractNumberEt(unittest.TestCase):
             self.assertEqual(is_ordinal(spoken, "et"), n, spoken)
 
 
+class TestLongScaleEt(unittest.TestCase):
+    def test_scale_anchors_pronounce(self):
+        # long scale: 10^9 = miljard, 10^12 = biljon
+        cases = {10 ** 6: "miljon", 10 ** 9: "miljard",
+                 10 ** 12: "biljon", 3 * 10 ** 12: "kolm biljonit"}
+        for n, expected in cases.items():
+            self.assertEqual(pronounce_number(n, "et"), expected, n)
+
+    def test_scale_anchors_extract(self):
+        cases = {"miljon": 10 ** 6, "miljard": 10 ** 9,
+                 "biljon": 10 ** 12, "kolm biljonit": 3 * 10 ** 12}
+        for spoken, expected in cases.items():
+            self.assertEqual(extract_number(spoken, "et"), expected, spoken)
+
+    def test_roundtrip_both_directions(self):
+        for n in (10 ** 6, 10 ** 9, 10 ** 12, 2 * 10 ** 12,
+                  1500000000000, 1000000000001):
+            spoken = pronounce_number(n, "et")
+            self.assertNotEqual(spoken, str(n), n)  # must be words, not digits
+            self.assertEqual(extract_number(spoken, "et"), n, spoken)
+
+    def test_boundary_beyond_scale(self):
+        # 10^15 exceeds the supported scale words and falls back to digits
+        self.assertEqual(pronounce_number(10 ** 15, "et"), str(10 ** 15))
+        self.assertNotEqual(pronounce_number(10 ** 15 - 1, "et"),
+                            str(10 ** 15 - 1))
+
+    def test_negative_trillion(self):
+        self.assertEqual(pronounce_number(-10 ** 12, "et"), "miinus biljon")
+        self.assertEqual(extract_number("miinus biljon", "et"), -10 ** 12)
+
+
 class TestExtractNumbersEt(unittest.TestCase):
     def test_multiple(self):
         self.assertEqual(

--- a/tests/test_number_parser_fi.py
+++ b/tests/test_number_parser_fi.py
@@ -161,6 +161,39 @@ class TestExtractNumberFi(unittest.TestCase):
             self.assertEqual(is_ordinal(spoken, "fi"), n, spoken)
 
 
+class TestLongScaleFi(unittest.TestCase):
+    def test_scale_anchors_pronounce(self):
+        # long scale: 10^9 = miljardi, 10^12 = biljoona
+        cases = {10 ** 6: "miljoona", 10 ** 9: "miljardi",
+                 10 ** 12: "biljoona", 2 * 10 ** 12: "kaksi biljoonaa"}
+        for n, expected in cases.items():
+            self.assertEqual(pronounce_number(n, "fi"), expected, n)
+
+    def test_scale_anchors_extract(self):
+        cases = {"miljoona": 10 ** 6, "miljardi": 10 ** 9,
+                 "biljoona": 10 ** 12, "kaksi biljoonaa": 2 * 10 ** 12}
+        for spoken, expected in cases.items():
+            self.assertEqual(extract_number(spoken, "fi"), expected, spoken)
+
+    def test_roundtrip_both_directions(self):
+        for n in (10 ** 6, 10 ** 9, 10 ** 12, 3 * 10 ** 12,
+                  1500000000000, 1000000000001):
+            spoken = pronounce_number(n, "fi")
+            self.assertNotEqual(spoken, str(n), n)  # must be words, not digits
+            self.assertEqual(extract_number(spoken, "fi"), n, spoken)
+
+    def test_boundary_beyond_scale(self):
+        # 10^15 exceeds the supported scale words and falls back to digits
+        self.assertEqual(pronounce_number(10 ** 15, "fi"), str(10 ** 15))
+        # just below the cap still pronounces
+        self.assertNotEqual(pronounce_number(10 ** 15 - 1, "fi"),
+                            str(10 ** 15 - 1))
+
+    def test_negative_trillion(self):
+        self.assertEqual(pronounce_number(-10 ** 12, "fi"), "miinus biljoona")
+        self.assertEqual(extract_number("miinus biljoona", "fi"), -10 ** 12)
+
+
 class TestExtractNumbersFi(unittest.TestCase):
     def test_multiple(self):
         self.assertEqual(


### PR DESCRIPTION
Finnish and Estonian are long-scale languages: the milliard-cognate names 10^9 (miljardi / miljard) and the billion-cognate names 10^12 (biljoona / biljon), per Wikipedia, "Long and short scales" (https://en.wikipedia.org/wiki/Long_and_short_scales).

The scale tables only reached 10^9, so `pronounce_number(10**12, "fi")` and `pronounce_number(10**12, "et")` returned the raw digit string `1000000000000` instead of a spoken form.

This extends the pronounce composition and the extraction scale words with biljoona / biljon and their partitives (biljoonaa / biljonit), and raises the supported ceiling to just under 10^15. Trillions now pronounce natively and round-trip through extract.

Builds on the scale-default root PR #165.

Tests: added long-scale round-trip suites (both directions) at 10^6 / 10^9 / 10^12 for both languages, with boundary cases at the 10^15 ceiling and negative-trillion cases.