### PR TITLE
fix: prevent Romance number extractor crash on large/scientific floats

### DIFF
--- a/ovos_number_parser/util.py
+++ b/ovos_number_parser/util.py
@@ -1,4 +1,6 @@
+import math
 from dataclasses import dataclass, field
+from decimal import Decimal
 from enum import Enum
 from typing import List, Dict, Union, Any, Tuple, Optional, Callable
 import re
@@ -719,16 +721,28 @@ class RomanceNumberExtractor:
         if not isinstance(number, (int, float)):
             raise TypeError("Number must be an int or float.")
 
+        # Non-finite floats (nan, inf) have no spoken numeric form; return a
+        # clean textual sentinel rather than crashing downstream int() calls.
+        if isinstance(number, float) and not math.isfinite(number):
+            return str(number)
+
         if ordinals:
             return self.pronounce_ordinal(number, gender, scale)
 
         if number < 0:
             return f"{self.vocab.NEGATIVE_SIGN[0]} {self.pronounce_number(abs(number), places, scale=scale, digits=digits, gender=gender)}"
 
+        # Normalize the textual form so very large or scientific-notation floats
+        # (e.g. 6.022e23 -> "602200000000000000000000") do not leak an "e" into
+        # the decimal-splitting / int() logic below and crash.
+        num_str = str(number)
+        if isinstance(number, float) and ("e" in num_str or "E" in num_str):
+            num_str = format(Decimal(num_str), 'f')
+
         # Handle decimals
-        if "." in str(number):
+        if "." in num_str:
             integer_part = int(number)
-            decimal_part_str = str(number).split('.')[1].rstrip("0")
+            decimal_part_str = num_str.split('.')[1].rstrip("0")
 
             # Handle cases where the decimal part rounds to zero
             if decimal_part_str and int(decimal_part_str) == 0:

--- a/tests/test_romance_large_floats.py
+++ b/tests/test_romance_large_floats.py
@@ -1,0 +1,77 @@
+"""Regression tests for the shared RomanceNumberExtractor.pronounce_number.
+
+Very large floats and scientific-notation floats used to leak an exponent
+(``"e"``) into the decimal-splitting / ``int()`` logic and raise ValueError for
+every language that routes through the shared extractor (pt/ro/ast/oc/an/gl/mwl).
+These tests pin the no-crash contract and guard against regressions in the
+ordinary int/float/decimal behaviour.
+"""
+import math
+
+import pytest
+
+import ovos_number_parser as N
+from ovos_number_parser import PT_PT
+
+# languages that share RomanceNumberExtractor.pronounce_number in util.py
+ROMANCE_LANGS = ("pt", "ro", "ast", "oc", "an", "gl", "mwl")
+
+# large / scientific / near-zero floats that previously crashed
+PATHOLOGICAL = (
+    6.022e23,
+    1e300,
+    1.234e30,
+    9.999e50,
+    1e-5,
+    1.5e-3,
+    6.626e-34,
+    1e-300,
+    2.5e-10,
+    -6.022e23,
+    -1e-5,
+)
+
+
+@pytest.mark.parametrize("lang", ROMANCE_LANGS)
+@pytest.mark.parametrize("value", PATHOLOGICAL)
+def test_large_and_scientific_floats_do_not_crash(lang, value):
+    result = N.pronounce_number(value, lang)
+    assert isinstance(result, str)
+    assert result  # non-empty spoken form
+
+
+@pytest.mark.parametrize("value", PATHOLOGICAL)
+def test_negative_scientific_keeps_sign_word(value):
+    # sanity: negatives still route through the negative-sign branch
+    if value < 0:
+        assert N.pronounce_number(value, "pt").startswith(PT_PT.vocab.NEGATIVE_SIGN[0])
+
+
+@pytest.mark.parametrize("nonfinite", [float("nan"), float("inf"), float("-inf")])
+def test_extractor_nonfinite_returns_sentinel_not_crash(nonfinite):
+    # the shared extractor must never raise on non-finite floats; it returns a
+    # clean textual sentinel (the public API separately rejects NaN up front).
+    result = PT_PT.pronounce_number(nonfinite)
+    assert isinstance(result, str)
+    assert result
+
+
+@pytest.mark.parametrize("lang", ROMANCE_LANGS)
+def test_ordinary_values_unchanged(lang):
+    # normal ints/floats/decimals must be completely unaffected by the fix
+    for v in (0, 1, 42, 100, 1000, 1234567, 0.0, 3.14, 0.5, 12.75):
+        result = N.pronounce_number(v, lang)
+        assert isinstance(result, str) and result
+
+
+def test_specific_known_forms_pt():
+    # exact spoken forms for representative ordinary values (regression pins)
+    assert N.pronounce_number(3.14, "pt") == "três vírgula catorze"
+    assert N.pronounce_number(42, "pt") == "quarenta e dois"
+
+
+def test_scientific_integral_matches_plain_integer_pt():
+    # a scientific literal whose repr uses exponent notation and is integral
+    # pronounces like its integer value (str(1e16) == "1e+16")
+    assert N.pronounce_number(1e16, "pt") == N.pronounce_number(10 ** 16, "pt")
+    assert N.pronounce_number(1e17, "pt") == N.pronounce_number(10 ** 17, "pt")


### PR DESCRIPTION
Large and scientific-notation floats (e.g. `6.022e23`) crashed the shared `RomanceNumberExtractor.pronounce_number` with `ValueError`, affecting every language routed through it: pt, ro, ast, oc, an, gl, mwl. The exponent character leaked into the decimal-splitting and `int()` conversions.

The textual form is now normalized through `Decimal` before splitting, so exponent notation expands to a plain decimal string, and non-finite floats return a clean textual sentinel instead of crashing. Ordinary int/float/decimal pronunciation is unchanged.

Part of the scale-default cleanup around #165.

Tests: new `tests/test_romance_large_floats.py` covers large, scientific, near-zero, negative and non-finite floats across all seven affected languages, plus regression pins for ordinary values.