### PR TITLE
fix: parse Catalan long-scale words in extract_number

### DIFF
--- a/ovos_number_parser/__init__.py
+++ b/ovos_number_parser/__init__.py
@@ -390,7 +390,7 @@ def pronounce_number(number: Union[int, float], lang: str,
     if lang.startswith("bg"):
         return pronounce_number_bg(number, places, short_scale, scientific, ordinals)
     if lang.startswith("ca"):
-        return pronounce_number_ca(number, places)
+        return pronounce_number_ca(number, places, short_scale=short_scale)
     if lang.startswith("ast"):
         return AST.pronounce_number(number, places, scale, ordinals, digits, gender)
     if lang.startswith("oc"):

--- a/ovos_number_parser/numbers_ca.py
+++ b/ovos_number_parser/numbers_ca.py
@@ -1,5 +1,6 @@
 from typing import List
 import collections
+import math
 
 from ovos_number_parser.util import (convert_to_mixed_fraction, look_for_fractions,
                                      is_numeric, tokenize, Token)
@@ -258,6 +259,41 @@ _SHORT_SCALE_CA = collections.OrderedDict([
 ])
 
 
+def _build_scale_lookup_ca(scale):
+    """Reverse a value->word scale table into a word->value lookup.
+
+    Catalan scale words appear in speech in both singular and plural
+    ("un miliard" / "dos miliards", "un bilió" / "dos bilions"), so each
+    listed form is registered together with its regularly-formed variant.
+    """
+    lookup = {}
+    for value, word in scale.items():
+        forms = {word}
+        if word.endswith("ons"):
+            forms.add(word[:-3] + "ó")      # milions -> milió
+        elif word.endswith("ó"):
+            forms.add(word[:-1] + "ons")    # sextilió -> sextilions
+        elif word.endswith("rds"):
+            forms.add(word[:-1])            # miliards -> miliard
+        elif word.endswith("s"):
+            forms.add(word[:-1])            # generic plural -> singular
+        else:
+            forms.add(word + "s")
+        # magnitudes beyond the float range (1e309+) overflow to inf; keep
+        # them as floats rather than forcing an int conversion that would raise
+        numeric = int(value) if math.isfinite(float(value)) else float(value)
+        for form in forms:
+            lookup[form] = numeric
+    return lookup
+
+
+# Long and short scales assign different magnitudes to the same word
+# (e.g. "bilió" is 10^12 on the long scale but 10^9 on the short scale),
+# see https://en.wikipedia.org/wiki/Long_and_short_scales
+_LONG_SCALE_LOOKUP_CA = _build_scale_lookup_ca(_LONG_SCALE_CA)
+_SHORT_SCALE_LOOKUP_CA = _build_scale_lookup_ca(_SHORT_SCALE_CA)
+
+
 _TENS_CA = {
     "vint": 20,
     "trenta": 30,
@@ -501,6 +537,10 @@ def pronounce_number_ca(number, places=2, short_scale=False, scientific=False):
             result += "zero"
         result += " coma"
         _num_str = str(number)
+        if "." not in _num_str:
+            # tiny/large floats stringify in scientific notation ("1e-09"),
+            # which has no decimal point to split on; render it in fixed form
+            _num_str = f"{number:.{places}f}"
         _num_str = _num_str.split(".")[1][0:places]
         for char in _num_str:
             result += " " + _NUM_STRING_CA[int(char)]
@@ -564,7 +604,7 @@ def is_fractional_ca(input_str, short_scale=True):
     return False
 
 
-def extract_number_ca(text, short_scale=True, ordinals=False):
+def extract_number_ca(text, short_scale=False, ordinals=False):
     """
     This function prepares the given text for parsing by making
     numbers consistent, getting rid of contractions, etc.
@@ -576,15 +616,23 @@ def extract_number_ca(text, short_scale=True, ordinals=False):
     group that precedes them, and the products are summed, so
     "un milió dos-cents trenta-quatre mil sis-cents" reads 1 234 600.
 
+    Scale words above a million are read according to ``short_scale``. Catalan
+    uses the long scale, where each new scale word steps by a factor of a
+    million ("miliard" is 10^9, "bilió" is 10^12); on the short scale the same
+    word "bilió" instead denotes 10^9. See
+    https://en.wikipedia.org/wiki/Long_and_short_scales. The default is the
+    long scale, matching ``pronounce_number_ca`` so the two round-trip.
+
     Args:
         text (str): the string to normalize
+        short_scale (bool): interpret large scale words on the short scale
+            (default False, the long scale used in Catalan)
+        ordinals (bool): unused, kept for API compatibility
     Returns:
         (int) or (float): The value of extracted number
 
     """
-    # TODO: short_scale and ordinals don't do anything here.
-    # The parameters are present in the function signature for API compatibility
-    # reasons.
+    scale_lookup = _SHORT_SCALE_LOOKUP_CA if short_scale else _LONG_SCALE_LOOKUP_CA
     text = text.lower()
     aWords = text.split()
     negative = False
@@ -603,6 +651,7 @@ def extract_number_ca(text, short_scale=True, ordinals=False):
     current = 0
     while count < len(aWords):
         val = 0
+        is_scale = False
         word = aWords[count]
         next_next_word = None
         if count + 1 < len(aWords):
@@ -615,6 +664,10 @@ def extract_number_ca(text, short_scale=True, ordinals=False):
         # is current word a number?
         if word in _NUMBERS_CA:
             val = _NUMBERS_CA[word]
+        elif word in scale_lookup:
+            # long/short scale word above a million ("miliard", "bilió", ...)
+            val = scale_lookup[word]
+            is_scale = True
         elif '-' in word:
             wordparts = word.split('-')
             # trenta-cinc > 35
@@ -656,9 +709,10 @@ def extract_number_ca(text, short_scale=True, ordinals=False):
                 result = float(result) / float(val)
                 total = result
                 current = 0
-            elif val in (1000, 1000000, 1000000000):
-                # a thousand/million scale word multiplies the group being
-                # built and banks the product ("cinc-cents mil" -> 500*1000)
+            elif is_scale or val in (1000, 1000000):
+                # a thousand/million/higher scale word multiplies the group
+                # being built and banks the product ("cinc-cents mil" ->
+                # 500*1000, "dos miliards" -> 2*10^9)
                 total += (current or 1) * val
                 current = 0
                 result = total + current
@@ -688,7 +742,7 @@ def extract_number_ca(text, short_scale=True, ordinals=False):
             for word in newWords:
                 newText += word + " "
 
-            afterAndVal = extract_number_ca(newText[:-1])
+            afterAndVal = extract_number_ca(newText[:-1], short_scale)
             if afterAndVal:
                 if result < afterAndVal or result < 20:
                     while afterAndVal > 1:
@@ -708,7 +762,7 @@ def extract_number_ca(text, short_scale=True, ordinals=False):
                 newText = ""
                 for word in newWords:
                     newText += word + " "
-                afterAndVal = extract_number_ca(newText[:-1])
+                afterAndVal = extract_number_ca(newText[:-1], short_scale)
                 if afterAndVal:
                     if result is None:
                         result = 0
@@ -739,7 +793,7 @@ def extract_number_ca(text, short_scale=True, ordinals=False):
             if digits:
                 afterDotVal = digits
             else:
-                afterDotVal = str(extract_number_ca(newText[:-1]))
+                afterDotVal = str(extract_number_ca(newText[:-1], short_scale))
                 afterDotVal = zeros * "0" + afterDotVal
             result = float(str(result or 0) + "." + afterDotVal)
             break

--- a/tests/test_number_parser_ca.py
+++ b/tests/test_number_parser_ca.py
@@ -1,6 +1,7 @@
 import unittest
 
 from ovos_number_parser import extract_number, pronounce_number, is_fractional
+from ovos_number_parser.util import Scale
 
 
 class TestCatalanPronounce(unittest.TestCase):
@@ -76,6 +77,83 @@ class TestCatalanRoundTrip(unittest.TestCase):
             with self.subTest(number=number):
                 spoken = pronounce_number(number, lang="ca")
                 self.assertEqual(extract_number(spoken, lang="ca"), number)
+
+
+class TestCatalanLongScale(unittest.TestCase):
+    """Catalan is a long-scale language: miliard=10^9, bilió=10^12.
+
+    See https://en.wikipedia.org/wiki/Long_and_short_scales
+    """
+
+    def test_extract_long_scale_words(self):
+        expected = {
+            'un miliard': 10 ** 9,
+            'un bilió': 10 ** 12,
+            'dos miliards': 2 * 10 ** 9,
+            'tres bilions': 3 * 10 ** 12,
+            'cinc miliards': 5 * 10 ** 9,
+            'un bilió dos miliards': 10 ** 12 + 2 * 10 ** 9,
+            'dos milions cinc-cents mil': 2500000,
+        }
+        for spoken, number in expected.items():
+            with self.subTest(spoken=spoken):
+                self.assertEqual(
+                    extract_number(spoken, lang="ca", scale=Scale.LONG), number)
+
+    def test_short_scale_reads_billion_as_ten_pow_nine(self):
+        # the same word "bilió" is 10^9 on the short scale
+        self.assertEqual(
+            extract_number('un bilió', lang="ca", scale=Scale.SHORT), 10 ** 9)
+        self.assertEqual(
+            extract_number('un trilió', lang="ca", scale=Scale.SHORT), 10 ** 12)
+
+    def test_pronounce_long_scale(self):
+        self.assertEqual(
+            pronounce_number(10 ** 9, lang="ca", scale=Scale.LONG), 'un miliard')
+        self.assertEqual(
+            pronounce_number(10 ** 12, lang="ca", scale=Scale.LONG), 'un bilió')
+
+    def test_round_trip_both_directions(self):
+        # pronounce -> extract and (word -> extract -> pronounce) at each order
+        for scale in (Scale.LONG, Scale.SHORT):
+            for number in (10 ** 6, 10 ** 9, 10 ** 12):
+                with self.subTest(scale=scale, number=number):
+                    spoken = pronounce_number(number, lang="ca", scale=scale)
+                    self.assertEqual(
+                        extract_number(spoken, lang="ca", scale=scale), number)
+
+    def test_long_and_short_disagree_above_million(self):
+        long_val = extract_number('un bilió', lang="ca", scale=Scale.LONG)
+        short_val = extract_number('un bilió', lang="ca", scale=Scale.SHORT)
+        self.assertNotEqual(long_val, short_val)
+        self.assertEqual(long_val, 10 ** 12)
+        self.assertEqual(short_val, 10 ** 9)
+
+    def test_scale_word_alone_without_multiplier(self):
+        # a bare scale word ("miliard") still counts as one unit
+        self.assertEqual(
+            extract_number('miliard', lang="ca", scale=Scale.LONG), 10 ** 9)
+
+    def test_unknown_scale_word_for_scale_is_ignored(self):
+        # "miliard" is not a short-scale word; extraction must not invent it
+        self.assertEqual(
+            extract_number('un miliard', lang="ca", scale=Scale.SHORT), 1)
+
+    def test_no_number_still_false_with_scale(self):
+        self.assertIn(
+            extract_number("hola com estàs", lang="ca", scale=Scale.LONG),
+            (False, None))
+
+
+class TestCatalanTinyFloat(unittest.TestCase):
+    """Scientific-notation floats must not crash pronunciation."""
+
+    def test_tiny_float_does_not_crash(self):
+        for number in (1e-9, 1e-12, -1e-9, 1e-300):
+            with self.subTest(number=number):
+                spoken = pronounce_number(number, lang="ca")
+                self.assertIsInstance(spoken, str)
+                self.assertTrue(spoken)
 
 
 class TestCatalanFractions(unittest.TestCase):


### PR DESCRIPTION
## Problem

`extract_number` for Catalan discarded every scale word above a million, so long-scale magnitudes collapsed to their leading unit: `extract_number('un miliard', 'ca', scale=Scale.LONG)` returned `1` (expected 10^9) and `extract_number('un bilió', 'ca', scale=Scale.LONG)` returned `1` (expected 10^12). Pronunciation of those magnitudes was already correct, so the two directions did not round-trip.

## Fix

- Build a reverse lookup from the long/short scale tables, registering each word alongside its regular singular/plural variant (`miliard`/`miliards`, `bilió`/`bilions`).
- Bank a matched scale word as a group multiplier, mirroring the existing thousand/million handling, so `un bilió dos miliards` reads 10^12 + 2·10^9.
- Interpret the same word by scale: `bilió` is 10^12 on the long scale and 10^9 on the short scale, per [Long and short scales](https://en.wikipedia.org/wiki/Long_and_short_scales).

## Default reconciliation

`extract_number_ca` defaulted to the short scale while `pronounce_number_ca` defaulted to the long scale, so direct calls could not round-trip. Both now default to the long scale used in Catalan, and the pronounce wrapper forwards the requested scale so short and long both round-trip in either direction.

## Also

Pronouncing tiny/scientific floats (e.g. `1e-9`) raised `IndexError` because the string form carries no decimal point; it now renders in fixed form.

Builds on the scale-default root PR #165.

## Tests

Extended `tests/test_number_parser_ca.py`: long-scale extraction, short-scale divergence, pronounce↔extract round-trips at 10^6/10^9/10^12 in both scales and directions, bare/unknown scale-word boundaries, and tiny-float pronunciation. Full suite: 1200 passed, 1 skipped, 1 xfailed.