### PR TITLE
refactor: migrate Catalan numbers onto the shared Romance engine

### DIFF
--- a/ovos_number_parser/__init__.py
+++ b/ovos_number_parser/__init__.py
@@ -10,7 +10,8 @@ from ovos_number_parser.numbers_ar import pronounce_number_ar, pronounce_ordinal
 from ovos_number_parser.numbers_az import numbers_to_digits_az, extract_number_az, is_fractional_az, pronounce_number_az
 from ovos_number_parser.numbers_bg import numbers_to_digits_bg, pronounce_number_bg, extract_number_bg, \
     is_fractional_bg, nice_number_bg
-from ovos_number_parser.numbers_ca import numbers_to_digits_ca, pronounce_number_ca, is_fractional_ca, extract_number_ca
+from ovos_number_parser.numbers_ca import (numbers_to_digits_ca, pronounce_number_ca,
+    is_fractional_ca, extract_number_ca, CA)
 from ovos_number_parser.numbers_cs import numbers_to_digits_cs, pronounce_number_cs, is_fractional_cs, \
     extract_number_cs, pronounce_ordinal_cs
 from ovos_number_parser.numbers_da import numbers_to_digits_da, pronounce_number_da, is_fractional_da, is_ordinal_da, \
@@ -445,7 +446,7 @@ def pronounce_number(number: Union[int, float], lang: str,
     if lang.startswith("bg"):
         return pronounce_number_bg(number, places, short_scale, scientific, ordinals)
     if lang.startswith("ca"):
-        return pronounce_number_ca(number, places, short_scale=short_scale)
+        return CA.pronounce_number(number, places, scale, ordinals, gender=gender)
     if lang.startswith("ast"):
         return AST.pronounce_number(number, places, scale, ordinals, digits, gender)
     if lang.startswith("oc"):
@@ -546,6 +547,8 @@ def pronounce_fraction(fraction_word: str, lang: str, scale: Optional[Scale] = N
             else PT_PT.pronounce_fraction(fraction_word, scale=scale)
     elif lang.startswith("ast"):
         return AST.pronounce_fraction(fraction_word, scale=scale)
+    elif lang.startswith("ca"):
+        return CA.pronounce_fraction(fraction_word, scale=scale)
     elif lang.startswith("oc"):
         return OC.pronounce_fraction(fraction_word, scale=scale)
     elif lang.startswith("an"):
@@ -590,6 +593,8 @@ def pronounce_ordinal(number: Union[int, float], lang: str,
         return RO.pronounce_ordinal(number, scale=scale, gender=gender)
     if lang.startswith("ast"):
         return AST.pronounce_ordinal(number, scale=scale, gender=gender)
+    if lang.startswith("ca"):
+        return CA.pronounce_ordinal(number, scale=scale, gender=gender)
     if lang.startswith("oc"):
         return OC.pronounce_ordinal(number, scale=scale, gender=gender)
     if lang.startswith("an"):
@@ -694,7 +699,7 @@ def extract_number(text: str, lang: str,
     if lang.startswith("bg"):
         return extract_number_bg(text, short_scale, ordinals)
     if lang.startswith("ca"):
-        return extract_number_ca(text, short_scale, ordinals)
+        return CA.extract_number(text, ordinals=ordinals, scale=scale)
     if lang.startswith("cs"):
         return extract_number_cs(text, short_scale, ordinals)
     if lang.startswith("da"):
@@ -801,7 +806,7 @@ def is_fractional(input_str: str, lang: str,
     if lang.startswith("bg"):
         return is_fractional_bg(input_str, short_scale)
     if lang.startswith("ca"):
-        return is_fractional_ca(input_str, short_scale)
+        return CA.is_fractional(input_str)
     if lang.startswith("cs"):
         return is_fractional_cs(input_str, short_scale)
     if lang.startswith("da"):
@@ -895,6 +900,8 @@ def is_ordinal(input_str: str, lang: str) -> Union[bool, float]:
         return RO.is_ordinal(input_str)
     if lang.startswith("ast"):
         return AST.is_ordinal(input_str)
+    if lang.startswith("ca"):
+        return CA.is_ordinal(input_str)
     if lang.startswith("oc"):
         return OC.is_ordinal(input_str)
     if lang.startswith("an"):

--- a/ovos_number_parser/numbers_ca.py
+++ b/ovos_number_parser/numbers_ca.py
@@ -1,74 +1,12 @@
-from typing import List
-import collections
-import math
+import re
+import warnings
+from typing import Optional, Union
 
-from ovos_number_parser.util import (convert_to_mixed_fraction, look_for_fractions,
-                                     is_numeric, tokenize, Token)
+from ovos_number_parser.util import (convert_to_mixed_fraction, DigitPronunciation,
+                                     Scale, GrammaticalGender, NumberVocabulary,
+                                     RomanceNumberExtractor)
 
-_NUMBERS_CA = {
-    "zero": 0,
-    "u": 1,
-    "un": 1,
-    "una": 1,
-    "uns": 1,
-    "unes": 1,
-    "primer": 1,
-    "primera": 1,
-    "segon": 2,
-    "segona": 2,
-    "tercer": 3,
-    "tercera": 3,
-    "dos": 2,
-    "dues": 2,
-    "tres": 3,
-    "quatre": 4,
-    "cinc": 5,
-    "sis": 6,
-    "set": 7,
-    "vuit": 8,
-    "huit": 8,
-    "nou": 9,
-    "deu": 10,
-    "onze": 11,
-    "dotze": 12,
-    "tretze": 13,
-    "catorze": 14,
-    "quinze": 15,
-    "setze": 16,
-    "disset": 17,
-    "divuit": 18,
-    "dinou": 19,
-    "vint": 20,
-    "trenta": 30,
-    "quaranta": 40,
-    "cinquanta": 50,
-    "seixanta": 60,
-    "setanta": 70,
-    "vuitanta": 80,
-    "noranta": 90,
-    "cent": 100,
-    "cents": 100,
-    "dos-cents": 200,
-    "dues-centes": 200,
-    "tres-cents": 300,
-    "tres-centes": 300,
-    "quatre-cents": 400,
-    "quatre-centes": 400,
-    "cinc-cents": 500,
-    "cinc-centes": 500,
-    "sis-cents": 600,
-    "sis-centes": 600,
-    "set--cents": 700,
-    "set-centes": 700,
-    "vuit-cents": 800,
-    "vuit-centes": 800,
-    "nou-cents": 900,
-    "nou-centes": 900,
-    "mil": 1000,
-    "milió": 1000000,
-    "milions": 1000000
-}
-
+# Fraction nouns, kept for the standalone ``nice_number_ca`` helper below.
 _FRACTION_STRING_CA = {
     2: 'mig',
     3: 'terç',
@@ -94,251 +32,293 @@ _FRACTION_STRING_CA = {
     1000: 'milè'
 }
 
-_NUM_STRING_CA = {
-    0: 'zero',
-    1: 'un',
-    2: 'dos',
-    3: 'tres',
-    4: 'quatre',
-    5: 'cinc',
-    6: 'sis',
-    7: 'set',
-    8: 'vuit',
-    9: 'nou',
-    10: 'deu',
-    11: 'onze',
-    12: 'dotze',
-    13: 'tretze',
-    14: 'catorze',
-    15: 'quinze',
-    16: 'setze',
-    17: 'disset',
-    18: 'divuit',
-    19: 'dinou',
-    20: 'vint',
-    30: 'trenta',
-    40: 'quaranta',
-    50: 'cinquanta',
-    60: 'seixanta',
-    70: 'setanta',
-    80: 'vuitanta',
-    90: 'noranta'
-}
+# Tens words that open a hyphenated tens-units compound. The Institut d'Estudis
+# Catalans normativa (Optimot fitxa "Guionet en els numerals compostos",
+# https://aplicacions.llengua.gencat.cat/llc/AppJava/index.html?action=Principal&method=detall&idFont=11676;
+# Consorci per a la Normalització Lingüística "6. Els numerals",
+# https://www.cpnl.cat/gramatica/24/6-els-numerals) requires a guionet between
+# the tens and the units and, in the twenties, the fused conjunction "-i-":
+# "vint-i-u", "trenta-dos", "quaranta-cinc".
+_HYPHEN_TENS_CA = ("vint", "trenta", "quaranta", "cinquanta", "seixanta",
+                   "setanta", "vuitanta", "noranta")
+_HYPHEN_UNITS_CA = ("un", "una", "u", "dos", "dues", "tres", "quatre", "cinc",
+                    "sis", "set", "vuit", "nou")
 
-# source: https://ca.wikipedia.org/wiki/Escales_curta_i_llarga
-_LONG_SCALE_CA = collections.OrderedDict([
-    (100, 'cent'),
-    (1000, 'mil'),
-    (1000000, 'milions'),
-    (1e9, "miliards"),
-    (1e12, "bilions"),
-    (1e15, "biliards"),
-    (1e18, "trilions"),
-    (1e21, "triliards"),
-    (1e24, "quadrilions"),
-    (1e27, "quadriliards"),
-    (1e30, "quintilions"),
-    (1e33, "quintiliards"),
-    (1e36, "sextilió"),
-    (1e39, "sextiliard"),
-    (1e42, "septilió"),
-    (1e45, "septiliard"),
-    (1e48, "octilió"),
-    (1e51, "octiliards"),
-    (1e54, "nonilió"),
-    (1e57, "noniliards"),
-    (1e60, "decilió"),
-    (1e63, "deciliard"),
-    (1e66, "undecilió"),
-    (1e69, "undeciliard"),
-    (1e72, "duodecilió"),
-    (1e75, "duodeciliard"),
-    (1e78, "tredecilió"),
-    (1e81, "tredeciliard"),
-    (1e84, "quattuordecilió"),
-    (1e87, "quattuordeciliard"),
-    (1e90, "quindecilió"),
-    (1e93, "quindeciliard"),
-    (1e96, "sexdecilió"),
-    (1e99, "sexdeciliard"),
-    (1e102, "septendecilió"),
-    (1e105, "septendeciliard"),
-    (1e108, "octodecilió"),
-    (1e111, "octodeciliard"),
-    (1e114, "novemdecilió"),
-    (1e117, "novemdeciliard"),
-    (1e120, "vigintilions"),
-    (1e123, "vigintiliard"),
-
-    (1e306, "unquinquagintilió"),
-    (1e312, "duoquinquagintilió"),
-    (1e360, "sexagintilió"),
-    (1e363, "sexagintiliard"),
-    (1e420, "septuagintilió"),
-    (1e423, "septuagintiliard"),
-    (1e480, "octogintilió"),
-    (1e483, "octogintilliard"),
-    (1e540, "nonagintilió"),
-    (1e543, "nonagintiliard"),
-    (1e600, "centilió"),
-    (1e603, "centiliard")
-])
-
-_SHORT_SCALE_CA = collections.OrderedDict([
-    (100, 'cent'),
-    (1000, 'mil'),
-    (1000000, 'milions'),
-    (1e9, 'bilions'),
-    (1e12, "trilions"),
-    (1e15, "quadrilions"),
-    (1e18, "quintilions"),
-    (1e21, "sextilions"),
-    (1e24, "septilions"),
-    (1e27, "octilions"),
-    (1e30, "nonilions"),
-    (1e33, "decilions"),
-    (1e36, "undecilions"),
-    (1e39, "duodecilions"),
-    (1e42, "tredecilions"),
-    (1e45, "quattordecilions"),
-    (1e48, "quindecilions"),
-    (1e51, "sexdecilions"),
-    (1e54, "septendecilions"),
-    (1e57, "octodecilions"),
-    (1e60, "novemdecilions"),
-    (1e63, "vigintilions"),
-    (1e66, "unvigintilions"),
-    (1e69, "duovigintilions"),
-    (1e72, "tresvigintilions"),
-    (1e75, "quattuorvigintilions"),
-    (1e78, "quinquavigintilions"),
-    (1e81, "sexvigintilions"),
-    (1e84, "septemvigintilions"),
-    (1e87, "octovigintilions"),
-    (1e90, "novemvigintilions"),
-    (1e93, "trigintilions"),
-    (1e96, "untrigintilions"),
-    (1e99, "duotrigintilions"),
-    (1e102, "trestrigintilions"),
-    (1e105, "quattuortrigintilions"),
-    (1e108, "quinquatrigintilions"),
-    (1e111, "sestrigintilions"),
-    (1e114, "septentrigintilions"),
-    (1e117, "octotrigintilions"),
-    (1e120, "noventrigintilions"),
-    (1e123, "quadragintilions"),
-    (1e153, "quinquagintilions"),
-    (1e183, "sexagintilions"),
-    (1e213, "septuagintilions"),
-    (1e243, "octogintilions"),
-    (1e273, "nonagintilions"),
-    (1e303, "centilions"),
-    (1e306, "uncentilions"),
-    (1e309, "duocentilions"),
-    (1e312, "trescentilions"),
-    (1e333, "decicentilions"),
-    (1e336, "undecicentilions"),
-    (1e363, "viginticentilions"),
-    (1e366, "unviginticentilions"),
-    (1e393, "trigintacentilions"),
-    (1e423, "quadragintacentilions"),
-    (1e453, "quinquagintacentilions"),
-    (1e483, "sexagintacentilions"),
-    (1e513, "septuagintacentilions"),
-    (1e543, "octogintacentilions"),
-    (1e573, "nonagintacentilions"),
-    (1e603, "ducentilions"),
-    (1e903, "trecentilions"),
-    (1e1203, "quadringentilions"),
-    (1e1503, "quingentilions"),
-    (1e1803, "sescentilions"),
-    (1e2103, "septingentilions"),
-    (1e2403, "octingentilions"),
-    (1e2703, "nongentilions"),
-    (1e3003, "milinilions")
-])
+_TWENTY_RE_CA = re.compile(
+    r"\bvint i (" + "|".join(_HYPHEN_UNITS_CA) + r")\b")
+_TENS_RE_CA = re.compile(
+    r"\b(" + "|".join(_HYPHEN_TENS_CA) + r") (" + "|".join(_HYPHEN_UNITS_CA) + r")\b")
 
 
-def _build_scale_lookup_ca(scale):
-    """Reverse a value->word scale table into a word->value lookup.
+def _hyphenate_ca(text: str) -> str:
+    """Join spoken tens-units compounds with the normative guionet.
 
-    Catalan scale words appear in speech in both singular and plural
-    ("un miliard" / "dos miliards", "un bilió" / "dos bilions"), so each
-    listed form is registered together with its regularly-formed variant.
+    The shared engine composes a tens-units group with spaces ("vint i tres",
+    "quaranta dos"); Catalan writes them hyphenated ("vint-i-tres",
+    "quaranta-dos"), the twenties keeping the fused "-i-". Idempotent, so it may
+    run at every recursion level without harm.
     """
-    lookup = {}
-    for value, word in scale.items():
-        forms = {word}
-        if word.endswith("ons"):
-            forms.add(word[:-3] + "ó")      # milions -> milió
-        elif word.endswith("ó"):
-            forms.add(word[:-1] + "ons")    # sextilió -> sextilions
-        elif word.endswith("rds"):
-            forms.add(word[:-1])            # miliards -> miliard
-        elif word.endswith("s"):
-            forms.add(word[:-1])            # generic plural -> singular
-        else:
-            forms.add(word + "s")
-        # magnitudes beyond the float range (1e309+) overflow to inf; keep
-        # them as floats rather than forcing an int conversion that would raise
-        numeric = int(value) if math.isfinite(float(value)) else float(value)
-        for form in forms:
-            lookup[form] = numeric
-    return lookup
+    text = _TWENTY_RE_CA.sub(r"vint-i-\1", text)
+    text = _TENS_RE_CA.sub(r"\1-\2", text)
+    return text
 
 
-# Long and short scales assign different magnitudes to the same word
-# (e.g. "bilió" is 10^12 on the long scale but 10^9 on the short scale),
-# see https://en.wikipedia.org/wiki/Long_and_short_scales
-_LONG_SCALE_LOOKUP_CA = _build_scale_lookup_ca(_LONG_SCALE_CA)
-_SHORT_SCALE_LOOKUP_CA = _build_scale_lookup_ca(_SHORT_SCALE_CA)
+def swap_gender_ca(word: str, gender: GrammaticalGender) -> str:
+    """Swap Catalan numeral/ordinal words between masculine and feminine.
+
+    Handles the gendered cardinals ("un"/"una", "dos"/"dues",
+    "dos-cents"/"dues-centes") and the ordinal/fraction endings
+    ("cinquè"/"cinquena", "quart"/"quarta").
+    """
+    if gender == GrammaticalGender.FEMININE:
+        if word == "un":
+            return "una"
+        if word == "dos":
+            return "dues"
+        if word == "mig":
+            return "mitja"
+        if "cents" in word:
+            word = word.replace("cents", "centes")
+            if word.startswith("dos"):
+                word = "dues" + word[3:]
+            return word
+        if word.endswith("è"):
+            return word[:-1] + "ena"       # cinquè -> cinquena, centè -> centena
+        if word.endswith(("r", "n", "t", "ç")):
+            return word + "a"              # primer -> primera, quart -> quarta
+        return word
+    # masculine: undo the feminine spellings
+    if word == "una":
+        return "un"
+    if word == "dues":
+        return "dos"
+    if word == "mitja":
+        return "mig"
+    if "centes" in word:
+        word = word.replace("centes", "cents")
+        if word.startswith("dues"):
+            word = "dos" + word[4:]
+        return word
+    if word.endswith("ena"):
+        return word[:-3] + "è"
+    return word
 
 
-_TENS_CA = {
-    "vint": 20,
-    "trenta": 30,
-    "quaranta": 40,
-    "cinquanta": 50,
-    "seixanta": 60,
-    "setanta": 70,
-    "vuitanta": 80,
-    "huitanta": 80,
-    "noranta": 90
-}
+def pluralize_ca(word: str) -> str:
+    """Regular Catalan plural for the scale/fraction words used here."""
+    if word.endswith("ó"):
+        return word[:-1] + "ons"           # milió -> milions, bilió -> bilions
+    if word.endswith("è"):
+        return word[:-1] + "ens"           # cinquè -> cinquens
+    if word.endswith("ç"):
+        return word + "os"                 # terç -> terços
+    if not word.endswith("s"):
+        return word + "s"                  # miliard -> miliards
+    return word
 
-_AFTER_TENS_CA = {
-    "u": 1,
-    "un": 1,
-    "dos": 2,
-    "dues": 2,
-    "tres": 3,
-    "quatre": 4,
-    "cinc": 5,
-    "sis": 6,
-    "set": 7,
-    "vuit": 8,
-    "huit": 8,
-    "nou": 9
-}
 
-_BEFORE_HUNDREDS_CA = {
-    "dos": 2,
-    "dues": 2,
-    "tres": 3,
-    "quatre": 4,
-    "cinc": 5,
-    "sis": 6,
-    "set": 7,
-    "vuit": 8,
-    "huit": 8,
-    "nou": 9,
-}
+_CA = NumberVocabulary(
+    LANG="ca",
+    swap_gender=swap_gender_ca,
+    pluralize=pluralize_ca,
 
-_HUNDREDS_CA = {
-    "cent": 100,
-    "cents": 100,
-    "centes": 100
-}
+    HUNDRED_PARTICLE="cent",  # Catalan does not apocopate: "cent", "cent un"
+    DENOMINATOR_PARTICLE="avos",
+    DIVIDED_BY_ZERO="dividit per zero",
+    NO_PREV_UNIT=[1000],  # "mil" not "un mil"
+    NO_PLURAL=[1000],     # "dos mil" not "dos mils"
+
+    NUMBER_OVERFLOW="número exageradament gran",
+    DEFAULT_SCALE=Scale.LONG,  # 10^9 = "miliard", 10^12 = "bilió"
+    JOIN_WORD=["i"],
+
+    JOINER_ON_TWENTYS=True,       # "vint i un" (hyphenated on output)
+    JOINER_ONLY_ON_TWENTYS=True,  # "trenta dos", not "trenta i dos"
+    JOINER_ON_HUNDREDS=False,     # "cent vint-i-tres", "dos-cents trenta-quatre"
+    JOINER_ON_THOUSANDS=False,    # "mil dos-cents"
+    JOINER_ON_SCALE_REMAINDER=False,  # "dos mil vint-i-tres", not "... i ..."
+    MULTIPLY_HUNDREDS=True,       # "dos cents" (from "dos-cents") = 200
+
+    DECIMAL_MARKER=["coma", "amb", "punt", ".", ","],
+    NEGATIVE_SIGN=["menys"],
+    UNITS={
+        0: 'zero',
+        1: 'un',
+        2: 'dos',
+        3: 'tres',
+        4: 'quatre',
+        5: 'cinc',
+        6: 'sis',
+        7: 'set',
+        8: 'vuit',
+        9: 'nou',
+    },
+    TENS={
+        10: 'deu',
+        11: 'onze',
+        12: 'dotze',
+        13: 'tretze',
+        14: 'catorze',
+        15: 'quinze',
+        16: 'setze',
+        17: 'disset',
+        18: 'divuit',
+        19: 'dinou',
+        20: 'vint',
+        30: 'trenta',
+        40: 'quaranta',
+        50: 'cinquanta',
+        60: 'seixanta',
+        70: 'setanta',
+        80: 'vuitanta',
+        90: 'noranta'
+    },
+    HUNDREDS={
+        200: 'dos-cents',
+        300: 'tres-cents',
+        400: 'quatre-cents',
+        500: 'cinc-cents',
+        600: 'sis-cents',
+        700: 'set-cents',
+        800: 'vuit-cents',
+        900: 'nou-cents'
+    },
+    FRACTION={
+        2: 'mig',
+        3: 'terç',
+        4: 'quart',
+        5: 'cinquè',
+        6: 'sisè',
+        7: 'setè',
+        8: 'vuitè',
+        9: 'novè',
+        10: 'desè',
+        11: 'onzè',
+        12: 'dotzè',
+        13: 'tretzè',
+        14: 'catorzè',
+        15: 'quinzè',
+        16: 'setzè',
+        17: 'dissetè',
+        18: 'divuitè',
+        19: 'dinovè',
+        20: 'vintè',
+        30: 'trentè',
+        100: 'centè',
+        1000: 'milè'
+    },
+    FRACTION_FEMALE={
+        2: 'mitja',
+        3: 'terça',
+        4: 'quarta'
+    },
+    SHORT_SCALE={
+        1000: 'mil',
+        10 ** 6: 'milió',
+        10 ** 9: 'bilió',
+        10 ** 12: 'trilió',
+        10 ** 15: 'quadrilió',
+        10 ** 18: 'quintilió',
+        10 ** 21: 'sextilió',
+        10 ** 24: 'septilió',
+    },
+    LONG_SCALE={
+        1000: 'mil',
+        10 ** 6: 'milió',
+        10 ** 9: 'miliard',
+        10 ** 12: 'bilió',
+        10 ** 15: 'biliard',
+        10 ** 18: 'trilió',
+        10 ** 21: 'triliard',
+        10 ** 24: 'quadrilió',
+    },
+
+    GENDERED_SPELLINGS={
+        GrammaticalGender.FEMININE: {
+            1: "una",
+            2: "dues"
+        }
+    },
+    DIGIT_SPELLINGS={},
+    ALT_SPELLINGS={
+        # standalone "u" (before nouns it becomes "un"), dialectal "huit" forms,
+        # and the bare hundreds particle used inside compounds after the hyphen
+        # is split off for extraction ("dos-cents" -> "dos cents")
+        "u": 1,
+        "huit": 8,
+        "huitanta": 80,
+        "cents": 100,
+        "centes": 100,
+    },
+    ORDINAL_UNITS={
+        1: 'primer',
+        2: 'segon',
+        3: 'tercer',
+        4: 'quart',
+        5: 'cinquè',
+        6: 'sisè',
+        7: 'setè',
+        8: 'vuitè',
+        9: 'novè',
+    },
+    ORDINAL_TENS={
+        10: 'desè',
+        11: 'onzè',
+        12: 'dotzè',
+        13: 'tretzè',
+        14: 'catorzè',
+        15: 'quinzè',
+        16: 'setzè',
+        17: 'dissetè',
+        18: 'divuitè',
+        19: 'dinovè',
+        20: 'vintè',
+        30: 'trentè',
+        40: 'quarantè',
+        50: 'cinquantè',
+        60: 'seixantè',
+        70: 'setantè',
+        80: 'vuitantè',
+        90: 'norantè'
+    },
+    ORDINAL_HUNDREDS={
+        100: 'centè'
+    },
+    ORDINAL_SHORT_SCALE={
+        10 ** 3: 'milè',
+        10 ** 6: 'milionè'
+    },
+    ORDINAL_LONG_SCALE={
+        10 ** 3: 'milè',
+        10 ** 6: 'milionè'
+    }
+)
+
+
+class CatalanNumberExtractor(RomanceNumberExtractor):
+    """Catalan number engine.
+
+    Adds the two Catalan-specific surface conventions the shared engine does
+    not model: hyphenated tens-units compounds on output and a digit-by-digit
+    decimal reading ("tres coma un quatre" for 3.14).
+    """
+
+    def pronounce_number(self,
+                         number: Union[int, float],
+                         places: int = 5,
+                         scale: Optional[Scale] = None,
+                         ordinals: bool = False,
+                         digits: DigitPronunciation = DigitPronunciation.DIGIT_BY_DIGIT,
+                         gender: GrammaticalGender = GrammaticalGender.MASCULINE,
+                         _force_hundreds_join: bool = False,
+                         _under_higher_scale: bool = False) -> str:
+        spoken = super().pronounce_number(number, places, scale, ordinals,
+                                          digits, gender, _force_hundreds_join,
+                                          _under_higher_scale)
+        return _hyphenate_ca(spoken)
+
+
+CA = CatalanNumberExtractor(_CA)
 
 
 def nice_number_ca(number, speech, denominators=range(1, 21)):
@@ -381,462 +361,80 @@ def nice_number_ca(number, speech, denominators=range(1, 21)):
         else:
             # quatre cinquens
             return_string = '{} {}'.format(num, den_str)
-    
+
     else:
         # vint i 3 desens
         return_string = '{} i {} {}'.format(whole, num, den_str)
     # plural
     if num > 1:
         if return_string[-1] == "è":
-           return_string =  return_string[:-1] + "ens"
+            return_string = return_string[:-1] + "ens"
         else:
             return_string += 's'
     return return_string
 
 
+##################################################################
+# all methods below are deprecated and only for backwards compat
+##################################################################
+
 def pronounce_number_ca(number, places=2, short_scale=False, scientific=False):
     """
-    Convert a number to it's spoken equivalent
-     For example, '5.2' would return 'cinc coma dos'
-     Args:
-        number(float or int): the number to pronounce
-        places(int): maximum decimal places to speak
-    Returns:
-        (str): The pronounced number
+    DEPRECATED
     """
-    
-    result = ""
-    if number < 0:
-        result = "menys "
-    number = abs(number)
-
-    if number == float("inf"):
-        return "infinit"
-    elif number == float("-inf"):
-        return "menys infinit"
-
-    number_names = _NUM_STRING_CA.copy()
-
-    if short_scale:
-        number_names.update(_SHORT_SCALE_CA)
-    else:
-        number_names.update(_LONG_SCALE_CA)      
-
-    digits = [number_names[n] for n in range(0, 20)]
-
-    tens = [number_names[n] for n in range(10, 100, 10)]
-
-    if short_scale==True:
-        hundreds = [_SHORT_SCALE_CA[n] for n in _SHORT_SCALE_CA.keys()]
-    else:
-        hundreds = [_LONG_SCALE_CA[n] for n in _LONG_SCALE_CA.keys()]
-    
-        
-    
-    if number in number_names: # check for a direct match 
-        result += number_names[number]
-    else:
-        def _sub_thousand(n):
-            assert 0 <= n <= 999
-            if n <= 19:
-                return digits[n]
-            elif n <= 99:
-                q, r = divmod(n, 10)
-                _deci = tens[q - 1]
-                _unit = r
-                _partial = _deci
-                if _unit > 0:
-                    if _deci == "vint":
-                        _partial = _partial + "-i-" + number_names[_unit]
-                    else:
-                        _partial = _partial + "-" + number_names[_unit]
-                return _partial
-            else:
-                q, r = divmod(n, 100)
-                if q == 1:
-                    _partial = "cent"
-                else:
-                    _partial = digits[q] + "-cents"
-                _partial += (
-                    " " + _sub_thousand(r) if r else "")  # separa centenars
-                return _partial
-
-        def _short_scale(n):
-            if n >= max(_SHORT_SCALE_CA.keys()):
-                return "número extremadament gran"
-            n = int(n)
-            assert 0 <= n
-            res = []
-            for i, z in enumerate(_split_by(n, 1000)):
-                if not z:
-                    continue
-                number = _sub_thousand(z)
-                if i:
-                    number += " "  # separa ordres de magnitud
-                    number += hundreds[i]
-                    if number == "un mil":
-                        number = "mil"
-                res.append(number)
-
-            return " ".join(reversed(res))
-
-        def _split_by(n, split=1000):
-            assert 0 <= n
-            res = []
-            while n:
-                n, r = divmod(n, split)
-                res.append(r)
-            return res
-
-        def _long_scale(n):
-            if n >= max(_LONG_SCALE_CA.keys()):
-                return "número extremadament gran"
-            n = int(n)
-            assert 0 <= n
-            res = []
-            for i, z in enumerate(_split_by(n, 1000000)):
-                if not z:
-                    continue
-                number = pronounce_number_ca(z, places, True, scientific)
-                # strip off the comma after the thousand
-                if i:
-                    # plus one as we skip 'thousand'
-                    # (and 'hundred', but this is excluded by index value)
-                    number = number.replace(',', '')
-                    number += " " + hundreds[i + 1]
-                res.append(number)
-            return " ".join(reversed(res))
-
-        if short_scale:
-            result += _short_scale(number)
-        else:
-            result += _long_scale(number)
-
-    big_nums = [_LONG_SCALE_CA[a] for a in _LONG_SCALE_CA]
-    if result in big_nums:
-        if result[-3:] == "rds":
-            result = "un " + result[:-1]
-        elif result[-3:] == "ons":
-            result = "un " + result[:-3] + "ó"
-    if len(result.split(" ")) > 1 and result.split(" ")[0] == "un":
-        big_num = result.split(" ")[1]
-        if big_num in big_nums:
-            new_big_num = big_num
-            if big_num[-3:] == "rds":
-                new_big_num = big_num[:-1]
-
-            elif big_num[-3:] == "ons":
-                new_big_num = big_num[:-3] + "ó"             
-            result = result.replace(big_num, new_big_num)
-
-    # Deal with decimal part, in Catalan is commonly used the comma
-    # instead the dot. Decimal part can be written both with comma
-    # and dot, but when pronounced, its pronounced "coma"
-    if not number == int(number) and places > 0:
-        if abs(number) < 1.0 and (result == "menys " or not result):
-            result += "zero"
-        result += " coma"
-        _num_str = str(number)
-        if "." not in _num_str:
-            # tiny/large floats stringify in scientific notation ("1e-09"),
-            # which has no decimal point to split on; render it in fixed form
-            _num_str = f"{number:.{places}f}"
-        _num_str = _num_str.split(".")[1][0:places]
-        for char in _num_str:
-            result += " " + _NUM_STRING_CA[int(char)]
-    return result
+    warnings.warn(
+        "migrate to use RomanceNumberExtractor and NumberVocabulary directly instead",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    scale = Scale.SHORT if short_scale else Scale.LONG
+    return CA.pronounce_number(number, places, scale=scale)
 
 
 def is_fractional_ca(input_str, short_scale=True):
     """
-    This function takes the given text and checks if it is a fraction.
-
-    Args:
-        input_str (str): the string to check if fractional
-        short_scale (bool): use short scale if True, long scale if False
-    Returns:
-        (bool) or (float): False if not a fraction, otherwise the fraction
-
+    DEPRECATED
     """
-    input_str = input_str.lower()
-    if input_str.endswith('é', -1):
-        input_str = input_str[:len(input_str) - 1] + "è"  # e.g. "cinqué -> cinquè"
-    elif input_str.endswith('ena', -3):
-        input_str = input_str[:len(input_str) - 3] + "è"  # e.g. "cinquena -> cinquè"
-    elif input_str.endswith('ens', -3):
-        input_str = input_str[:len(input_str) - 3] + "è"  # e.g. "cinquens -> cinquè"
-    elif input_str.endswith('enes', -4):
-        input_str = input_str[:len(input_str) - 4] + "è"  # e.g. "cinquenes -> cinquè"
-    elif input_str.endswith('os', -2):
-        input_str = input_str[:len(input_str) - 2]  # e.g. "terços -> terç"
-    elif (input_str == 'terceres' or input_str == 'tercera'):
-        input_str = "terç"  # e.g. "tercer -> terç"
-    elif (input_str == 'mitges' or input_str == 'mitja'):
-        input_str = "mig"  # e.g. "mitges -> mig"
-    elif (input_str == 'meitat' or input_str == 'meitats'):
-        input_str = "mig"  # e.g. "mitges -> mig"
-    elif input_str.endswith('a', -1):
-        input_str = input_str[:len(input_str) - 1]  # e.g. "quarta -> quart"
-    elif input_str.endswith('es', -2):
-        input_str = input_str[:len(input_str) - 2]  # e.g. "quartes -> quartes"
-    elif input_str.endswith('s', -1):
-        input_str = input_str[:len(input_str) - 1]  # e.g. "quarts -> quart"
-
-    aFrac = ["mig", "terç", "quart", "cinquè", "sisè", "sètè", "vuitè", "novè",
-             "desè", "onzè", "dotzè", "tretzè", "catorzè", "quinzè", "setzè",
-             "dissetè", "divuitè", "dinovè"]
-
-    if input_str in aFrac:
-        return 1.0 / (aFrac.index(input_str) + 2)
-    if input_str == "vintè":
-        return 1.0 / 20
-    if input_str == "trentè":
-        return 1.0 / 30
-    if input_str == "centè":
-        return 1.0 / 100
-    if input_str == "milè":
-        return 1.0 / 1000
-    if (input_str == "vuitè" or input_str == "huitè"):
-        return 1.0 / 8
-    if (input_str == "divuitè" or input_str == "dihuitè"):
-        return 1.0 / 18
-
-    return False
+    warnings.warn(
+        "migrate to use RomanceNumberExtractor and NumberVocabulary directly instead",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return CA.is_fractional(input_str)
 
 
 def extract_number_ca(text, short_scale=False, ordinals=False):
     """
-    This function prepares the given text for parsing by making
-    numbers consistent, getting rid of contractions, etc.
-
-    Cardinal numerals follow the standard Catalan structure described in the
-    Consorci per a la Normalització Lingüística grammar, "6. Els numerals"
-    (IEC normativa; https://www.cpnl.cat/gramatica/24/6-els-numerals): the
-    scale words "mil" and "milions" carry no hyphen and multiply the hundreds
-    group that precedes them, and the products are summed, so
-    "un milió dos-cents trenta-quatre mil sis-cents" reads 1 234 600.
-
-    Scale words above a million are read according to ``short_scale``. Catalan
-    uses the long scale, where each new scale word steps by a factor of a
-    million ("miliard" is 10^9, "bilió" is 10^12); on the short scale the same
-    word "bilió" instead denotes 10^9. See
-    https://en.wikipedia.org/wiki/Long_and_short_scales. The default is the
-    long scale, matching ``pronounce_number_ca`` so the two round-trip.
-
-    Args:
-        text (str): the string to normalize
-        short_scale (bool): interpret large scale words on the short scale
-            (default False, the long scale used in Catalan)
-        ordinals (bool): unused, kept for API compatibility
-    Returns:
-        (int) or (float): The value of extracted number
-
+    DEPRECATED
     """
-    scale_lookup = _SHORT_SCALE_LOOKUP_CA if short_scale else _LONG_SCALE_LOOKUP_CA
-    text = text.lower()
-    aWords = text.split()
-    negative = False
-    while aWords and aWords[0] in ['menys']:
-        negative = True
-        aWords = aWords[1:]
-    count = 0
-    result = None
-    # A Catalan number is a run of groups joined by scale words: each hundreds
-    # group ("cinc-cents") multiplied by its scale ("mil", "milions") and the
-    # products summed. "total" holds the already-scaled groups, "current" the
-    # group under construction, so a scale word multiplies only its own group
-    # and never the accumulated higher-magnitude total ("dos milions cinc-cents
-    # mil" = 2000000 + 500*1000, not 2000000 + 500 + 1000).
-    total = 0
-    current = 0
-    while count < len(aWords):
-        val = 0
-        is_scale = False
-        word = aWords[count]
-        next_next_word = None
-        if count + 1 < len(aWords):
-            next_word = aWords[count + 1]
-            if count + 2 < len(aWords):
-                next_next_word = aWords[count + 2]
-        else:
-            next_word = None
-
-        # is current word a number?
-        if word in _NUMBERS_CA:
-            val = _NUMBERS_CA[word]
-        elif word in scale_lookup:
-            # long/short scale word above a million ("miliard", "bilió", ...)
-            val = scale_lookup[word]
-            is_scale = True
-        elif '-' in word:
-            wordparts = word.split('-')
-            # trenta-cinc > 35
-            if len(wordparts) == 2 and (wordparts[0] in _TENS_CA and wordparts[1] in _AFTER_TENS_CA):
-                val = _TENS_CA[wordparts[0]] + _AFTER_TENS_CA[wordparts[1]]
-            # vint-i-dues > 22
-            elif len(wordparts) == 3 and wordparts[1] == 'i' and (
-                    wordparts[0] in _TENS_CA and wordparts[2] in _AFTER_TENS_CA):
-                val = _TENS_CA[wordparts[0]] + _AFTER_TENS_CA[wordparts[2]]
-            # quatre-centes > 400
-            elif len(wordparts) == 2 and (wordparts[0] in _BEFORE_HUNDREDS_CA and wordparts[1] in _HUNDREDS_CA):
-                val = _BEFORE_HUNDREDS_CA[wordparts[0]] * 100
-
-        elif word.isdigit():  # doesn't work with decimals
-            val = int(word)
-        elif is_numeric(word):
-            val = float(word)
-        elif is_fractional_ca(word):
-            if not result:
-                result = 1
-            result = result * is_fractional_ca(word)
-            count += 1
-            continue
-
-        if not val:
-            # look for fractions like "2/3"
-            aPieces = word.split('/')
-            # if (len(aPieces) == 2 and is_numeric(aPieces[0])
-            #   and is_numeric(aPieces[1])):
-            if look_for_fractions(aPieces):
-                val = float(aPieces[0]) / float(aPieces[1])
-
-        if val:
-            if result is None:
-                result = 0
-            # handle fractions
-            # TODO: caution, review use of "ens" word
-            if next_word == "ens":
-                result = float(result) / float(val)
-                total = result
-                current = 0
-            elif is_scale or val in (1000, 1000000):
-                # a thousand/million/higher scale word multiplies the group
-                # being built and banks the product ("cinc-cents mil" ->
-                # 500*1000, "dos miliards" -> 2*10^9)
-                total += (current or 1) * val
-                current = 0
-                result = total + current
-            elif val == 100:
-                # "cent" multiplies its group ("cent mil" -> 100*1000) or opens
-                # a new hundreds group ("mil cent" -> 1000 + 100)
-                current = (current or 1) * 100
-                result = total + current
-            else:
-                # ones, tens and hyphenated hundreds accumulate within the group
-                # ("dos mil vint-i-tres" -> 2000 + 23)
-                current += val
-                result = total + current
-
-        if next_word is None:
-            break
-
-        # number word and fraction
-        ands = ["i"]
-        if next_word in ands:
-            zeros = 0
-            if result is None:
-                count += 1
-                continue
-            newWords = aWords[count + 2:]
-            newText = ""
-            for word in newWords:
-                newText += word + " "
-
-            afterAndVal = extract_number_ca(newText[:-1], short_scale)
-            if afterAndVal:
-                if result < afterAndVal or result < 20:
-                    while afterAndVal > 1:
-                        afterAndVal = afterAndVal / 10.0
-                    for word in newWords:
-                        if word == "zero" or word == "0":
-                            zeros += 1
-                        else:
-                            break
-                for _ in range(0, zeros):
-                    afterAndVal = afterAndVal / 10.0
-                result += afterAndVal
-                break
-        elif next_next_word is not None:
-            if next_next_word in ands and next_word not in _NUMBERS_CA:
-                newWords = aWords[count + 3:]
-                newText = ""
-                for word in newWords:
-                    newText += word + " "
-                afterAndVal = extract_number_ca(newText[:-1], short_scale)
-                if afterAndVal:
-                    if result is None:
-                        result = 0
-                    result += afterAndVal
-                    break
-
-        decimals = ["coma", "amb", "punt", ".", ","]
-        if next_word in decimals:
-            zeros = 0
-            newWords = aWords[count + 2:]
-            newText = ""
-            for word in newWords:
-                newText += word + " "
-            for word in newWords:
-                if word == "zero" or word == "0":
-                    zeros += 1
-                else:
-                    break
-            # read the decimal tail digit by digit ("uno cuatro" -> .14)
-            digits = ""
-            for word in newWords:
-                if word.isdigit():
-                    digits += word
-                elif word in _NUMBERS_CA and _NUMBERS_CA[word] < 10:
-                    digits += str(_NUMBERS_CA[word])
-                else:
-                    break
-            if digits:
-                afterDotVal = digits
-            else:
-                afterDotVal = str(extract_number_ca(newText[:-1], short_scale))
-                afterDotVal = zeros * "0" + afterDotVal
-            result = float(str(result or 0) + "." + afterDotVal)
-            break
-        count += 1
-
-    # Return the $str with the number related words removed
-    # (now empty strings, so strlen == 0)
-    # aWords = [word for word in aWords if len(word) > 0]
-    # text = ' '.join(aWords)
-    if "." in str(result):
-        integer, dec = str(result).split(".")
-        # cast float to int
-        if dec == "0":
-            result = int(integer)
-
-    if negative and result is not None and result is not False:
-        result = -result
-    return result or False
+    warnings.warn(
+        "migrate to use RomanceNumberExtractor and NumberVocabulary directly instead",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    scale = Scale.SHORT if short_scale else Scale.LONG
+    return CA.extract_number(text, ordinals=ordinals, scale=scale)
 
 
 def numbers_to_digits_ca(utterance: str) -> str:
     """
-    Substitueix els números escrits en un text en català per les seves equivalents en xifres.
-
-    Args:
-        utterance (str): Cadena d'entrada que possiblement conté números escrits.
-
-    Returns:
-        str: Text amb els números escrits substituïts per xifres.
+    DEPRECATED
     """
-    # TODO - above twenty it's ambiguous, "twenty one" is 2 words but only 1 number
-    number_replacements = {
-        "un": "1", "dos": "2", "tres": "3", "quatre": "4",
-        "cinc": "5", "sis": "6", "set": "7", "vuit": "8", "nou": "9",
-        "deu": "10", "onze": "11", "dotze": "12", "tretze": "13", "catorze": "14",
-        "quinze": "15", "setze": "16", "disset": "17", "divuit": "18",
-        "dinou": "19", "vint": "20"
-        # Amplieu aquest diccionari per a números més alts si és necessari
-    }
-    words: List[Token] = tokenize(utterance)
-    for idx, tok in enumerate(words):
-        if tok.word in number_replacements:
-            words[idx] = number_replacements[tok.word]
-        else:
-            words[idx] = tok.word
-    return " ".join(words)
+    warnings.warn(
+        "migrate to use RomanceNumberExtractor and NumberVocabulary directly instead",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return CA.numbers_to_digits(utterance)
+
+
+if __name__ == '__main__':
+    print('--- Catalan number tests ---')
+    for n in (16, 21, 42, 66, 99, 100, 101, 123, 200, 500, 999, 1000, 2023,
+              1_000_000, 2_000_000, 1_234_600):
+        print(f'{n} ->', CA.pronounce_number(n))
+    print('10^9 ->', CA.pronounce_number(10 ** 9))
+    print('10^12 ->', CA.pronounce_number(10 ** 12))
+    print("'vint-i-un' ->", CA.extract_number('vint-i-un'))
+    print("'un milió dos-cents trenta-quatre mil sis-cents' ->",
+          CA.extract_number('un milió dos-cents trenta-quatre mil sis-cents'))

--- a/tests/test_number_parser_ca.py
+++ b/tests/test_number_parser_ca.py
@@ -180,3 +180,28 @@ class TestCatalanFractions(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestCatalanRoundTripSweep(unittest.TestCase):
+    """pronounce -> extract identity across the whole 0..10,000,000 range.
+
+    Dense at the low end where every tens-units and hundreds compound occurs,
+    then strided through the millions; every value is checked with both signs.
+    """
+
+    def _sweep(self):
+        for n in range(0, 3000):
+            yield n
+        for n in range(3000, 100000, 137):
+            yield n
+        for n in range(100000, 10_000_001, 4999):
+            yield n
+
+    def test_round_trip_both_signs(self):
+        bad = []
+        for n in self._sweep():
+            for value in (n, -n):
+                spoken = pronounce_number(value, lang="ca")
+                if extract_number(spoken, lang="ca") != value:
+                    bad.append((value, spoken))
+        self.assertEqual(bad, [], f"round-trip failures: {bad[:10]}")


### PR DESCRIPTION
Migrates Catalan (`ca`) number extraction and pronunciation from the bespoke
`extract_number_ca` / `pronounce_number_ca` code onto the shared
`RomanceNumberExtractor` + `NumberVocabulary` engine, matching pt/gl/ast/mwl/an/oc/ro.

## What moved to the shared engine
- Cardinal extraction, pronunciation, fractions, ordinals and `numbers_to_digits`
  are now driven by a Catalan `NumberVocabulary`.
- The old module-level functions remain as thin deprecated wrappers so existing
  imports keep working with identical results.
- Top-level dispatch (`__init__.py`) routes `ca` through the engine for
  pronounce / extract / is_fractional, and newly wires ordinals and fractions.

## Catalan-specific handling
- A small `CatalanNumberExtractor` subclass adds the two conventions the generic
  engine does not model:
  - the normative **guionet** in tens-units compounds — "vint-i-un",
    "quaranta-dos", "seixanta-sis" — applied idempotently on output;
  - **digit-by-digit** decimals ("tres coma un quatre" for 3.14).
- Extraction needs no bespoke tokenizer: the shared engine normalises hyphens to
  spaces, so the fused twenties ("vint-i-una"), hyphenated tens ("trenta-quatre")
  and hyphenated hundreds ("dos-cents") accumulate naturally, with
  `MULTIPLY_HUNDREDS` turning "dos cents" into 200.
- No hundred apocopation: "cent" throughout ("cent", "cent un", "cent vint-i-tres").
- Long scale by default: 10^9 = "miliard", 10^12 = "bilió"; short scale reuses
  "bilió" for 10^9.

## Sources
Institut d'Estudis Catalans normativa, cross-checked for the guionet / gender /
hundreds forms: the Consorci per a la Normalització Lingüística grammar
"6. Els numerals" and the Optimot fitxa "Guionet en els numerals compostos",
both cited in the module docstrings (worked example
"un milió dos-cents trenta-quatre mil sis-cents" = 1 234 600).

## Tests
- All existing `ca` tests stay green with identical results (round-trip, scale
  defaults, hundred apocopation, fractions, the group-accumulator fix).
- Adds a pronounce -> extract round-trip sweep across 0..10,000,000 for both signs.
- Full suite: 1337 passed, 1 skipped, 1 xfailed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Catalan number pronunciation, extraction, fractions, ordinals, and negative-number handling.
  * Added support for normative Catalan hyphenation, grammatical gender, and plural forms.
  * Improved consistency when converting spoken Catalan numbers back into numeric values.

* **Bug Fixes**
  * Corrected Catalan fraction and ordinal processing to use language-specific behavior.
  * Enhanced accuracy across a broad range of positive and negative numbers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->