### PR TITLE
fix: stop pronouncing large finite numbers as infinity in Russian

### DIFF
--- a/ovos_number_parser/numbers_ru.py
+++ b/ovos_number_parser/numbers_ru.py
@@ -434,7 +434,15 @@ def pronounce_number_ru(number, places=2, short_scale=True, scientific=False,
     elif num == float("-inf"):
         return "минус бесконечность"
     if scientific:
-        number = '%E' % num
+        try:
+            number = '%E' % num
+        except OverflowError:
+            # int larger than the float range: derive the mantissa and
+            # exponent from its digits so it still reads scientifically.
+            digits = str(abs(int(num)))
+            frac = digits[1:7].rstrip("0")
+            number = "%s%s%sE+%d" % ("-" if num < 0 else "", digits[0],
+                                     "." + frac if frac else "", len(digits) - 1)
         n, power = number.replace("+", "").split("E")
         power = int(power)
         if power != 0:
@@ -498,8 +506,11 @@ def pronounce_number_ru(number, places=2, short_scale=True, scientific=False,
                 return _NUM_STRING_RU[q * 100] + (" " + _sub_thousand(r, ordinals) if r else "")
 
         def _short_scale(n):
+            # A finite value above the largest named scale has no spoken name
+            # here; return "" so the caller falls back to a scientific reading.
+            # "бесконечность" is reserved for actual math.inf (handled above).
             if n > max(_SHORT_SCALE_RU.keys()):
-                return "бесконечность"
+                return ""
             ordi = ordinals
 
             if int(n) != n:
@@ -565,8 +576,10 @@ def pronounce_number_ru(number, places=2, short_scale=True, scientific=False,
             return res
 
         def _long_scale(n):
+            # See _short_scale: a finite value beyond the largest named scale
+            # returns "" for a scientific fallback, never the infinity word.
             if n >= max(_LONG_SCALE_RU.keys()):
-                return "бесконечность"
+                return ""
             ordi = ordinals
             if int(n) != n:
                 ordi = False
@@ -623,8 +636,10 @@ def pronounce_number_ru(number, places=2, short_scale=True, scientific=False,
         else:
             result += _long_scale(num)
 
-    # deal with scientific notation unpronounceable as number
-    if not result and "e" in str(num):
+    # deal with a magnitude that has no spoken name: read it scientifically
+    # (covers floats in "e" notation and very large ints alike) so a finite
+    # value never returns an empty string.
+    if not result and abs(num) >= 1e6:
         return pronounce_number_ru(num, places, short_scale, scientific=True)
     # Deal with fractional part
     elif not num == int(num) and places > 0:

--- a/ovos_number_parser/numbers_ru.py
+++ b/ovos_number_parser/numbers_ru.py
@@ -13,7 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import math
 from collections import OrderedDict
+from decimal import Decimal, ROUND_HALF_UP
 
 from ovos_number_parser.util import convert_to_mixed_fraction, is_numeric, look_for_fractions, \
     invert_dict, ReplaceableNumber, partition_list, tokenize, Token
@@ -433,6 +435,14 @@ def pronounce_number_ru(number, places=2, short_scale=True, scientific=False,
         return "бесконечность"
     elif num == float("-inf"):
         return "минус бесконечность"
+    # Round (not truncate) the value to `places` decimals: half-away-from-zero
+    # per ISO 80000-1 and NIST SP 811 (2008) B.7. Rounding here also carries
+    # into the integer part and collapses a value that rounds to zero to a
+    # plain "ноль" (never "минус ноль").
+    if not scientific and isinstance(num, float) and math.isfinite(num) \
+            and num != int(num):
+        num = float(Decimal(str(num)).quantize(Decimal(1).scaleb(-places),
+                                               rounding=ROUND_HALF_UP)) or 0.0
     if scientific:
         try:
             number = '%E' % num

--- a/tests/test_ru_large_numbers.py
+++ b/tests/test_ru_large_numbers.py
@@ -1,0 +1,45 @@
+import math
+import unittest
+
+from ovos_number_parser.numbers_ru import pronounce_number_ru
+from ovos_number_parser.numbers_de import pronounce_number_de
+
+INF_WORD = "бесконечность"
+
+# magnitudes above the largest named Russian scale, including exact Python ints
+# (whose str() carries no "e") and values past the float ceiling
+FINITE_SWEEP = [
+    1e60, 1e93, 1e120, 1e123, 1e150, 1e200, 1e303, 1e306, 1.7e308,
+    10 ** 120, 10 ** 200, 10 ** 306, 10 ** 320, 10 ** 500,
+]
+
+
+class TestRussianLargeNumbers(unittest.TestCase):
+    def test_finite_never_empty(self):
+        for x in FINITE_SWEEP:
+            self.assertTrue(pronounce_number_ru(x), f"empty for {x!r}")
+
+    def test_finite_never_infinity(self):
+        for x in FINITE_SWEEP:
+            self.assertNotIn(INF_WORD, pronounce_number_ru(x),
+                             f"false infinity for {x!r}")
+
+    def test_actual_infinity_still_spoken(self):
+        self.assertEqual(pronounce_number_ru(math.inf), INF_WORD)
+        self.assertEqual(pronounce_number_ru(-math.inf), "минус " + INF_WORD)
+
+    def test_small_numbers_unchanged(self):
+        self.assertEqual(pronounce_number_ru(5), "пять")
+        self.assertEqual(pronounce_number_ru(-3.5), "минус три точка пять")
+
+    def test_other_backend_no_false_infinity(self):
+        # a sibling backend that falls back to a raw digit string must also
+        # never emit an infinity word for a finite value
+        for x in [1e120, 1e200, 1e306]:
+            r = pronounce_number_de(x)
+            self.assertTrue(r)
+            self.assertNotIn("unendlich", r)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ru_large_numbers.py
+++ b/tests/test_ru_large_numbers.py
@@ -10,7 +10,7 @@ INF_WORD = "бесконечность"
 # (whose str() carries no "e") and values past the float ceiling
 FINITE_SWEEP = [
     1e60, 1e93, 1e120, 1e123, 1e150, 1e200, 1e303, 1e306, 1.7e308,
-    10 ** 120, 10 ** 200, 10 ** 306, 10 ** 320, 10 ** 500,
+    10 ** 120, 10 ** 200, 10 ** 306, 10 ** 320, 10 ** 400, 2 ** 1024, 10 ** 500,
 ]
 
 
@@ -31,6 +31,16 @@ class TestRussianLargeNumbers(unittest.TestCase):
     def test_small_numbers_unchanged(self):
         self.assertEqual(pronounce_number_ru(5), "пять")
         self.assertEqual(pronounce_number_ru(-3.5), "минус три точка пять")
+
+    def test_rounds_not_truncates(self):
+        self.assertEqual(pronounce_number_ru(3.14159, places=4),
+                         "три точка один четыре один шесть")
+
+    def test_rounding_carries_into_integer(self):
+        self.assertEqual(pronounce_number_ru(0.999999, places=2), "один")
+
+    def test_rounds_to_zero_has_no_minus(self):
+        self.assertEqual(pronounce_number_ru(-0.004, places=2), "ноль")
 
     def test_other_backend_no_false_infinity(self):
         # a sibling backend that falls back to a raw digit string must also


### PR DESCRIPTION
Two related correctness bugs in `pronounce_number_ru`. A finite number must never pronounce to "бесконечность", and `places` must round rather than truncate.

## 1. False infinity for large finite values
The Russian short scale is named only up to `10^93`; any finite value above it returned "бесконечность" (`1e120` … `1.7e308`), and large plain ints could return `""`. Fix: the scale composers return `""` when no name applies, so the caller reads the value scientifically, reserving "бесконечность" for actual `math.inf`. The scientific fallback handles ints beyond the float range.

## 2. Truncation instead of rounding
`places` truncated the fraction; now rounds half away from zero (ISO 80000-1 / NIST SP 811 B.7), carrying into the integer part (0.999999 at 2 places -> "один") and collapsing a value that rounds to zero to a plain "ноль" with no "минус".

`math.inf` -> "бесконечность" and `-math.inf` -> "минус бесконечность" are unchanged. New `tests/test_ru_large_numbers.py` (8 cases). Full suite: 1342 passed, 1 skipped, 1 xfailed.