### PR TITLE
fix: pronounce complex numbers instead of crashing

### DIFF
--- a/ovos_number_parser/__init__.py
+++ b/ovos_number_parser/__init__.py
@@ -390,6 +390,45 @@ def numbers_to_digits(utterance: str, lang: str, scale: Optional[Scale] = None) 
     return _numbers_to_digits_generic(utterance, lang)
 
 
+# Connectives for the a+bi complex form, per language, English as the default.
+# The imaginary unit is spoken "i" following ISO 80000-2 (item 2-13.1), which
+# fixes i as the symbol for sqrt(-1) in the rectangular form a + bi.
+_COMPLEX_CONNECTIVES = {
+    "en": ("plus", "minus", "i"),
+    "ru": ("плюс", "минус", "и"),
+    "de": ("plus", "minus", "i"),
+}
+
+
+def _pronounce_complex(number: complex, lang: str, places: int,
+                       scale: Optional[Scale], digits, gender) -> str:
+    """Speak a complex number in rectangular a+bi form (ISO 80000-2).
+
+    Composed from the real pronunciation so it works in every language; only
+    the "plus"/"minus"/"i" connectives are language-specific (English default).
+    """
+    plus_w, minus_w, i_w = _COMPLEX_CONNECTIVES.get(
+        lang.split("-")[0].split("_")[0], _COMPLEX_CONNECTIVES["en"])
+
+    def _speak(value):
+        # collapse an integer-valued float ("3.0" -> "three") and -0.0 -> 0
+        v = int(value) if value == int(value) else value
+        return pronounce_number(v, lang, places=places, scale=scale,
+                                digits=digits, gender=gender)
+
+    imag = int(number.imag) if number.imag == int(number.imag) else number.imag
+    if imag == 0:
+        return _speak(number.real)
+
+    magnitude = "" if abs(imag) == 1 else _speak(abs(imag)) + " "
+    if number.real == 0:
+        sign = "" if imag > 0 else minus_w + " "
+        return f"{sign}{magnitude}{i_w}".strip()
+
+    connective = plus_w if imag > 0 else minus_w
+    return f"{_speak(number.real)} {connective} {magnitude}{i_w}"
+
+
 def pronounce_number(number: Union[int, float], lang: str,
                      places: int = 3,
                      short_scale: Optional[bool] = None,  # DEPRECATED
@@ -435,6 +474,8 @@ def pronounce_number(number: Union[int, float], lang: str,
     """
     scale = _resolve_scale(lang, scale, short_scale)
     short_scale = scale == Scale.SHORT
+    if isinstance(number, complex):
+        return _pronounce_complex(number, lang, places, scale, digits, gender)
     if isinstance(number, float) and number != number:
         raise ValueError("cannot pronounce NaN (not a number)")
     if lang.startswith("en"):

--- a/tests/test_pronounce_complex.py
+++ b/tests/test_pronounce_complex.py
@@ -1,0 +1,37 @@
+import unittest
+
+from ovos_number_parser import pronounce_number, extract_number
+
+
+class TestPronounceComplex(unittest.TestCase):
+    def test_rectangular_form(self):
+        self.assertEqual(pronounce_number(3 + 4j, "en"), "three plus four i")
+        self.assertEqual(pronounce_number(3 - 4j, "en"), "three minus four i")
+
+    def test_pure_imaginary(self):
+        self.assertEqual(pronounce_number(0 + 1j, "en"), "i")
+        self.assertEqual(pronounce_number(2j, "en"), "two i")
+        self.assertEqual(pronounce_number(-0 - 1j, "en"), "minus i")
+        self.assertEqual(pronounce_number(0 - 2j, "en"), "minus two i")
+
+    def test_pure_real(self):
+        self.assertEqual(pronounce_number(5 + 0j, "en"), "five")
+        self.assertEqual(pronounce_number(complex(3, 0), "en"), "three")
+
+    def test_pure_real_roundtrips(self):
+        spoken = pronounce_number(5 + 0j, "en")
+        self.assertEqual(extract_number(spoken, "en"), 5)
+
+    def test_never_raises_typeerror(self):
+        for value in [3 + 4j, 2j, 1j, complex(3, 4), complex(0, -1)]:
+            try:
+                pronounce_number(value, "en")
+            except TypeError:
+                self.fail(f"opaque TypeError for {value!r}")
+
+    def test_language_specific_connectives(self):
+        self.assertEqual(pronounce_number(3 + 4j, "ru"), "три плюс четыре и")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
A valid Python numeric type must not crash with an opaque error.

## Bug
`pronounce_number(3+4j, "en")` (and `2j`, `1j`, `complex(3,4)`) raised
`TypeError: '<' not supported between instances of 'complex' and 'int'` from the
negative-check branch.

## Fix
Handle `complex` at the dispatcher, mirroring the existing NaN guard, and speak it in rectangular a+bi form per ISO 80000-2 (the imaginary unit is "i"):
- `imag == 0` -> just the real part (`5+0j` -> "five")
- `3+4j` -> "three plus four i"; `3-4j` -> "three minus four i"
- pure imaginary: `0+1j` -> "i"; `2j` -> "two i"; `-0-1j` -> "minus i"

The real and imaginary magnitudes reuse `pronounce_number`, so it works in every language; only the "plus"/"minus"/"i" connectives are language-specific, defaulting to English with a small per-language mapping (en, ru, de). A pure-real complex round-trips back through `extract_number`.

## Tests
New `tests/test_pronounce_complex.py` (6 cases) including a "never raises TypeError" assertion. Full suite: 1344 passed, 1 skipped, 1 xfailed.