### PR TITLE
fix: compose Catalan compound ordinals per the IEC normativa

### DIFF
--- a/ovos_number_parser/numbers_ca.py
+++ b/ovos_number_parser/numbers_ca.py
@@ -284,6 +284,21 @@ _CA = NumberVocabulary(
     ORDINAL_HUNDREDS={
         100: 'centè'
     },
+    # Unit ordinals used inside a hyphenated tens-units compound. Catalan forms
+    # these from the cardinal plus "-è" ("dos" -> "dosè", "quatre" -> "quatrè"),
+    # which differs from the standalone ordinals for 1-4 ("primer", "segon",
+    # "tercer", "quart"): "vint-i-dosè", not "vint-i-segon".
+    ORDINAL_COMPOUND_UNITS={
+        1: 'unè',
+        2: 'dosè',
+        3: 'tresè',
+        4: 'quatrè',
+        5: 'cinquè',
+        6: 'sisè',
+        7: 'setè',
+        8: 'vuitè',
+        9: 'novè',
+    },
     ORDINAL_SHORT_SCALE={
         10 ** 3: 'milè',
         10 ** 6: 'milionè'
@@ -298,10 +313,65 @@ _CA = NumberVocabulary(
 class CatalanNumberExtractor(RomanceNumberExtractor):
     """Catalan number engine.
 
-    Adds the two Catalan-specific surface conventions the shared engine does
-    not model: hyphenated tens-units compounds on output and a digit-by-digit
-    decimal reading ("tres coma un quatre" for 3.14).
+    Adds the Catalan-specific surface conventions the shared engine does not
+    model: hyphenated tens-units compounds on output, a digit-by-digit decimal
+    reading ("tres coma un quatre" for 3.14), and the ordinal composition rule
+    below.
     """
+
+    def _pronounce_ordinal_up_to_999(
+            self, n: int,
+            gender: GrammaticalGender = GrammaticalGender.MASCULINE) -> str:
+        """Ordinal word for 0-999 following the Institut d'Estudis Catalans rule.
+
+        Catalan ordinals are single fused words for 1-19 and the round tens/
+        hundreds ("onzè", "vintè", "centè"); every larger number is written as
+        the cardinal with only its final element carrying the ordinal ending.
+        The masculine ending is the cardinal + "-è" and the feminine the
+        cardinal + "-na" ("22è vint-i-dosè" / "22a vint-i-dosena", "54è
+        cinquanta-quatrè", "353è tres-cents cinquanta-tresè"), so a tens-units
+        compound keeps a cardinal tens word ("vint-i-", "trenta-") and turns
+        only the unit ordinal, unlike the shared engine's tens-ordinal + unit-
+        ordinal composition ("desè primer", "vintè primer") which is wrong here.
+
+        Source: Consorci per a la Normalització Lingüística, "Els numerals
+        ordinals" (reproducing the IEC / Institut d'Estudis Catalans normativa);
+        Optimot fitxa "Guionet en els numerals compostos".
+        """
+        if not 0 <= n <= 999:
+            raise ValueError("Number must be between 0 and 999.")
+        if n == 0:
+            return self.vocab.UNITS[0]
+
+        parts = []
+        if n >= 100:
+            hundred = n // 100 * 100
+            n %= 100
+            if n == 0:
+                # round hundred takes the ordinal ending itself:
+                # "cent" -> "centè", "dos-cents" -> "dos-centè"
+                word = self.vocab.ORDINAL_HUNDREDS.get(hundred) \
+                    or self.vocab.HUNDREDS[hundred][:-1] + "è"
+                return self.vocab.swap_gender(word, gender)
+            # otherwise the hundreds stay cardinal; only the tail is ordinal
+            parts.append(self.vocab.HUNDRED_PARTICLE if hundred == 100
+                         else self.vocab.HUNDREDS[hundred])
+
+        # n is now 1-99
+        if n in self.vocab.ORDINAL_TENS:
+            # fused single word: teens 11-19 and the round tens 20, 30 ... 90
+            parts.append(self.vocab.swap_gender(self.vocab.ORDINAL_TENS[n], gender))
+        elif n < 10:
+            parts.append(self.vocab.swap_gender(self.vocab.ORDINAL_UNITS[n], gender))
+        else:
+            ten = n // 10 * 10
+            unit = n % 10
+            unit_word = self.vocab.swap_gender(
+                self.vocab.ORDINAL_COMPOUND_UNITS[unit], gender)
+            joiner = "-i-" if ten == 20 else "-"
+            parts.append(f"{self.vocab.TENS[ten]}{joiner}{unit_word}")
+
+        return " ".join(parts)
 
     def pronounce_number(self,
                          number: Union[int, float],

--- a/tests/test_number_parser_ca.py
+++ b/tests/test_number_parser_ca.py
@@ -1,7 +1,93 @@
 import unittest
 
-from ovos_number_parser import extract_number, pronounce_number, is_fractional
-from ovos_number_parser.util import Scale
+from ovos_number_parser import (extract_number, pronounce_number, is_fractional,
+                                pronounce_ordinal)
+from ovos_number_parser.util import Scale, GrammaticalGender
+
+
+class TestCatalanOrdinals(unittest.TestCase):
+    """Catalan ordinals verified against the Institut d'Estudis Catalans normativa.
+
+    Source: Consorci per a la Normalització Lingüística, "Els numerals ordinals"
+    (reproducing the IEC normativa) and the Optimot fitxa "Guionet en els
+    numerals compostos". The masculine ordinal is the cardinal + "-è" and the
+    feminine the cardinal + "-na"; only the final element of a compound carries
+    the ordinal ending, so a tens-units compound keeps a cardinal tens word
+    ("vint-i-unè", not "vintè primer").
+    """
+
+    # (number, masculine, feminine)
+    IEC_ANCHORS = [
+        (1, "primer", "primera"),
+        (2, "segon", "segona"),
+        (3, "tercer", "tercera"),
+        (4, "quart", "quarta"),
+        (5, "cinquè", "cinquena"),
+        (8, "vuitè", "vuitena"),
+        (10, "desè", "desena"),
+        # teens each own their own word, never desè + unit
+        (11, "onzè", "onzena"),
+        (12, "dotzè", "dotzena"),
+        (13, "tretzè", "tretzena"),
+        (16, "setzè", "setzena"),
+        (17, "dissetè", "dissetena"),
+        (19, "dinovè", "dinovena"),
+        # round tens
+        (20, "vintè", "vintena"),
+        (30, "trentè", "trentena"),
+        (40, "quarantè", "quarantena"),
+        (90, "norantè", "norantena"),
+        # twenties keep the fused "-i-"; the unit takes the -è/-na form
+        (21, "vint-i-unè", "vint-i-unena"),
+        (22, "vint-i-dosè", "vint-i-dosena"),
+        (23, "vint-i-tresè", "vint-i-tresena"),
+        (24, "vint-i-quatrè", "vint-i-quatrena"),
+        (29, "vint-i-novè", "vint-i-novena"),
+        # thirties onward join with a plain hyphen
+        (31, "trenta-unè", "trenta-unena"),
+        (42, "quaranta-dosè", "quaranta-dosena"),
+        (54, "cinquanta-quatrè", "cinquanta-quatrena"),
+        # hundreds: round hundreds take the ending, compounds stay cardinal
+        (100, "centè", "centena"),
+        (200, "dos-centè", "dos-centena"),
+        (300, "tres-centè", "tres-centena"),
+        (121, "cent vint-i-unè", "cent vint-i-unena"),
+        (353, "tres-cents cinquanta-tresè", "tres-cents cinquanta-tresena"),
+        # thousands
+        (1000, "milè", "milena"),
+        (2000, "dos milè", "dos milena"),
+    ]
+
+    def test_masculine_and_feminine(self):
+        for n, masc, fem in self.IEC_ANCHORS:
+            with self.subTest(number=n, gender="m"):
+                self.assertEqual(pronounce_ordinal(n, lang="ca"), masc)
+            with self.subTest(number=n, gender="f"):
+                self.assertEqual(
+                    pronounce_ordinal(n, lang="ca",
+                                      gender=GrammaticalGender.FEMININE), fem)
+
+    def test_skill_path_pronounce_number_ordinals(self):
+        # ovos-skill-count reaches ordinals through pronounce_number(ordinals=True)
+        for n, masc, _ in self.IEC_ANCHORS:
+            with self.subTest(number=n):
+                self.assertEqual(
+                    pronounce_number(n, lang="ca", ordinals=True), masc)
+
+    def test_compound_is_not_naive_tens_plus_unit(self):
+        # regression guard: the shared engine used to emit "desè primer" (11)
+        # and "vintè primer" (21) by concatenating tens and unit ordinals
+        for n in (11, 12, 13, 21, 22, 31):
+            spoken = pronounce_ordinal(n, lang="ca")
+            self.assertNotIn(" primer", spoken)
+            self.assertNotIn("desè ", spoken)
+            self.assertNotIn("vintè ", spoken)
+
+    def test_ordinals_round_trip_through_is_fractional(self):
+        # the -è ordinal words double as the fraction denominators
+        for word, value in (("onzè", 1 / 11), ("dotzè", 1 / 12),
+                            ("vintè", 1 / 20), ("centè", 1 / 100)):
+            self.assertAlmostEqual(is_fractional(word, lang="ca"), value)
 
 
 class TestCatalanPronounce(unittest.TestCase):


### PR DESCRIPTION
Catalan compound ordinals were malformed: the ordinal path concatenated the tens ordinal with the unit ordinal, producing "desè primer" for 11th and "vintè primer" for 21st. Catalan does not write them that way — the teens each have their own word, and a tens-units compound keeps a cardinal tens word, turning only its final element into an ordinal.

## Fix

Compose Catalan ordinals the way the Institut d'Estudis Catalans normativa prescribes: the masculine ordinal is the cardinal + "-è" and the feminine the cardinal + "-na", and only the final element of a compound carries the ending.

| n | before | after |
|---|--------|-------|
| 11 | `desè primer` | `onzè` |
| 12 | `desè segon` | `dotzè` |
| 13 | `desè tercer` | `tretzè` |
| 21 | `vintè primer` | `vint-i-unè` |
| 22 | `vintè segon` | `vint-i-dosè` |
| 31 | `trenta-primera`* | `trenta-unè` |

Round ordinals (`desè`, `vintè`, `centè`, `milè`), hundreds (`dos-centè`), full compounds (`tres-cents cinquanta-tresè`) and the feminine forms are all covered. Cardinals, fractions and the round-trip sweep are unchanged.

The rule is implemented entirely inside the Catalan engine (`numbers_ca.py`), so the shared Romance ordinal path and the other languages that use it (es/fr/it/pt/gl) are untouched.

Verified against the Consorci per a la Normalització Lingüística "Els numerals ordinals" fitxa (reproducing the IEC normativa) and the Optimot "Guionet en els numerals compostos" fitxa: `22è vint-i-dosè` / `22a vint-i-dosena`, `54è cinquanta-quatrè`, `353è tres-cents cinquanta-tresè`.

## Tests

Adds a Catalan ordinal suite anchored to IEC-verified masculine and feminine forms across 1..100, the round tens/hundreds/thousand, and compound hundreds, plus a regression guard against the naive concatenation and the skill-facing `pronounce_number(ordinals=True)` path.