### PR TITLE
fix: keep the sign on negative Dutch millions with a remainder

### DIFF
--- a/ovos_number_parser/numbers_nl.py
+++ b/ovos_number_parser/numbers_nl.py
@@ -869,7 +869,14 @@ def _extract_whole_number_with_text_nl(tokens, short_scale, ordinals):
                 prev_val = 0
 
     if val is not None and to_sum:
-        val += sum(to_sum)
+        # The negative marker only reaches the first scale group, so a spoken
+        # "min vijf miljoen ..." leaves the trailing groups positive. When the
+        # leading group is negative the whole magnitude is, so recombine the
+        # absolute parts and restore the sign once.
+        if to_sum[0] < 0:
+            val = -(abs(val) + sum(abs(part) for part in to_sum))
+        else:
+            val += sum(to_sum)
 
     return val, number_words
 

--- a/tests/test_number_parser_nl.py
+++ b/tests/test_number_parser_nl.py
@@ -142,6 +142,15 @@ class TestDutchWideRoundTrip(unittest.TestCase):
                 spoken = pronounce_number(number, lang="nl")
                 self.assertEqual(extract_number(spoken, lang="nl"), number)
 
+    def test_round_trip_negative_millions_with_remainder(self):
+        # the negative marker only reaches the first scale group, so the
+        # trailing groups of "min ... miljoen ..." must still inherit the sign
+        for number in [-1500000, -1225280, -2540830, -5443013, -6634040,
+                       -1001710]:
+            with self.subTest(number=number):
+                spoken = pronounce_number(number, lang="nl")
+                self.assertEqual(extract_number(spoken, lang="nl"), number)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Round-trip sweeps of `pronounce_number_nl` through `extract_number_nl` over ±10,000,000 exposed a sign bug: negative numbers of a million or more that carry a sub-million remainder came back with the wrong value.

```
-5443013 -> min vijf miljoen ...drieenveertigduizenddertien -> -4556987  (was)
-1500000 -> min één miljoen vijfhonderdduizend            -> -500000   (was)
```

The negative marker only reaches the first scale group during extraction, so once "miljoen" splits the number into groups the trailing hundreds and thousands stayed positive. The tail now recombines the absolute parts and restores the sign once when the leading group is negative. Purely additive magnitudes are unchanged.

A negative-million round-trip case is added to the Dutch suite. Full suite green (the pre-existing `test_packaging` metadata check is unrelated).