### PR TITLE
fix: parse a bare 'one thousand' after a larger scale in Russian numbers

### DIFF
--- a/ovos_number_parser/numbers_ru.py
+++ b/ovos_number_parser/numbers_ru.py
@@ -1029,7 +1029,8 @@ def _extract_whole_number_with_text_ru(tokens, short_scale, ordinals):
         # twenty two, fifty six
         if (prev_word in _SUMS and val and val < 10) \
                 or (prev_word in _SUMS and val and val < 100 and prev_val >= 100) \
-                or all([prev_word in multiplies, val < prev_val if prev_val else False]):
+                or all([prev_word in multiplies, word not in multiplies,
+                        val < prev_val if prev_val else False]):
             if prev_val < 0:
                 # continue a negated number: "minus forty two" = -(40+2)
                 val = prev_val - val
@@ -1040,6 +1041,12 @@ def _extract_whole_number_with_text_ru(tokens, short_scale, ordinals):
         # twenty hundred, six hundred
         if word in multiplies:
             if not prev_val:
+                prev_val = 1
+            if prev_val >= current_val:
+                # a bare larger scale already sits in prev_val ("миллион
+                # тысяча"): this smaller scale word opens a new additive group
+                # of one, rather than multiplying the larger scale by itself
+                to_sum.append(prev_val)
                 prev_val = 1
             val = prev_val * val
 

--- a/tests/test_ru_large_numbers.py
+++ b/tests/test_ru_large_numbers.py
@@ -1,7 +1,8 @@
 import math
 import unittest
 
-from ovos_number_parser.numbers_ru import pronounce_number_ru
+from ovos_number_parser.numbers_ru import (pronounce_number_ru,
+                                           extract_number_ru)
 from ovos_number_parser.numbers_de import pronounce_number_de
 
 INF_WORD = "бесконечность"
@@ -49,6 +50,30 @@ class TestRussianLargeNumbers(unittest.TestCase):
             r = pronounce_number_de(x)
             self.assertTrue(r)
             self.assertNotIn("unendlich", r)
+
+
+class TestRussianBareThousandAfterScale(unittest.TestCase):
+    """A bare "тысяча" (one thousand) following a larger scale must open a new
+    additive group, not multiply the larger scale by itself."""
+
+    def test_million_plus_bare_thousand(self):
+        self.assertEqual(extract_number_ru("миллион тысяча пятьсот"), 1001500)
+        self.assertEqual(extract_number_ru("миллион тысяча"), 1001000)
+        self.assertEqual(
+            extract_number_ru("миллиард миллион тысяча"), 1001001000)
+
+    def test_regular_scale_composition_unchanged(self):
+        self.assertEqual(extract_number_ru("сто тысяч"), 100000)
+        self.assertEqual(extract_number_ru("двести тысяч пятьсот"), 200500)
+        self.assertEqual(
+            extract_number_ru("два миллиона триста тысяч"), 2300000)
+
+    def test_round_trip_million_boundary(self):
+        for number in [1001710, 4001978, 7001935, -1001710, 1001000,
+                       1000001, 1234567]:
+            with self.subTest(number=number):
+                spoken = pronounce_number_ru(number)
+                self.assertEqual(extract_number_ru(spoken), number)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Round-trip sweeps of `pronounce_number_ru` through `extract_number_ru` over ±10,000,000 (and spot values to 10^12) exposed a scale-composition bug. Russian spells scale words with no leading "one", so "million thousand ..." was mis-parsed: the completed million sat in the working value and the bare thousand multiplied it.

```
миллион тысяча пятьсот -> was wildly wrong (off by ~10^3–10^6), now 1001500
```

A bare scale word whose value does not exceed the value already accumulated now opens a new additive group of one, instead of multiplying the larger scale by itself. Genuine composition ("hundred thousand", "two million three hundred thousand") is unchanged. New round-trip regression tests cover the million boundary; full suite green (the pre-existing `test_packaging` metadata check is unrelated).