### PR TITLE
fix: parse a bare 'one thousand' after a larger scale in Ukrainian numbers

### DIFF
--- a/ovos_number_parser/numbers_uk.py
+++ b/ovos_number_parser/numbers_uk.py
@@ -1024,7 +1024,8 @@ def _extract_whole_number_with_text_uk(tokens, short_scale, ordinals):
         # twenty two, fifty six
         if (prev_word in _SUMS and val and val < 10) \
                 or (prev_word in _SUMS and val and val < 100 and prev_val >= 100) \
-                or all([prev_word in multiplies, val < prev_val if prev_val else False]):
+                or all([prev_word in multiplies, word not in multiplies,
+                        val < prev_val if prev_val else False]):
             if prev_val < 0:
                 # continue a negated number: "minus forty two" = -(40+2)
                 val = prev_val - val
@@ -1035,6 +1036,12 @@ def _extract_whole_number_with_text_uk(tokens, short_scale, ordinals):
         multiplies.update({"тисячa", "тисячі", "тисячу", "тисячах", "тисячaми", "тисячею", "тисяч"})
         if word in multiplies:
             if not prev_val:
+                prev_val = 1
+            if prev_val >= current_val:
+                # a bare larger scale already sits in prev_val ("мільйон
+                # тисяча"): this smaller scale word opens a new additive group
+                # of one, rather than multiplying the larger scale by itself
+                to_sum.append(prev_val)
                 prev_val = 1
             val = prev_val * val
 

--- a/tests/test_uk_bare_thousand.py
+++ b/tests/test_uk_bare_thousand.py
@@ -1,0 +1,30 @@
+import unittest
+
+from ovos_number_parser.numbers_uk import (extract_number_uk,
+                                           pronounce_number_uk)
+
+
+class TestUkrainianBareThousandAfterScale(unittest.TestCase):
+    """A bare "тисяча" (one thousand) following a larger scale must open a new
+    additive group, not multiply the larger scale by itself."""
+
+    def test_million_plus_bare_thousand(self):
+        self.assertEqual(
+            extract_number_uk("мільйон тисяча сімсот десять"), 1001710)
+        self.assertEqual(extract_number_uk("мільйон тисяча"), 1001000)
+
+    def test_regular_scale_composition_unchanged(self):
+        self.assertEqual(extract_number_uk("сто тисяч"), 100000)
+        self.assertEqual(
+            extract_number_uk("два мільйони триста тисяч"), 2300000)
+
+    def test_round_trip_million_boundary(self):
+        for number in [1001710, 4001978, 7001935, -1001710, 1001000,
+                       1000001, 1234567]:
+            with self.subTest(number=number):
+                spoken = pronounce_number_uk(number)
+                self.assertEqual(extract_number_uk(spoken), number)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Round-trip sweeps of `pronounce_number_uk` through `extract_number_uk` over ±10,000,000 (and spot values to 10^12) exposed a scale-composition bug. Ukrainian spells scale words with no leading "one", so "million thousand ..." was mis-parsed: the completed million sat in the working value and the bare thousand multiplied it.

```
мільйон тисяча сімсот десять -> was wildly wrong (off by ~10^3–10^6), now 1001710
```

A bare scale word whose value does not exceed the value already accumulated now opens a new additive group of one, instead of multiplying the larger scale by itself. Genuine composition ("hundred thousand", "two million three hundred thousand") is unchanged. New round-trip regression tests cover the million boundary; full suite green (the pre-existing `test_packaging` metadata check is unrelated).