### PR TITLE
fix: parse a bare 'one thousand' after a larger scale in Croatian numbers

### DIFF
--- a/ovos_number_parser/numbers_hr.py
+++ b/ovos_number_parser/numbers_hr.py
@@ -766,7 +766,8 @@ def _extract_whole_number_with_text_hr(tokens, short_scale, ordinals):
         # dvadeset dva, pedeset šest
         if (prev_word in _SUMS and val and val < 10) \
                 or (prev_word in _SUMS and val and val < 100 and prev_val >= 100) \
-                or all([prev_word in multiplies, val < prev_val if prev_val else False]):
+                or all([prev_word in multiplies, word not in multiplies,
+                        val < prev_val if prev_val else False]):
             if prev_val < 0:
                 # continue a negated number: "minus četrdeset dva" = -(40+2)
                 val = prev_val - val
@@ -777,6 +778,12 @@ def _extract_whole_number_with_text_hr(tokens, short_scale, ordinals):
         # dvije tisuće, šest milijuna
         if word in multiplies:
             if not prev_val:
+                prev_val = 1
+            if prev_val >= current_val:
+                # a bare larger scale already sits in prev_val ("milijun
+                # tisuću"): this smaller scale word opens a new additive group
+                # of one, rather than multiplying the larger scale by itself
+                to_sum.append(prev_val)
                 prev_val = 1
             val = prev_val * val
 

--- a/tests/test_hr_bare_thousand.py
+++ b/tests/test_hr_bare_thousand.py
@@ -1,0 +1,30 @@
+import unittest
+
+from ovos_number_parser.numbers_hr import (extract_number_hr,
+                                           pronounce_number_hr)
+
+
+class TestCroatianBareThousandAfterScale(unittest.TestCase):
+    """A bare "tisuću" (one thousand) following a larger scale must open a new
+    additive group, not multiply the larger scale by itself."""
+
+    def test_million_plus_bare_thousand(self):
+        self.assertEqual(
+            extract_number_hr("milijun tisuću sedamsto deset"), 1001710)
+        self.assertEqual(extract_number_hr("milijun tisuću"), 1001000)
+
+    def test_regular_scale_composition_unchanged(self):
+        self.assertEqual(extract_number_hr("sto tisuća"), 100000)
+        self.assertEqual(
+            extract_number_hr("dva milijuna tristo tisuća"), 2300000)
+
+    def test_round_trip_million_boundary(self):
+        for number in [1001710, 4001978, 7001935, -1001710, 1001000,
+                       1000001, 1234567]:
+            with self.subTest(number=number):
+                spoken = pronounce_number_hr(number)
+                self.assertEqual(extract_number_hr(spoken), number)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Round-trip sweeps of `pronounce_number_hr` through `extract_number_hr` over ±10,000,000 (and spot values to 10^12) exposed a scale-composition bug. Croatian spells scale words with no leading "one", so "million thousand ..." was mis-parsed: the completed million sat in the working value and the bare thousand multiplied it.

```
milijun tisuću sedamsto deset -> was wildly wrong (off by ~10^3–10^6), now 1001710
```

A bare scale word whose value does not exceed the value already accumulated now opens a new additive group of one, instead of multiplying the larger scale by itself. Genuine composition ("hundred thousand", "two million three hundred thousand") is unchanged. New round-trip regression tests cover the million boundary; full suite green (the pre-existing `test_packaging` metadata check is unrelated).