### PR TITLE
fix: parse a bare 'one thousand' after a larger scale in Bulgarian numbers

### DIFF
--- a/ovos_number_parser/numbers_bg.py
+++ b/ovos_number_parser/numbers_bg.py
@@ -760,7 +760,8 @@ def _extract_whole_number_with_text_bg(tokens, short_scale, ordinals):
         # двадесет [и] три, сто [и] пет
         if (prev_word in _SUMS_BG and val and val < 10) \
                 or (prev_word in _SUMS_BG and val and val < 100 and prev_val >= 100) \
-                or all([prev_word in _MULTIPLIES_BG, val < prev_val if prev_val else False]):
+                or all([prev_word in _MULTIPLIES_BG, word not in _MULTIPLIES_BG,
+                        val < prev_val if prev_val else False]):
             if prev_val < 0:
                 # continue a negated number: "минус четиридесет и две" = -(40+2)
                 val = prev_val - val
@@ -771,6 +772,12 @@ def _extract_whole_number_with_text_bg(tokens, short_scale, ordinals):
         # две хиляди, три милиона
         if word in _MULTIPLIES_BG:
             if not prev_val:
+                prev_val = 1
+            if prev_val >= current_val:
+                # a bare larger scale already sits in prev_val ("милион
+                # хиляда"): this smaller scale word opens a new additive group
+                # of one, rather than multiplying the larger scale by itself
+                to_sum.append(prev_val)
                 prev_val = 1
             val = prev_val * val
 

--- a/tests/test_bg_bare_thousand.py
+++ b/tests/test_bg_bare_thousand.py
@@ -1,0 +1,31 @@
+import unittest
+
+from ovos_number_parser.numbers_bg import (extract_number_bg,
+                                           pronounce_number_bg)
+
+
+class TestBulgarianBareThousandAfterScale(unittest.TestCase):
+    """A bare "хиляда" (one thousand) following a larger scale must open a new
+    additive group, not multiply the larger scale by itself."""
+
+    def test_million_plus_bare_thousand(self):
+        self.assertEqual(
+            extract_number_bg("един милион хиляда седемстотин и десет"),
+            1001710)
+        self.assertEqual(extract_number_bg("един милион хиляда"), 1001000)
+
+    def test_regular_scale_composition_unchanged(self):
+        self.assertEqual(extract_number_bg("сто хиляди"), 100000)
+        self.assertEqual(
+            extract_number_bg("два милиона триста хиляди"), 2300000)
+
+    def test_round_trip_million_boundary(self):
+        for number in [1001710, 4001978, 7001935, -1001710, 1001000,
+                       1000001, 1234567]:
+            with self.subTest(number=number):
+                spoken = pronounce_number_bg(number)
+                self.assertEqual(extract_number_bg(spoken), number)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Round-trip sweeps of `pronounce_number_bg` through `extract_number_bg` over ±10,000,000 (and spot values to 10^12) exposed a scale-composition bug. Bulgarian spells scale words with no leading "one", so "million thousand ..." was mis-parsed: the completed million sat in the working value and the bare thousand multiplied it.

```
един милион хиляда седемстотин и десет -> was wildly wrong (off by ~10^3–10^6), now 1001710
```

A bare scale word whose value does not exceed the value already accumulated now opens a new additive group of one, instead of multiplying the larger scale by itself. Genuine composition ("hundred thousand", "two million three hundred thousand") is unchanged. New round-trip regression tests cover the million boundary; full suite green (the pre-existing `test_packaging` metadata check is unrelated).