### PR TITLE
fix: compose adjacent scale words in Greek numbers

### DIFF
--- a/ovos_number_parser/numbers_el.py
+++ b/ovos_number_parser/numbers_el.py
@@ -419,6 +419,7 @@ def _parse_number_span(tokens, i):
     current = 0
     started = False
     last_rank = 4
+    last_scale = None
     n = len(tokens)
     j = i
     while j < n:
@@ -455,11 +456,26 @@ def _parse_number_span(tokens, i):
         if tok in _SCALES_LOOKUP:
             scale = _SCALES_LOOKUP[tok]
             if started and current == 0:
-                break  # a scale word was already consumed for this group
+                # a bare scale word directly after another scale word
+                if last_scale is not None and scale < last_scale:
+                    # descending sequence ("εκατομμύριο χίλια"): add one of it
+                    total += scale
+                    last_scale = scale
+                    j += 1
+                    continue
+                if last_scale is not None and scale == last_scale:
+                    break  # a repeat of the same scale ends the number
+                # ascending sequence ("χίλια δισεκατομμύρια"): the smaller
+                # scale multiplies the larger one that follows
+                total *= scale
+                last_scale = scale
+                j += 1
+                continue
             total += (current if current else 1) * scale
             current = 0
             started = True
             last_rank = 4
+            last_scale = scale
             j += 1
             continue
         if tok in _FRACTIONS_LOOKUP:

--- a/tests/test_el_scale_composition.py
+++ b/tests/test_el_scale_composition.py
@@ -1,0 +1,34 @@
+import unittest
+
+from ovos_number_parser.numbers_el import (extract_number_el,
+                                           pronounce_number_el)
+
+
+class TestGreekScaleComposition(unittest.TestCase):
+    """A bare scale word following a larger scale must continue the number:
+    added when descending ("εκατομμύριο χίλια"), multiplied when the smaller
+    scale precedes a larger one ("χίλια δισεκατομμύρια")."""
+
+    def test_million_plus_bare_thousand(self):
+        self.assertEqual(
+            extract_number_el("ένα εκατομμύριο χίλια επτακόσια δέκα"), 1001710)
+
+    def test_thousand_times_billion(self):
+        self.assertEqual(extract_number_el("χίλια δισεκατομμύρια"),
+                         1000000000000)
+
+    def test_regular_composition_unchanged(self):
+        self.assertEqual(
+            extract_number_el("δύο εκατομμύρια τριακόσιες χιλιάδες"), 2300000)
+        self.assertEqual(extract_number_el("χίλια"), 1000)
+
+    def test_round_trip_million_boundary(self):
+        for number in [1001710, 4001978, 7001935, -1001710, 1001000,
+                       1000001, 1234567, 1000000000000]:
+            with self.subTest(number=number):
+                spoken = pronounce_number_el(number)
+                self.assertEqual(extract_number_el(spoken), number)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Round-trip sweeps of `pronounce_number_el` through `extract_number_el` over ±10,000,000 (and 10^7–10^12) exposed a scale-composition bug. A bare scale word directly after another scale was rejected outright.

```
ένα εκατομμύριο χίλια επτακόσια δέκα -> was 1000000, now 1001710
χίλια δισεκατομμύρια               -> was 1000,    now 1000000000000
```

A smaller scale following a larger one is now added (descending, "εκατομμύριο χίλια"), and a smaller scale preceding a larger one multiplies it (ascending, "χίλια δισεκατομμύρια" = 10^12). A repeat of the same scale still ends the number. Regular composition ("δύο εκατομμύρια τριακόσιες χιλιάδες") is unchanged. New round-trip regression tests added; full suite green (the pre-existing `test_packaging` metadata check is unrelated).