### PR TITLE
fix: parse a bare scale word in Farsi numbers

### DIFF
--- a/ovos_number_parser/numbers_fa.py
+++ b/ovos_number_parser/numbers_fa.py
@@ -169,7 +169,8 @@ def _parse_sentence(text):
         elif x in _FARSI_BIG:
             current_words.append(x)
             d = _FARSI_BIG.index(x)
-            if mode == 'init' and d == 1:
+            if s == 0:
+                # a bare scale word ("... و هزار") means one of that scale
                 s = 1
             s *= 10 ** (3 * d)
             current_number += s

--- a/tests/test_fa_bare_scale.py
+++ b/tests/test_fa_bare_scale.py
@@ -1,0 +1,29 @@
+import unittest
+
+from ovos_number_parser.numbers_fa import (extract_number_fa,
+                                           pronounce_number_fa)
+
+
+class TestFarsiBareScale(unittest.TestCase):
+    """A bare scale word ("... و هزار") means one of that scale and must be
+    added, not dropped."""
+
+    def test_million_plus_bare_thousand(self):
+        self.assertEqual(
+            extract_number_fa("یک میلیون و هزار و هفتصد و ده"), 1001710)
+        self.assertEqual(extract_number_fa("هزار"), 1000)
+
+    def test_regular_composition_unchanged(self):
+        self.assertEqual(extract_number_fa("دو هزار"), 2000)
+        self.assertEqual(extract_number_fa("سیصد هزار"), 300000)
+
+    def test_round_trip_million_boundary(self):
+        for number in [1001710, 4001978, 7001935, -1001710, 1001000,
+                       1000001, 1234567, 1000000000000]:
+            with self.subTest(number=number):
+                spoken = pronounce_number_fa(number)
+                self.assertEqual(extract_number_fa(spoken), number)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Round-trip sweeps of `pronounce_number_fa` through `extract_number_fa` over ±10,000,000 (and to 10^12) exposed a dropped-scale bug. Farsi spells scale words with no leading "one", so a bare "... و هزار" contributed nothing because the scale multiplier stayed zero.

```
یک میلیون و هزار و هفتصد و ده -> was 1000710, now 1001710
هزار                          -> was dropped, now 1000
```

A scale word with no count in front now means one of that scale. Regular composition ("دو هزار", "سیصد هزار") is unchanged. New round-trip regression tests added; full suite green (the pre-existing `test_packaging` metadata check is unrelated).