### PR TITLE
fix: parse a bare 'ettusen' after a larger scale in Swedish numbers

### DIFF
--- a/ovos_number_parser/numbers_sv.py
+++ b/ovos_number_parser/numbers_sv.py
@@ -531,18 +531,33 @@ def extract_number_sv(text, short_scale=True, ordinals=False):
     # merge lower-magnitude continuations ("2000 23" -> 2023)
     scales = {100, 1000, 1000000, 1000000000, 1000000000000}
     merged = []
-    for w in expanded:
+    for idx, w in enumerate(expanded):
         if merged and w.isdigit() and merged[-1].isdigit():
             prev, nxt = int(merged[-1]), int(w)
             if nxt in scales and prev < nxt:
                 # "två miljoner" -> 2 * 1000000
                 merged[-1] = str(prev * nxt)
                 continue
-            if _merge_values_sv(prev, nxt):
+            follow = int(expanded[idx + 1]) if idx + 1 < len(expanded) \
+                and expanded[idx + 1].isdigit() else None
+            # a small value that a following scale word will multiply belongs
+            # to that scale, not the preceding group ("en miljon ett tusen")
+            if not (follow in scales and nxt < follow) \
+                    and _merge_values_sv(prev, nxt):
                 # "tvåtusen tjugotre" -> 2000 + 23
                 merged[-1] = str(prev + nxt)
                 continue
         merged.append(w)
+    # fold descending scale groups the forward pass left apart
+    # ("1000000", "1710" -> 1001710)
+    collapsed = []
+    for w in merged:
+        if collapsed and w.isdigit() and collapsed[-1].isdigit() \
+                and _merge_values_sv(int(collapsed[-1]), int(w)):
+            collapsed[-1] = str(int(collapsed[-1]) + int(w))
+        else:
+            collapsed.append(w)
+    merged = collapsed
     # spoken decimals: "två komma fem" -> "2.5"
     out = []
     i = 0

--- a/tests/test_sv_bare_thousand.py
+++ b/tests/test_sv_bare_thousand.py
@@ -1,0 +1,32 @@
+import unittest
+
+from ovos_number_parser.numbers_sv import (extract_number_sv,
+                                           pronounce_number_sv)
+
+
+class TestSwedishBareThousandAfterScale(unittest.TestCase):
+    """A bare "ettusen" (one thousand) following a larger scale must be added,
+    not collapsed into the preceding scale as a stray one."""
+
+    def test_million_plus_bare_thousand(self):
+        self.assertEqual(
+            extract_number_sv("en miljon ettusen sjuhundratio"), 1001710)
+        self.assertEqual(
+            extract_number_sv("sexmiljoner ettusen tvåhundraåttiofem"),
+            6001285)
+
+    def test_regular_composition_unchanged(self):
+        self.assertEqual(extract_number_sv("ettusen"), 1000)
+        self.assertEqual(extract_number_sv("tjugoettusen"), 21000)
+        self.assertEqual(extract_number_sv("tvåtusen tjugotre"), 2023)
+
+    def test_round_trip_million_boundary(self):
+        for number in [1001710, 4001978, 7001935, -1001710, 1001000,
+                       1000001, 1234567]:
+            with self.subTest(number=number):
+                spoken = pronounce_number_sv(number)
+                self.assertEqual(extract_number_sv(spoken), number)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Round-trip sweeps of `pronounce_number_sv` through `extract_number_sv` over ±10,000,000 exposed a dropped-thousand bug. "en miljon ettusen ..." splits "ettusen" into "ett tusen", and the leading one was swallowed by the preceding million before the thousand scale could apply.

```
en miljon ettusen sjuhundratio       -> was 1000001, now 1001710
sexmiljoner ettusen tvåhundraåttiofem -> was 6000000, now 6001285
```

A small value that a following scale word will multiply now binds forward instead of merging backward, and a trailing collapse pass folds the completed thousand group back into the larger scale. Compound thousands ("tjugoettusen" = 21000) and "tvåtusen tjugotre" are unchanged. New round-trip regression tests added; full suite green (the pre-existing `test_packaging` metadata check is unrelated).