### PR TITLE
fix: treat a zero denominator as not a fraction

### DIFF
--- a/ovos_number_parser/util.py
+++ b/ovos_number_parser/util.py
@@ -225,7 +225,9 @@ def look_for_fractions(split_list: List[str]) -> bool:
 
     if len(split_list) == 2:
         if is_numeric(split_list[0]) and is_numeric(split_list[1]):
-            return True
+            # a zero denominator is not a fraction; callers divide by it, so
+            # reject it here rather than raise ZeroDivisionError downstream
+            return float(split_list[1]) != 0
 
     return False
 

--- a/tests/test_nonstr_input_sentinel.py
+++ b/tests/test_nonstr_input_sentinel.py
@@ -29,6 +29,15 @@ class TestNonStringInputSentinel(unittest.TestCase):
         for lang in LANGS:
             self.assertFalse(extract_number("", lang))
 
+    def test_zero_denominator_fraction_does_not_raise(self):
+        # a spoken "1/0" must not raise ZeroDivisionError for languages that
+        # route fractions through the shared look_for_fractions helper
+        shared = [l for l in LANGS if l not in ("pl", "id", "ms")]
+        for lang in shared:
+            for text in ("1/0", "5/0", "1/0 apples"):
+                self.assertFalse(extract_number(text, lang),
+                                 f"extract_number({text!r}, {lang!r})")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -645,10 +645,16 @@ class TestLookForFractions(unittest.TestCase):
 
     def test_look_for_fractions_edge_cases(self):
         """Test look_for_fractions with edge cases."""
-        self.assertTrue(look_for_fractions(["0", "0"]))  # Zero fraction
         self.assertTrue(look_for_fractions(["inf", "1"]))  # Infinity (is_numeric returns True)
         self.assertTrue(look_for_fractions(["1", "inf"]))  # Infinity denominator
         self.assertTrue(look_for_fractions(["nan", "1"]))  # NaN (is_numeric returns True)
+
+    def test_look_for_fractions_zero_denominator(self):
+        """A zero denominator is not a fraction; callers divide by it."""
+        self.assertFalse(look_for_fractions(["1", "0"]))
+        self.assertFalse(look_for_fractions(["0", "0"]))
+        self.assertFalse(look_for_fractions(["5", "0.0"]))
+        self.assertTrue(look_for_fractions(["0", "5"]))  # zero numerator is fine
 
     def test_look_for_fractions_mixed_valid_invalid(self):
         """Test look_for_fractions with mixed valid/invalid combinations."""


### PR DESCRIPTION
An adversarial pass found that `extract_number("1/0", lang=...)` raised `ZeroDivisionError` for every language that routes written fractions through the shared `look_for_fractions` helper (en, ru, sv, de, es, and ~25 more). The helper accepted `["1", "0"]` as a fraction, and each caller then evaluated `float(a) / float(b)`.

The helper now rejects a zero denominator, so the text falls through to "no number" instead of raising. A zero numerator ("0/5") is still a valid fraction. The existing edge-case test that asserted `["0", "0"]` was a fraction is corrected, and a dispatcher-level regression covers the affected languages.

Two languages carry their own fraction code and are handled in sibling PRs (id/ms, pl). Full suite green (the pre-existing `test_packaging` metadata check is unrelated).