### PR TITLE
fix: extract a written slash fraction in Polish without crashing

### DIFF
--- a/ovos_number_parser/numbers_pl.py
+++ b/ovos_number_parser/numbers_pl.py
@@ -945,7 +945,7 @@ def _extract_whole_number_with_text_pl(tokens, short_scale, ordinals):
             aPieces = word.split('/')
             if look_for_fractions(aPieces):
                 val = float(aPieces[0]) / float(aPieces[1])
-                number_words.append(tokens[idx + 1])
+                current_val = val
         else:
             if all([
                 prev_word in _SUMS,

--- a/tests/test_pl_slash_fraction.py
+++ b/tests/test_pl_slash_fraction.py
@@ -1,0 +1,20 @@
+import unittest
+
+from ovos_number_parser.numbers_pl import extract_number_pl
+
+
+class TestPolishSlashFraction(unittest.TestCase):
+    """A written "N/M" fraction must be extracted, not raise IndexError when
+    it is the final token."""
+
+    def test_bare_slash_fraction(self):
+        self.assertEqual(extract_number_pl("3/4"), 0.75)
+        self.assertEqual(extract_number_pl("1/2"), 0.5)
+        self.assertEqual(extract_number_pl("0/5"), 0.0)
+
+    def test_slash_fraction_in_sentence(self):
+        self.assertEqual(extract_number_pl("mam 3/4 jabłka"), 0.75)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`extract_number("3/4", lang="pl")` raised `IndexError`: the fraction branch appended `tokens[idx + 1]` even when the fraction was the final token. It now records the fraction value the way the neighbouring branches do, without reaching past the end.

```
3/4 -> 0.75   1/2 -> 0.5   0/5 -> 0.0   (all raised IndexError before)
```

Regression tests added. Full suite green (the pre-existing `test_packaging` metadata check is unrelated). A zero denominator ("1/0") is covered by the shared-helper PR.