### PR TITLE
fix: reject a zero denominator in Indonesian and Malay slash fractions

### DIFF
--- a/ovos_number_parser/numbers_id.py
+++ b/ovos_number_parser/numbers_id.py
@@ -315,7 +315,8 @@ def _extract_number(text: str, lang: _LangDef,
                 val += fractions[tokens[i + 1]]
             return int(val) if val == int(val) else val
         pieces = clean.split("/")
-        if len(pieces) == 2 and all(p.lstrip("-").isdigit() for p in pieces):
+        if len(pieces) == 2 and all(p.lstrip("-").isdigit() for p in pieces) \
+                and float(pieces[1]) != 0:
             return float(pieces[0]) / float(pieces[1])
 
         # ordinals: "pertama", "kedua", "kedua puluh satu"

--- a/tests/test_id_ms_zero_denominator.py
+++ b/tests/test_id_ms_zero_denominator.py
@@ -1,0 +1,23 @@
+import unittest
+
+from ovos_number_parser.numbers_id import (extract_number_id,
+                                           extract_number_ms)
+
+
+class TestIndonesianMalayZeroDenominator(unittest.TestCase):
+    """A written "N/0" must not raise ZeroDivisionError; valid fractions still
+    parse."""
+
+    def test_zero_denominator_does_not_raise(self):
+        for extract in (extract_number_id, extract_number_ms):
+            self.assertFalse(extract("1/0"))
+            self.assertFalse(extract("5/0"))
+
+    def test_valid_fractions_unchanged(self):
+        for extract in (extract_number_id, extract_number_ms):
+            self.assertEqual(extract("3/4"), 0.75)
+            self.assertEqual(extract("1/2"), 0.5)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Indonesian and Malay carry their own fraction parsing (shared `numbers_id.py`), which divided `"1/0"` directly and raised `ZeroDivisionError`. A zero denominator is now treated as not-a-fraction, so the text falls through to no number; valid fractions ("3/4", "1/2") are unchanged.

Regression tests added. Full suite green (the pre-existing `test_packaging` metadata check is unrelated).