### PR TITLE
fix: guard non-finite/overflow string tokens in extract_number

### DIFF
--- a/ovos_number_parser/numbers_ar.py
+++ b/ovos_number_parser/numbers_ar.py
@@ -9,6 +9,7 @@ Arabic-Indic (٠-٩) and Persian/Urdu (۰-۹) digits, and numbers written
 immediately adjacent to punctuation (``٢٠٢٤،``, ``25.``).
 """
 
+from math import isfinite
 from ovos_number_parser.util import convert_to_mixed_fraction
 
 _AR_SEPARATOR = " و"  # the conjunction attaches to the following word
@@ -376,8 +377,9 @@ def _group_slot(tokens, j):
 
 def _is_number(s):
     try:
-        float(s)
-        return True
+        # a non-finite token ("inf", "nan", "1e309" or an overflowing digit
+        # string) carries no usable number and must not be treated as one
+        return isfinite(float(s))
     except ValueError:
         return False
 

--- a/ovos_number_parser/numbers_da.py
+++ b/ovos_number_parser/numbers_da.py
@@ -1,4 +1,4 @@
-from math import floor
+from math import floor, isfinite
 
 from ovos_number_parser.util import (invert_dict, convert_to_mixed_fraction, tokenize,
                                      ReplaceableNumber, Token, look_for_fractions)
@@ -931,7 +931,12 @@ def extract_number_da(text, short_scale=False, ordinals=False):
 
     if not numbers:
         return False
-    number = float(numbers[0].value)
+    try:
+        number = float(numbers[0].value)
+    except (OverflowError, ValueError):
+        return False
+    if not isfinite(number):
+        return False
     if number.is_integer():
         number = int(number)
     return number

--- a/ovos_number_parser/numbers_de.py
+++ b/ovos_number_parser/numbers_de.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict
-from math import floor
+from math import floor, isfinite
 
 from ovos_number_parser.util import (invert_dict, convert_to_mixed_fraction, tokenize, ReplaceableNumber, Token,
                                      look_for_fractions)
@@ -901,7 +901,12 @@ def extract_number_de(text, short_scale=True, ordinals=False):
     number = numbers[0].value if numbers else None
 
     if number:
-        number = float(number)
+        try:
+            number = float(number)
+        except (OverflowError, ValueError):
+            return False
+        if not isfinite(number):
+            return False
         if number.is_integer():
             number = int(number)
 

--- a/ovos_number_parser/numbers_el.py
+++ b/ovos_number_parser/numbers_el.py
@@ -8,6 +8,7 @@ spellings, and unaccented input: matching is done on text with the Greek
 tonos and diaeresis stripped and the final sigma folded.
 """
 
+from math import isfinite
 from ovos_number_parser.util import convert_to_mixed_fraction
 
 # tonos/diaeresis stripping + final sigma folding, applied after casefold
@@ -352,8 +353,9 @@ def _build_ordinal_lookup():
 
 def _is_number(s):
     try:
-        float(s)
-        return True
+        # a non-finite token ("inf", "nan", "1e309" or an overflowing digit
+        # string) carries no usable number and must not be treated as one
+        return isfinite(float(s))
     except ValueError:
         return False
 

--- a/ovos_number_parser/numbers_es.py
+++ b/ovos_number_parser/numbers_es.py
@@ -289,12 +289,16 @@ def extract_number_es(text, short_scale=True, ordinals=False):
     vocabulary follows RAE, *Ortografía de la lengua española* (2010, p. 671):
     the twenties are written solid ("veintiuno".."veintinueve") while from
     thirty on the parts stand apart ("treinta y uno"), "y" joins only tens to
-    units, and "cien" apocopates to "ciento" inside compounds. The ``scale``
-    defaults to the long scale used in Spain (millón 10^6, billón 10^12).
+    units, and "cien" apocopates to "ciento" inside compounds.
+
+    This low-level entry point defaults ``short_scale`` to ``True``. The public
+    :func:`ovos_number_parser.extract_number` wrapper instead resolves the scale
+    from the language configuration, applying the long scale used in Spain
+    (millón 10^6, billón 10^12) that Castilian Spanish speakers expect.
 
     Args:
         text (str): the string to extract a number from
-        short_scale (bool): use the short scale instead of the default long scale
+        short_scale (bool): use the short scale (default) instead of the long scale
         ordinals (bool): also recognise ordinal words
     Returns:
         (int, float) or False: the extracted number, or False if none is found

--- a/ovos_number_parser/numbers_et.py
+++ b/ovos_number_parser/numbers_et.py
@@ -13,7 +13,7 @@ References:
     * https://et.wikipedia.org/wiki/Arvs%C3%B5na
     * https://en.wiktionary.org/wiki/Appendix:Estonian_numbers
 """
-from math import floor
+from math import floor, isfinite
 
 from ovos_number_parser.util import convert_to_mixed_fraction
 
@@ -405,9 +405,10 @@ def _extract_span_et(tokens, idx):
     cleaned = token.replace(',', '.')
     try:
         val = float(cleaned)
-        if val == int(val) and '.' not in cleaned:
-            val = int(val)
-        return val, idx + 1
+        if isfinite(val):
+            if val == int(val) and '.' not in cleaned:
+                val = int(val)
+            return val, idx + 1
     except ValueError:
         pass
 

--- a/ovos_number_parser/numbers_fa.py
+++ b/ovos_number_parser/numbers_fa.py
@@ -102,8 +102,9 @@ class NumberVariantFA(IntEnum):
 
 def _is_number(s):
     try:
-        float(s)
-        return True
+        # a non-finite token ("inf", "nan", "1e309" or an overflowing digit
+        # string) carries no usable number and must not be treated as one
+        return math.isfinite(float(s))
     except ValueError:
         return False
 

--- a/ovos_number_parser/numbers_fi.py
+++ b/ovos_number_parser/numbers_fi.py
@@ -14,7 +14,7 @@ References:
     * https://fi.wikipedia.org/wiki/Numeraali
     * https://en.wiktionary.org/wiki/Appendix:Finnish_numbers
 """
-from math import floor
+from math import floor, isfinite
 
 from ovos_number_parser.util import convert_to_mixed_fraction
 
@@ -455,9 +455,10 @@ def _extract_span_fi(tokens, idx):
     cleaned = token.replace(',', '.')
     try:
         val = float(cleaned)
-        if val == int(val) and '.' not in cleaned:
-            val = int(val)
-        return val, idx + 1
+        if isfinite(val):
+            if val == int(val) and '.' not in cleaned:
+                val = int(val)
+            return val, idx + 1
     except ValueError:
         pass
 

--- a/ovos_number_parser/numbers_he.py
+++ b/ovos_number_parser/numbers_he.py
@@ -8,6 +8,7 @@ value times two (``מאתיים`` = 200, ``אלפיים`` = 2000). Niqqud (vowel
 points and cantillation marks) is stripped before matching.
 """
 
+from math import isfinite
 from ovos_number_parser.util import convert_to_mixed_fraction
 
 # niqqud and cantillation marks are stripped so vocalized text matches
@@ -311,8 +312,9 @@ _ORDINAL_UNITS_LOOKUP.update({w: v for v, w in _ORDINALS_FEM_HE.items()})
 
 def _is_number(s):
     try:
-        float(s)
-        return True
+        # a non-finite token ("inf", "nan", "1e309" or an overflowing digit
+        # string) carries no usable number and must not be treated as one
+        return isfinite(float(s))
     except ValueError:
         return False
 

--- a/ovos_number_parser/numbers_hu.py
+++ b/ovos_number_parser/numbers_hu.py
@@ -1,5 +1,5 @@
 from ovos_number_parser.util import (convert_to_mixed_fraction)
-from math import floor
+from math import floor, isfinite
 _NUM_STRING_HU = {
     0: 'nulla',
     1: 'egy',
@@ -434,9 +434,10 @@ def extract_number_hu(text, short_scale=True, ordinals=False):
         cleaned = token.replace(',', '.')
         try:
             val = float(cleaned)
-            if val == int(val) and '.' not in cleaned:
-                val = int(val)
-            return -val if negative else val
+            if isfinite(val):
+                if val == int(val) and '.' not in cleaned:
+                    val = int(val)
+                return -val if negative else val
         except ValueError:
             pass
 

--- a/ovos_number_parser/numbers_id.py
+++ b/ovos_number_parser/numbers_id.py
@@ -22,6 +22,7 @@ take the ``ke-`` prefix ("kedua" = 2nd) with the irregular "pertama"
 """
 import re
 from dataclasses import dataclass, field
+from math import isfinite
 from typing import Dict, List, Optional, Union
 
 _UNITS_COMMON = {
@@ -310,6 +311,8 @@ def _extract_number(text: str, lang: _LangDef,
         clean = tok.strip(".!?;:")
         if re.fullmatch(r"-?\d+(?:[.,]\d+)?", clean):
             val = float(clean.replace(",", "."))
+            if not isfinite(val):
+                return False
             # "2 setengah" = 2.5
             if i + 1 < len(tokens) and tokens[i + 1] in fractions:
                 val += fractions[tokens[i + 1]]

--- a/ovos_number_parser/numbers_nb.py
+++ b/ovos_number_parser/numbers_nb.py
@@ -23,7 +23,7 @@ Sources:
     - https://ordbokene.no (Språkrådet/UiB: Bokmålsordboka & Nynorskordboka;
       every pronounced form in this module is an attested entry)
 """
-from math import floor
+from math import floor, isfinite
 
 from ovos_number_parser.util import (invert_dict, convert_to_mixed_fraction, tokenize,
                                      ReplaceableNumber, Token, look_for_fractions)
@@ -736,7 +736,12 @@ def _extract_number(text, t, ordinals=False):
     numbers = _extract_numbers_with_text(tokenize(text), t)
     if not numbers:
         return False
-    number = float(numbers[0].value)
+    try:
+        number = float(numbers[0].value)
+    except (OverflowError, ValueError):
+        return False
+    if not isfinite(number):
+        return False
     if number.is_integer():
         number = int(number)
     return number

--- a/ovos_number_parser/numbers_sl.py
+++ b/ovos_number_parser/numbers_sl.py
@@ -1,3 +1,4 @@
+from math import isfinite
 from collections import OrderedDict
 
 from ovos_number_parser.util import (convert_to_mixed_fraction)
@@ -623,9 +624,10 @@ def extract_number_sl(text, short_scale=True, ordinals=False):
         cleaned = token.replace(',', '.')
         try:
             val = float(cleaned)
-            if val == int(val) and '.' not in cleaned:
-                val = int(val)
-            return -val if negative else val
+            if isfinite(val):
+                if val == int(val) and '.' not in cleaned:
+                    val = int(val)
+                return -val if negative else val
         except ValueError:
             pass
 

--- a/ovos_number_parser/numbers_sv.py
+++ b/ovos_number_parser/numbers_sv.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from math import floor
+from math import floor, isfinite
 
 from ovos_number_parser.util import (convert_to_mixed_fraction, is_numeric, look_for_fractions, Token)
 
@@ -584,7 +584,9 @@ def extract_number_sv(text, short_scale=True, ordinals=False):
     count = 0
     while count < len(aWords):
         word = aWords[count]
-        if is_numeric(word):
+        if is_numeric(word) and isfinite(float(word)):
+            # an overflowing digit string ("9" * 400) or a non-finite token
+            # floats to inf; it carries no usable number, so it is skipped
             val = float(word)
             if count + 1 < len(aWords):
                 valNext = is_fractional_sv(aWords[count + 1])

--- a/ovos_number_parser/util.py
+++ b/ovos_number_parser/util.py
@@ -203,13 +203,20 @@ def is_numeric(input_str: str) -> bool:
         input_str (str): The string to test for numeric value.
 
     Returns:
-        bool: True if the string can be converted to a float, False otherwise.
+        bool: True if the string is a finite number (or a plain integer string,
+            which stays exact even when it exceeds float range), False for a
+            non-finite token such as "inf", "nan" or "1e309".
     """
     try:
-        float(input_str)
-        return True
+        val = float(input_str)
     except ValueError:
         return False
+    if math.isfinite(val):
+        return True
+    # a plain integer string that overflows float to inf is still a usable
+    # number (Python ints are unbounded); a non-finite token such as "inf",
+    # "nan" or "1e309" carries no usable number and must not be treated as one
+    return input_str.strip().lstrip("+-").isdigit()
 
 
 def look_for_fractions(split_list: List[str]) -> bool:
@@ -507,6 +514,11 @@ class RomanceNumberExtractor:
             t = tok.strip(".,!?;:").replace(",", ".")
             if t and t.lstrip("-").replace(".", "", 1).isdigit():
                 val = float(t)
+                # an out-of-range digit token (e.g. "1e309" or a 400-digit
+                # string) overflows to inf/nan; it carries no usable number,
+                # so skip it rather than return a non-finite value
+                if not math.isfinite(val):
+                    continue
                 return int(val) if val.is_integer() else val
             if tok in numbers_map or tok in ordinals_map or tok in scales_map:
                 break

--- a/tests/test_overflow_string_sentinel.py
+++ b/tests/test_overflow_string_sentinel.py
@@ -1,0 +1,60 @@
+import math
+import unittest
+
+from ovos_number_parser import extract_number
+
+# every language that has an extractor wired into the dispatch
+LANGS = ["en", "es", "pt", "de", "fr", "it", "nl", "ru", "ar", "fa", "pl",
+         "sv", "fi", "el", "he", "hu", "sl", "ro", "ast", "oc", "an", "kab",
+         "id", "ms", "tr", "sk", "hr", "bg", "cs", "uk", "az", "da", "ca",
+         "gl", "eu", "et", "fy", "nb", "nn", "mwl"]
+
+# pathological string tokens that overflow float() or parse to inf/nan
+OVERFLOW_TOKENS = ["inf", "-inf", "nan", "1e309", "1e400", "9" * 400]
+
+
+class TestOverflowStringSentinel(unittest.TestCase):
+    def test_non_finite_string_tokens_never_raise(self):
+        # a pathological string token must degrade to the "no number" sentinel
+        # (or a finite parsed value) through the public API, never raise
+        for lang in LANGS:
+            for token in OVERFLOW_TOKENS:
+                try:
+                    result = extract_number(token, lang)
+                except Exception as exc:  # pragma: no cover - failure path
+                    self.fail(
+                        f"extract_number({token!r}, {lang!r}) raised "
+                        f"{type(exc).__name__}: {exc}")
+                # whatever comes back must be either the False sentinel, an
+                # exact integer (a huge digit string stays exact), or a finite
+                # float - never a non-finite float such as inf or nan
+                if isinstance(result, float):
+                    self.assertTrue(
+                        math.isfinite(result),
+                        f"extract_number({token!r}, {lang!r}) returned a "
+                        f"non-finite value {result!r}")
+
+    def test_non_finite_with_trailing_words(self):
+        # the same token embedded in a sentence must not raise either
+        for lang in LANGS:
+            for token in OVERFLOW_TOKENS:
+                text = f"{token} apples"
+                try:
+                    extract_number(text, lang)
+                except Exception as exc:  # pragma: no cover - failure path
+                    self.fail(
+                        f"extract_number({text!r}, {lang!r}) raised "
+                        f"{type(exc).__name__}: {exc}")
+
+    def test_finite_big_float_string_still_parses(self):
+        # a huge but finite float string must keep parsing where the language
+        # already did so - only the overflow/inf/nan path is guarded
+        for lang in ("et", "fi", "hu", "sl", "da", "de", "nb", "nn"):
+            result = extract_number("1e300", lang)
+            self.assertIsNot(result, False)
+            if isinstance(result, float):
+                self.assertTrue(math.isfinite(result))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -556,12 +556,16 @@ class TestIsNumeric(unittest.TestCase):
         self.assertTrue(is_numeric("1E0"))
 
     def test_is_numeric_special_float_values(self):
-        """Test is_numeric with special float values."""
-        self.assertTrue(is_numeric("inf"))
-        self.assertTrue(is_numeric("-inf"))
-        self.assertTrue(is_numeric("nan"))
-        self.assertTrue(is_numeric("infinity"))
-        self.assertTrue(is_numeric("-infinity"))
+        """Non-finite tokens carry no usable number and are rejected."""
+        self.assertFalse(is_numeric("inf"))
+        self.assertFalse(is_numeric("-inf"))
+        self.assertFalse(is_numeric("nan"))
+        self.assertFalse(is_numeric("infinity"))
+        self.assertFalse(is_numeric("-infinity"))
+        # a digit string that overflows float to inf is still an exact integer
+        self.assertTrue(is_numeric("9" * 400))
+        # scientific notation that overflows to inf is not a usable number
+        self.assertFalse(is_numeric("1e309"))
 
     def test_is_numeric_non_numeric_strings(self):
         """Test is_numeric with non-numeric strings."""
@@ -644,10 +648,10 @@ class TestLookForFractions(unittest.TestCase):
         self.assertFalse(look_for_fractions(["1", "2", "3", "4"]))  # Too long
 
     def test_look_for_fractions_edge_cases(self):
-        """Test look_for_fractions with edge cases."""
-        self.assertTrue(look_for_fractions(["inf", "1"]))  # Infinity (is_numeric returns True)
-        self.assertTrue(look_for_fractions(["1", "inf"]))  # Infinity denominator
-        self.assertTrue(look_for_fractions(["nan", "1"]))  # NaN (is_numeric returns True)
+        """A non-finite side is not a usable number, so it is not a fraction."""
+        self.assertFalse(look_for_fractions(["inf", "1"]))  # infinity numerator
+        self.assertFalse(look_for_fractions(["1", "inf"]))  # infinity denominator
+        self.assertFalse(look_for_fractions(["nan", "1"]))  # NaN numerator
 
     def test_look_for_fractions_zero_denominator(self):
         """A zero denominator is not a fraction; callers divide by it."""


### PR DESCRIPTION
## Problem

Pathological string tokens reached the numeric conversion paths inside `extract_number` and raised `OverflowError` through the public API, instead of returning the `False` "no number" sentinel. Probing every language with `"inf"`, `"-inf"`, `"nan"`, `"1e309"`, `"1e400"`, and a 400-digit integer string surfaced two crash families plus a set of non-finite (`inf`/`nan`) returns that also violate the extract contract.

| Language | Input | Before | After |
|----------|-------|--------|-------|
| et, fi, hu, sl | `inf`, `-inf`, `1e309`, `1e400`, 400-digit | `OverflowError` | `False` |
| da, de, nb, nn | 400-digit | `OverflowError` | `False` |
| id, ms | 400-digit | `OverflowError` | `False` |
| es, pt, fr, it, ro, ast, oc, an, ca, gl, mwl | 400-digit | `inf` | `False` |
| ar, el, fa, he | `inf`, `nan`, `1e309`, 400-digit | `inf`/`nan` | `False` |
| sv | 400-digit | `inf` | `False` |
| en, nl, ru, pl, kab, tr, sk, hr, bg, cs, uk, az, eu, fy | 400-digit | exact int (unchanged) | exact int (unchanged) |

## Fix

The conversion paths now degrade a non-finite or unrepresentably-huge parsed value to the sentinel rather than raising, without touching normal finite inputs:

- **Shared root** `is_numeric` rejects non-finite tokens while still accepting a plain integer string that overflows float to `inf` (Python ints stay exact, so `en` and friends keep parsing the 400-digit value).
- `RomanceNumberExtractor` skips a digit token that overflows to `inf`/`nan`.
- `et`/`fi`/`hu`/`sl` gate the float→int narrowing behind `math.isfinite`.
- `da`/`de`/`nb`/`nn` catch the `float(bigint)` overflow and drop to the sentinel.
- `id`/`ms` skip a non-finite digit token.
- `ar`/`el`/`fa`/`he` reject non-finite tokens in their `_is_number` helper.
- `sv` keeps a digit token only when it is finite.

Also aligns `extract_number_es`'s low-level docstring with its actual short-scale default; the public `extract_number(s, lang="es")` resolves the long scale from the language configuration and is unchanged (`un billón` still returns 10^12).

## Validation

- New adversarial suite `test_overflow_string_sentinel.py` probes the full crasher set across every language: no crash, no non-finite float returned; huge finite integers stay exact.
- Two `test_util` cases updated to encode the corrected `is_numeric`/`look_for_fractions` contract for non-finite tokens.
- Full suite green (`1465 passed`), except the pre-existing `test_packaging` metadata artifact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved number extraction across supported languages by rejecting invalid, non-finite values such as `NaN`, infinity, and overflowing scientific notation.
  * Prevented parsing errors when processing extremely large or malformed numeric strings.
  * Preserved support for very large finite numbers and plain large integer strings.

* **Documentation**
  * Clarified number-scale defaults and behavior for Spanish extraction.

* **Tests**
  * Added coverage for overflow, non-finite values, embedded numeric tokens, and finite large-number handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->