### PR TITLE
fix: keep a leading one before a scale word in numbers_to_digits

### DIFF
--- a/ovos_number_parser/__init__.py
+++ b/ovos_number_parser/__init__.py
@@ -308,7 +308,7 @@ def _numbers_to_digits_generic(utterance: str, lang: str) -> str:
             continue
         j = i
 
-        def _continues(next_j):
+        def _continues(next_j, via_connector=False):
             """The span only grows if the combined words form one larger
             number ("vingt et un" = 21) rather than two separate numbers
             ("due e tre")."""
@@ -319,14 +319,29 @@ def _numbers_to_digits_generic(utterance: str, lang: str) -> str:
                 return False
             current_val = extract_number(current, lang)
             next_val = extract_number(_clean(tokens[next_j]), lang)
-            return extended_val != current_val and extended_val != next_val \
-                and abs(extended_val) > abs(current_val)
+            if current_val is False or current_val is None:
+                return False
+            if extended_val == current_val \
+                    or abs(extended_val) <= abs(current_val):
+                return False
+            if extended_val != next_val:
+                return True
+            # "one hundred": multiplying a scale word by one leaves the value
+            # unchanged, so the value comparison above cannot tell that the
+            # multiplier is grammatically required. Directly adjacent to a
+            # scale word it is, so the span must keep growing; behind a
+            # connector ("one and three") it is a separate number and must
+            # not be absorbed.
+            return not via_connector and abs(current_val) == 1 \
+                and next_val is not False and next_val is not None \
+                and abs(next_val) >= 100
 
         while j + 1 < len(tokens):
             if _is_num(tokens[j + 1]) and _continues(j + 1):
                 j += 1
             elif _clean(tokens[j + 1]) in connectors and j + 2 < len(tokens) \
-                    and _is_num(tokens[j + 2]) and _continues(j + 2):
+                    and _is_num(tokens[j + 2]) \
+                    and _continues(j + 2, via_connector=True):
                 j += 2
             else:
                 break

--- a/tests/test_numbers_to_digits_leading_one.py
+++ b/tests/test_numbers_to_digits_leading_one.py
@@ -1,0 +1,60 @@
+"""Regression guard for a leading "one" before a scale word.
+
+Multiplying a scale word by one leaves the value unchanged, so a purely
+numeric comparison cannot tell that the multiplier is grammatically required.
+The span builder used to stop after the "one" and emit two numbers
+("one hundred and one" -> "1 101"). These assertions run through the PUBLIC
+``numbers_to_digits`` entry point, which is where the defect surfaced; a
+per-language guard would not have caught it.
+"""
+import unittest
+
+from ovos_number_parser import numbers_to_digits
+
+
+class TestLeadingOneBeforeScale(unittest.TestCase):
+    # lang -> (spoken, expected)
+    LEADING_ONE = {
+        "en": [("one hundred and one dollars", "101 dollars"),
+               ("one thousand and one", "1001"),
+               ("one hundred", "100"),
+               ("one million", "1000000")],
+        "sv": [("ett hundra och ett kronor", "101 kronor")],
+        "da": [("et hundrede og et kroner", "101 kroner")],
+    }
+
+    # multipliers other than one always worked; they must keep working
+    CONTROLS = {
+        "en": [("two hundred and one", "201"),
+               ("twenty one", "21"),
+               ("I have one dog", "I have 1 dog")],
+    }
+
+    # a number behind a connector is a SEPARATE number and must not be
+    # absorbed into the preceding span, even when that span is "one"
+    NOT_ABSORBED = {
+        "en": [("one and three", "1 and 3")],
+        "it": [("due e tre", "2 e 3"), ("uno e tre", "1 e 3")],
+    }
+
+    def test_leading_one_before_scale_word(self):
+        for lang, cases in self.LEADING_ONE.items():
+            for spoken, expected in cases:
+                self.assertEqual(numbers_to_digits(spoken, lang), expected,
+                                 f"{lang}: {spoken!r}")
+
+    def test_other_multipliers_unchanged(self):
+        for lang, cases in self.CONTROLS.items():
+            for spoken, expected in cases:
+                self.assertEqual(numbers_to_digits(spoken, lang), expected,
+                                 f"{lang}: {spoken!r}")
+
+    def test_connector_separated_numbers_stay_separate(self):
+        for lang, cases in self.NOT_ABSORBED.items():
+            for spoken, expected in cases:
+                self.assertEqual(numbers_to_digits(spoken, lang), expected,
+                                 f"{lang}: {spoken!r}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Resolves #238.

Multiplying a scale word by one leaves the value unchanged, so `_continues()`'s `extended_val != next_val` guard could not distinguish *numerically redundant* from *grammatically required*: for "one hundred", `extended_val` and `next_val` are both 100, so the span stopped after "one" and the text became "1 101".

A multiplier of one (or minus one) **directly adjacent** to a scale word now keeps the span growing. Behind a connector it is still a separate number, so `one and three` -> `1 and 3` and Italian `uno e tre` -> `1 e 3` are unaffected — that structural distinction is what keeps the original guard's purpose intact.

Verified across en/sv/da (the reported languages) plus controls (`two hundred and one`, `twenty one`, `I have one dog`). Regression tests go through the **public** `numbers_to_digits` entry point — the previous guard asserted only the per-language function, which is why this was believed fixed.

Full suite green (1471 passed).

Note for a follow-up: `numbers_to_digits_en` returns the correct result on its own, but the public dispatcher routes English through the generic fallback rather than the per-language implementation. Left as-is here since the generic path is now correct.