### PR TITLE
fix: enforce descending direction on Romance additive joiners

### DIFF
--- a/ovos_number_parser/numbers_ro.py
+++ b/ovos_number_parser/numbers_ro.py
@@ -89,6 +89,7 @@ _RO = NumberVocabulary(
     # "de" links counts of twenty and above to their scale word
     # ("douăzeci de mii") and is dropped during extraction
     JOIN_WORD=["și", "de"],
+    MULTIPLICATIVE_JOIN_WORD=["de"],
     JOINER_ON_TWENTYS=True,  # "douăzeci și unu"
     JOINER_ON_HUNDREDS=False,  # "o sută douăzeci" - no joiner after hundreds
     JOINER_ON_HUNDRED_PARTICLE=False,

--- a/ovos_number_parser/util.py
+++ b/ovos_number_parser/util.py
@@ -349,6 +349,15 @@ class NumberVocabulary:
 
     # full spelling of "one <scale>" groups when they use an article or a
     # special form of "one" ("o mie", "un milion")
+    #: entries of JOIN_WORD that are *not* additive joiners but partitive or
+    #: multiplicative prepositions, where the value after the word is larger
+    #: than the one before it by design. Romanian inserts "de" before a scale
+    #: above twenty ("douăzeci de mii" = 20 x 1000) and before a fraction's
+    #: base ("jumătate de milion" = half *of* a million), unlike the additive
+    #: "și" ("douăzeci și unu" = 21). Listed here so the descending-joiner rule
+    #: skips them.
+    MULTIPLICATIVE_JOIN_WORD: List[str] = field(default_factory=list)
+
     SCALE_ONE: Dict[int, str] = field(default_factory=dict)
 
     # grammatical gender the count before each scale word agrees with
@@ -507,7 +516,9 @@ class RomanceNumberExtractor:
 
         # normalize and tokenize
         clean_text = text.lower().replace('-', ' ')
-        tokens = [t for t in clean_text.split() if t not in self.vocab.JOIN_WORD]
+        # the joiner is kept: it is what tells "vinte e um" (21, one number)
+        # apart from "tres e vinte" (3 and 20, two numbers)
+        tokens = clean_text.split()
 
         # a digit token wins if it appears before any spoken number word
         for tok in tokens:
@@ -538,6 +549,22 @@ class RomanceNumberExtractor:
             token = tokens[i]
             if token in self.vocab.NEGATIVE_SIGN:
                 is_negative = True
+                i += 1
+                continue
+
+            if token in self.vocab.JOIN_WORD:
+                if token in self.vocab.MULTIPLICATIVE_JOIN_WORD:
+                    i += 1
+                    continue
+                # Romance additive joiners are strictly descending: the value
+                # after the joiner is smaller than the one before it
+                # ("vinte e um" = 21, "mil e quinhentos" = 1500). An ascending
+                # pair is not one number but two ("tres y veinte" = "3:20"),
+                # so the number ends here.
+                nxt = numbers_map.get(tokens[i + 1]) if i + 1 < len(tokens) else None
+                pending = current or result
+                if saw_number and nxt is not None and pending and nxt >= pending:
+                    break
                 i += 1
                 continue
 
@@ -574,7 +601,12 @@ class RomanceNumberExtractor:
             fraction = self.is_fractional(token)
             if fraction is not False:
                 saw_number = True
-                next_token = tokens[i + 1] if i + 1 < len(tokens) else None
+                # look past a joiner: the scale a fraction multiplies may sit
+                # behind one ("jumătate de milion" = half a million)
+                nxt_i = i + 1
+                while nxt_i < len(tokens) and tokens[nxt_i] in self.vocab.JOIN_WORD:
+                    nxt_i += 1
+                next_token = tokens[nxt_i] if nxt_i < len(tokens) else None
                 next_val = numbers_map.get(next_token) if next_token else None
                 if token not in plural_fractions and next_val is not None \
                         and next_val >= 1000:
@@ -683,6 +715,16 @@ class RomanceNumberExtractor:
                 number_span_words = []
                 j = i
                 while j < len(words) and continues_span(j):
+                    if words[j] in self.vocab.JOIN_WORD and number_span_words \
+                            and words[j] not in self.vocab.MULTIPLICATIVE_JOIN_WORD:
+                        # the span only crosses a joiner when the value after
+                        # it is smaller than the value before it ("vinte e um").
+                        # An ascending pair is two numbers, not one, and the
+                        # span has to end so the tail survives ("tres y veinte").
+                        nxt = numbers_map.get(next_word(j))
+                        sofar = self.extract_number(" ".join(number_span_words))
+                        if nxt is None or sofar is False or nxt >= sofar:
+                            break
                     number_span_words.append(words[j])
                     j += 1
 

--- a/tests/test_joiner_direction.py
+++ b/tests/test_joiner_direction.py
@@ -1,0 +1,150 @@
+"""Direction rules for the additive joiner in Romance numerals.
+
+Romance languages build the numbers between the round tens with an additive
+joiner: "vinte **e** um", "vingt **et** un", "veinte **y** uno". The joiner is
+not free word order -- it is *strictly descending*. The value written after the
+joiner is always smaller than the value written before it:
+
+    vinte e um        20 + 1     descending, one number  (21)
+    cento e um       100 + 1     descending, one number  (101)
+    mil e quinhentos 1000 + 500  descending, one number  (1500)
+
+The reverse order is not a numeral at all. "três e vinte" is two separate
+numbers -- most commonly a spoken clock time ("three twenty"), which is exactly
+how a voice assistant receives it. Reading it as 23 silently corrupts the
+utterance, and because the parsers share one engine the same misreading applied
+to every Romance language at once.
+
+The engine used to *discard* the joiner before parsing, which made the
+distinction impossible to express: "três e vinte" and "vinte e três" both
+reduced to a bare pair of numbers and accumulated additively to 23. The joiner
+is now retained and the descending rule enforced.
+
+One word wearing two hats
+-------------------------
+Romanian lists two words as joiners, and only one of them is additive:
+
+    douăzeci **și** unu     20 + 1       additive, descending  (21)
+    douăzeci **de** mii     20 x 1000    multiplicative, ASCENDING (20000)
+    jumătate **de** milion  1/2 of 10^6  partitive, ASCENDING  (500000)
+
+"de" is a preposition inserted before a scale word, not a joiner, so the value
+after it is *larger* by design. It is declared in
+``MULTIPLICATIVE_JOIN_WORD`` and exempted from the descending rule. Those cases
+are asserted here so the distinction cannot be collapsed again.
+"""
+import unittest
+
+from ovos_number_parser import extract_number, numbers_to_digits
+
+
+#: (lang, ascending phrase, value of its first number, descending phrase, value)
+#:
+#: The ascending phrase must parse as ONLY its leading number -- the tail is a
+#: separate number and must not be absorbed. The descending phrase must parse
+#: as the single combined numeral.
+JOINER_CASES = [
+    # lang    ascending           head  descending          combined
+    ("es", "tres y veinte", 3, "veinte y uno", 21),
+    ("ca", "tres i vint", 3, "vint i un", 21),
+    ("gl", "tres e vinte", 3, "vinte e un", 21),
+    ("pt", "três e vinte", 3, "vinte e um", 21),
+    ("fr", "trois et vingt", 3, "vingt et un", 21),
+    ("it", "tre e venti", 3, "mille e cento", 1100),
+    ("ro", "trei și douăzeci", 3, "douăzeci și unu", 21),
+]
+
+
+class TestJoinerIsDescending(unittest.TestCase):
+    """An ascending pair is two numbers; a descending pair is one number."""
+
+    def test_ascending_pair_is_not_absorbed(self):
+        for lang, phrase, head, _, _ in JOINER_CASES:
+            with self.subTest(lang=lang, phrase=phrase):
+                self.assertEqual(extract_number(phrase, lang), head)
+
+    def test_descending_pair_is_one_number(self):
+        for lang, _, _, phrase, combined in JOINER_CASES:
+            with self.subTest(lang=lang, phrase=phrase):
+                self.assertEqual(extract_number(phrase, lang), combined)
+
+    def test_ascending_tail_survives_digit_substitution(self):
+        """The tail must still be in the output, not swallowed by the span.
+
+        This is the failure that reached the date parser: collapsing
+        "las tres y veinte" to "las 23" destroyed the minutes, so the time
+        could not be recovered downstream.
+        """
+        for lang, phrase, head, _, _ in JOINER_CASES:
+            with self.subTest(lang=lang, phrase=phrase):
+                converted = numbers_to_digits(phrase, lang)
+                self.assertIn(str(head), converted)
+                # the trailing number survived as digits of its own
+                self.assertTrue(
+                    converted.rstrip().endswith("20")
+                    or converted.rstrip().endswith("100"),
+                    f"tail lost in {converted!r}")
+
+
+class TestDescendingChains(unittest.TestCase):
+    """Longer numerals chain several descending steps and must stay intact."""
+
+    CHAINS = [
+        ("pt", "duzentos e cinquenta e sete", 257),
+        ("pt", "mil e quinhentos", 1500),
+        ("pt", "cento e um", 101),
+        ("pt", "quarenta e dois mil", 42000),
+        ("pt", "um milhão e quinhentos mil", 1500000),
+        ("es", "treinta y cuatro", 34),
+        ("es", "ciento veintitrés", 123),
+        ("fr", "quatre-vingt-dix", 90),
+        ("ca", "vint-i-un", 21),
+    ]
+
+    def test_chains(self):
+        for lang, phrase, expected in self.CHAINS:
+            with self.subTest(lang=lang, phrase=phrase):
+                self.assertEqual(extract_number(phrase, lang), expected)
+
+
+class TestRomanianMultiplicativeDe(unittest.TestCase):
+    """Romanian "de" is a preposition, not a joiner: it ascends by design."""
+
+    def test_de_before_scale_multiplies(self):
+        # "douăzeci de mii" is 20 x 1000, not 20 followed by 1000
+        self.assertEqual(extract_number("douăzeci de mii", "ro"), 20000)
+
+    def test_de_before_fraction_base(self):
+        self.assertEqual(extract_number("jumătate de milion", "ro"), 500000)
+        self.assertEqual(extract_number("jumătate de mie", "ro"), 500)
+
+    def test_si_still_descends(self):
+        self.assertEqual(extract_number("douăzeci și unu", "ro"), 21)
+        # ... and still refuses to ascend
+        self.assertEqual(extract_number("trei și douăzeci", "ro"), 3)
+
+
+class TestNaturalSentences(unittest.TestCase):
+    """Real sentences, which is where the ascending pair actually shows up."""
+
+    SENTENCES = [
+        # spoken clock times -- the original regression
+        ("es", "el tren sale a las tres y veinte", 3),
+        ("gl", "o tren sae ás tres e vinte", 3),
+        ("pt", "o comboio sai às três e vinte", 3),
+        ("fr", "le train part à trois et vingt", 3),
+        # genuine numerals inside a sentence still read whole
+        ("pt", "tenho vinte e um anos", 21),
+        ("es", "tengo veinte y uno años", 21),
+        ("pt", "custa mil e quinhentos euros", 1500),
+        ("ro", "am cumpărat douăzeci de mii de pixeli", 20000),
+    ]
+
+    def test_sentences(self):
+        for lang, sentence, expected in self.SENTENCES:
+            with self.subTest(lang=lang, sentence=sentence):
+                self.assertEqual(extract_number(sentence, lang), expected)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`extract_number('tres y veinte', 'es')` returned **23**. It should be **3** — "las tres y veinte" is a spoken clock time (3:20), two numbers, not the numeral 23.

**Root cause, and why it hit every Romance language at once:** the engine deleted the joiner before parsing —

```python
tokens = [t for t in clean_text.split() if t not in self.vocab.JOIN_WORD]
```

so `três e vinte` and `vinte e três` both collapsed to the same bare token pair and accumulated additively to 23. The distinction was structurally inexpressible.

The Romance additive joiner is **strictly descending** — the value after it is always smaller (`vinte e um`, `cento e um`, `mil e quinhentos`). The joiner is now retained and that rule enforced in both `extract_number` and the `numbers_to_digits` span builder, so an ascending pair ends the span and **the tail survives** (`las tres y veinte` -> `las 3 y 20`, not `las 23`).

**One word, two grammars.** Romanian lists `["și", "de"]` as joiners but only `și` is additive. `de` is a preposition before a scale word and ascends by design (`douăzeci de mii` = 20x1000, `jumătate de milion` = half *of* a million). Rather than special-case Romanian, added a `MULTIPLICATIVE_JOIN_WORD` vocabulary field that exempts such words — the grammar is now modelled, not patched.

Also made the fraction lookahead joiner-aware, since it previously peeked at `tokens[i+1]` and now finds the joiner there.

Tests cover es/ca/gl/pt/fr/it/ro ascending-vs-descending pairs, descending chains, tail survival under `numbers_to_digits`, the Romanian `de` cases, and natural sentences (spoken times). Suite green; **this also fixes 3 pre-existing Spanish failures in ovos-date-parser** (`TestQuarterAndHalf`, `TestNiceTimeRoundTrip`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved recognition of number phrases using language-specific connecting words.
  * Added support for Romanian multiplicative expressions using “de.”
  * Improved handling of number phrases in sentences, fractions, scales, and time-related expressions.

* **Bug Fixes**
  * Prevented incorrectly combining separate numbers when connecting words appear in ascending order.
  * Preserved surrounding text more reliably during number-to-digit conversion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->