### PR TITLE
fix: pronounce infinity and oversized integers without crashing

### DIFF
--- a/ovos_number_parser/__init__.py
+++ b/ovos_number_parser/__init__.py
@@ -514,6 +514,69 @@ def _round_for_speech(number: Union[int, float], places: int) -> Union[int, floa
     return float(rounded)
 
 
+# Words for positive / negative infinity, keyed by language prefix.
+# Any language not listed falls back to the English default.
+_INFINITY_WORDS = {
+    "en": ("infinity", "negative infinity"),
+    "es": ("infinito", "infinito negativo"),
+    "pt": ("infinito", "infinito negativo"),
+    "it": ("infinito", "meno infinito"),
+    "fr": ("infini", "moins infini"),
+    "de": ("unendlich", "minus unendlich"),
+}
+
+
+#: Spoken connective for a scientific reading, keyed by language prefix, as
+#: "<mantissa> <connective> <exponent>". Languages absent from this table fall
+#: back to English rather than to a crash; that is a known and deliberate
+#: limitation, not a claim of coverage.
+_SCIENTIFIC_WORDS = {
+    "en": "times ten to the power of",
+    "es": "por diez elevado a",
+    "pt": "vezes dez elevado a",
+    "it": "per dieci alla",
+    "fr": "fois dix puissance",
+    "de": "mal zehn hoch",
+}
+
+
+def _base_lang(lang: str) -> str:
+    """Bare language code, so "pt-BR" and "pt" resolve to the same entry."""
+    return lang.lower().split("-")[0]
+
+
+def _pronounce_infinity(number: float, lang: str) -> str:
+    """Spoken form of +/-infinity for any language (English default)."""
+    pos, neg = _INFINITY_WORDS.get(_base_lang(lang), _INFINITY_WORDS["en"])
+    return neg if number < 0 else pos
+
+
+def _pronounce_bignum_fallback(number: Union[int, float], lang: str,
+                               places: int) -> str:
+    """
+    Spoken scientific reading for finite numbers too large for a language's
+    named-scale table, computed from the decimal string so it never overflows
+    the float range.
+
+    Mantissa, sign and exponent are all pronounced by the target language.
+    Only the connective joining them is looked up, and falls back to English
+    for languages missing from _SCIENTIFIC_WORDS.
+    """
+    digits = str(abs(int(number)))
+    exponent = len(digits) - 1
+    tail = digits[1:1 + places].rstrip("0")
+    mantissa = float(digits[0] + ("." + tail if tail else ""))
+    # the sign rides on the mantissa so each language speaks its own minus
+    # word ("menos dois...") instead of an English prefix
+    if number < 0:
+        mantissa = -mantissa
+    mantissa_words = pronounce_number(mantissa, lang=lang, places=places)
+    exponent_words = pronounce_number(exponent, lang=lang)
+    connective = _SCIENTIFIC_WORDS.get(_base_lang(lang),
+                                       _SCIENTIFIC_WORDS["en"])
+    return f"{mantissa_words} {connective} {exponent_words}"
+
+
 def pronounce_number(number: Union[int, float], lang: str,
                      places: int = 3,
                      short_scale: Optional[bool] = None,  # DEPRECATED
@@ -568,9 +631,30 @@ def pronounce_number(number: Union[int, float], lang: str,
         return _pronounce_complex(number, lang, places, scale, digits, gender)
     if isinstance(number, float) and number != number:
         raise ValueError("cannot pronounce NaN (not a number)")
+    # Infinity is not tied to any named-scale table; handle it uniformly for
+    # every language so no per-language path has to convert it to an integer.
+    if isinstance(number, float) and math.isinf(number):
+        return _pronounce_infinity(number, lang)
     # Round to the spoken precision before dispatch so every backend speaks a
     # rounded value instead of a truncated one (see _round_for_speech).
     number = _round_for_speech(number, places)
+    try:
+        return _pronounce_number_dispatch(
+            number, lang, places, short_scale, scientific, ordinals,
+            digits, gender, scale)
+    except (IndexError, KeyError, OverflowError):
+        # A finite number overflowed a language's named-scale table. Kabyle
+        # has a documented finite ceiling (raises above 9999), so keep that
+        # contract; every other language falls back to a spoken scientific
+        # reading rather than crashing. Ordinary-magnitude numbers keep their
+        # original error so genuine bugs are not masked.
+        if not lang.startswith("kab") and abs(number) >= 10 ** 15:
+            return _pronounce_bignum_fallback(number, lang, places)
+        raise
+
+
+def _pronounce_number_dispatch(number, lang, places, short_scale, scientific,
+                               ordinals, digits, gender, scale):
     if lang.startswith("en"):
         return pronounce_number_en(number, places, short_scale, scientific, ordinals)
     if lang.startswith("az"):

--- a/tests/test_pronounce_nonfinite_bignum.py
+++ b/tests/test_pronounce_nonfinite_bignum.py
@@ -1,0 +1,97 @@
+import glob
+import math
+import os
+import unittest
+
+from ovos_number_parser import pronounce_number
+from ovos_number_parser.numbers_kab import pronounce_number_kab
+
+# every shipped language, derived from the numbers_*.py modules
+_PKG = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+LANGS = sorted(
+    os.path.basename(f)[len("numbers_"):-len(".py")]
+    for f in glob.glob(os.path.join(_PKG, "ovos_number_parser", "numbers_*.py"))
+)
+
+
+class TestInfinity(unittest.TestCase):
+    def test_localized_infinity_words(self):
+        self.assertEqual(pronounce_number(float("inf"), "en"), "infinity")
+        self.assertEqual(pronounce_number(float("-inf"), "en"),
+                         "negative infinity")
+        self.assertEqual(pronounce_number(float("inf"), "it"), "infinito")
+        self.assertEqual(pronounce_number(float("-inf"), "it"), "meno infinito")
+        self.assertEqual(pronounce_number(float("inf"), "de"), "unendlich")
+
+    def test_english_default_for_unmapped_language(self):
+        # eu and kab used to crash converting infinity to an integer
+        self.assertEqual(pronounce_number(float("inf"), "eu"), "infinity")
+        self.assertEqual(pronounce_number(float("-inf"), "kab"),
+                         "negative infinity")
+
+    def test_region_suffix_still_matches(self):
+        self.assertEqual(pronounce_number(float("inf"), "pt-br"), "infinito")
+
+    def test_infinity_never_crashes_any_language(self):
+        for lang in LANGS:
+            for value in (float("inf"), float("-inf")):
+                with self.subTest(lang=lang, value=value):
+                    out = pronounce_number(value, lang)
+                    self.assertIsInstance(out, str)
+                    self.assertTrue(out)
+
+
+class TestHugeFiniteIntegers(unittest.TestCase):
+    def test_beyond_scale_falls_back_to_scientific(self):
+        # it previously raised IndexError on numbers past its named scale.
+        # The connective is spoken in the target language, not in English.
+        out = pronounce_number(10 ** 400, "it")
+        self.assertIn("per dieci alla", out)
+        self.assertIn("quattrocento", out)
+        self.assertNotIn("times ten to the power of", out)
+
+    def test_negative_huge_integer(self):
+        # the sign rides on the mantissa, so each language speaks its own
+        # minus word rather than an English "negative" prefix
+        out = pronounce_number(-(10 ** 400), "it")
+        self.assertTrue(out.startswith("meno "), out)
+        self.assertNotIn("negative", out)
+
+    def test_mantissa_pronounced_in_target_language(self):
+        # Czech has no entry in _SCIENTIFIC_WORDS, so the connective falls
+        # back to English while the mantissa and exponent stay Czech. This
+        # pins the documented fallback, not a claim of Czech coverage.
+        out = pronounce_number(2 ** 2000, "cs")
+        self.assertIsInstance(out, str)
+        self.assertIn("times ten to the power of", out)
+
+    def test_representative_langs_never_crash_on_huge_int(self):
+        for lang in ("en", "it", "eu", "cs", "pl", "ru", "de", "fr"):
+            for value in (10 ** 400, 2 ** 2000):
+                with self.subTest(lang=lang, value=value):
+                    out = pronounce_number(value, lang)
+                    self.assertIsInstance(out, str)
+
+    def test_ordinary_numbers_unchanged(self):
+        # the fallback must not touch in-range values
+        self.assertEqual(pronounce_number(1234, "it"),
+                         "mille, duecento trentaquattro")
+        self.assertEqual(pronounce_number(10 ** 20, "en"),
+                         "one hundred quintillion")
+
+
+class TestKabyleDocumentedCeiling(unittest.TestCase):
+    def test_finite_above_cap_still_raises(self):
+        # Kabyle intentionally supports finite numbers only up to 9999
+        with self.assertRaises(OverflowError):
+            pronounce_number_kab(10 ** 400)
+        with self.assertRaises(OverflowError):
+            pronounce_number(10 ** 400, "kab")
+
+    def test_infinity_bypasses_the_finite_cap(self):
+        # infinity is not a finite-above-cap value; it must be spoken
+        self.assertEqual(pronounce_number(float("inf"), "kab"), "infinity")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`pronounce_number` crashed on values past a language's named-scale table — `OverflowError` in Kabyle, `IndexError` in Italian — and had no reading for infinity at all.

Non-finite and out-of-scale values are now guarded at the dispatcher, so no per-language backend has to handle them. Infinity gets a spoken word in every language (localized where available, English otherwise). Finite integers beyond the named scale fall back to a scientific reading computed from the **decimal string**, so it never overflows float range.

Localization of that fallback:
- the **connective** is looked up per language (`per dieci alla`, `vezes dez elevado a`, `por diez elevado a`, ...), falling back to English only for languages not yet listed — documented as a known limitation, and pinned by a test using Czech so the fallback stays deliberate
- the **sign rides on the mantissa**, so each language speaks its own minus word (`meno ...`) instead of an English `negative` prefix
- language codes are normalized to their base, so `pt-BR` and `es-MX` resolve correctly

Suite green (1497 passed).

**Known gap, pre-existing and not addressed here:** this only rescues languages that *raise*. Languages whose backend silently returns garbage still do — `pt` pads with repeated scale words (`sextiliões vigintiliões vigintiliões`) and `fr`/`de`/`nl` return the raw digit string. Verified present on `dev` before this change. Fix to follow.