### PR TITLE
fix: never speak padded or unread output for oversized numbers

### DIFF
--- a/ovos_number_parser/__init__.py
+++ b/ovos_number_parser/__init__.py
@@ -537,6 +537,12 @@ _SCIENTIFIC_WORDS = {
     "it": "per dieci alla",
     "fr": "fois dix puissance",
     "de": "mal zehn hoch",
+    "nl": "maal tien tot de macht",
+    "ca": "per deu elevat a",
+    "gl": "veces dez elevado a",
+    "ro": "ori zece la puterea",
+    "da": "gange ti i",
+    "sv": "gånger tio upphöjt till",
 }
 
 
@@ -549,6 +555,41 @@ def _pronounce_infinity(number: float, lang: str) -> str:
     """Spoken form of +/-infinity for any language (English default)."""
     pos, neg = _INFINITY_WORDS.get(_base_lang(lang), _INFINITY_WORDS["en"])
     return neg if number < 0 else pos
+
+
+#: a run of digits this long in "spoken" output means a backend gave up and
+#: handed back the numeral instead of reading it
+_DIGIT_RUN = re.compile(r"\d{7,}")
+
+
+def _has_padded_scale_words(spoken: str) -> bool:
+    """
+    Whether a backend padded a magnitude by repeating its largest scale word.
+
+    Some backends do not raise past their named-scale table; they repeat the
+    biggest word they know until the magnitude is covered
+    ("trilioi trilioi trilioi", "sextiliões vigintiliões vigintiliões").
+    No natural numeral repeats a scale word back to back, so two identical
+    adjacent words mark output that is not a reading at all.
+
+    Only sound for a *composed* reading -- a digit-by-digit rendering repeats
+    words legitimately ("11" -> "um um") -- so callers must scope this check.
+    """
+    words = spoken.split()
+    return any(a == b for a, b in zip(words, words[1:]))
+
+
+def _has_unread_digits(spoken: str) -> bool:
+    """
+    Whether a backend gave up and handed back the numeral instead of reading it.
+
+    Unlike padded scale words this is not nonsense: a bare numeral is a
+    documented fallback for some languages (Finnish and Estonian pin it), and
+    a TTS engine will read the digits itself. It is only worth replacing when
+    a localized scientific reading is available -- swapping it for one glued
+    together with English words would be a downgrade, not a fix.
+    """
+    return bool(_DIGIT_RUN.search(spoken))
 
 
 def _pronounce_bignum_fallback(number: Union[int, float], lang: str,
@@ -639,7 +680,7 @@ def pronounce_number(number: Union[int, float], lang: str,
     # rounded value instead of a truncated one (see _round_for_speech).
     number = _round_for_speech(number, places)
     try:
-        return _pronounce_number_dispatch(
+        spoken = _pronounce_number_dispatch(
             number, lang, places, short_scale, scientific, ordinals,
             digits, gender, scale)
     except (IndexError, KeyError, OverflowError):
@@ -651,6 +692,20 @@ def pronounce_number(number: Union[int, float], lang: str,
         if not lang.startswith("kab") and abs(number) >= 10 ** 15:
             return _pronounce_bignum_fallback(number, lang, places)
         raise
+    # A backend that does not raise past its scale table returns padded or
+    # unread output instead (see _is_spoken_reading). Only composed readings
+    # of large numbers are checked: a digit-by-digit rendering repeats words
+    # legitimately, and Kabyle's finite ceiling is a documented contract.
+    if abs(number) >= 10 ** 15 and not lang.startswith("kab") \
+            and not scientific and digits == DigitPronunciation.FULL_NUMBER:
+        # padded scale words are never a reading, so always replace them
+        if _has_padded_scale_words(spoken):
+            return _pronounce_bignum_fallback(number, lang, places)
+        # a bare numeral is a legitimate fallback the TTS can read; only
+        # improve on it where the scientific reading is fully localized
+        if _has_unread_digits(spoken) and _base_lang(lang) in _SCIENTIFIC_WORDS:
+            return _pronounce_bignum_fallback(number, lang, places)
+    return spoken
 
 
 def _pronounce_number_dispatch(number, lang, places, short_scale, scientific,

--- a/tests/test_bignum_silent_garbage.py
+++ b/tests/test_bignum_silent_garbage.py
@@ -1,0 +1,129 @@
+"""Backends that do not raise past their named scale must not speak nonsense.
+
+`pronounce_number` guards values beyond a language's named-scale table, but the
+guard was an exception handler, so it only ever rescued the languages whose
+backend actually *raised* (Kabyle's OverflowError, Italian's IndexError).
+
+Several backends fail differently: they return a value, so the guard never
+fires and the caller receives it as a success. Two failure shapes were observed
+on a 400-digit integer:
+
+    pt  "doze mil quinhentos sextiliões vigintiliões vigintiliões vigintiliões"
+    fr  "1250000000000000000000000 ... 000"   (the raw numeral, unread)
+
+The first pads the magnitude by repeating the largest scale word it knows; the
+second gives up and hands back digits. Both reach a TTS engine and are spoken.
+
+The output of a large composed reading is now validated, and anything matching
+those shapes falls back to the scientific reading instead.
+"""
+import unittest
+
+from ovos_number_parser import pronounce_number
+from ovos_number_parser import (_has_padded_scale_words,
+                                _has_unread_digits)
+
+#: languages that previously returned padded or unread output rather than
+#: raising, plus the ones that raised, so the whole class is covered at once
+LANGS = ["pt", "es", "fr", "de", "nl", "eu", "it", "en", "ca", "gl", "ro"]
+
+#: a 400-digit integer: past every named-scale table in the library
+HUGE = 10 ** 400 + 25 * 10 ** 398
+
+
+class TestNoSilentGarbage(unittest.TestCase):
+
+    #: languages with a localized connective, where a bare numeral is
+    #: replaced by a real reading. Languages without one (fi, et) keep the
+    #: numeral deliberately -- English glue would be worse than digits.
+    LOCALIZED = ["pt", "es", "fr", "de", "nl", "it", "en", "ca", "gl", "ro"]
+
+    def test_no_raw_digit_runs(self):
+        """Digits in 'spoken' output mean the numeral was never read."""
+        for lang in self.LOCALIZED:
+            with self.subTest(lang=lang):
+                out = pronounce_number(HUGE, lang)
+                self.assertFalse(any(c.isdigit() for c in out),
+                                 f"{lang} returned unread digits: {out[:60]!r}")
+
+    def test_no_repeated_adjacent_scale_words(self):
+        """No natural numeral repeats a scale word back to back."""
+        for lang in LANGS:
+            with self.subTest(lang=lang):
+                words = pronounce_number(HUGE, lang).split()
+                repeats = [a for a, b in zip(words, words[1:]) if a == b]
+                self.assertEqual(repeats, [],
+                                 f"{lang} padded with {repeats}")
+
+    def test_reading_mentions_the_exponent(self):
+        """The fallback is a scientific reading, so 400 must be spoken."""
+        expected = {"pt": "quatrocentos", "es": "cuatrocientos",
+                    "fr": "quatre cents", "it": "quattrocento",
+                    "en": "four hundred", "de": "vierhundert"}
+        for lang, word in expected.items():
+            with self.subTest(lang=lang):
+                self.assertIn(word, pronounce_number(HUGE, lang))
+
+    def test_negative_huge_is_signed(self):
+        for lang in LANGS:
+            with self.subTest(lang=lang):
+                out = pronounce_number(-HUGE, lang)
+                self.assertNotEqual(out, pronounce_number(HUGE, lang))
+
+
+class TestOrdinaryMagnitudesUnaffected(unittest.TestCase):
+    """The validation must not divert numbers the backends read correctly."""
+
+    CASES = [
+        ("pt", 10 ** 18, "trilião"),
+        ("fr", 10 ** 12, "billion"),
+        ("de", 10 ** 9, "Milliarde"),
+        ("en", 1234567, "million"),
+        ("es", 10 ** 6, "millón"),
+    ]
+
+    def test_named_scales_still_used(self):
+        for lang, value, word in self.CASES:
+            with self.subTest(lang=lang, value=value):
+                out = pronounce_number(value, lang)
+                self.assertIn(word, out)
+                self.assertNotIn("ten to the power", out)
+
+
+class TestReadingValidator(unittest.TestCase):
+    """Unit coverage for the validator, including why it is scoped.
+
+    The repeated-word signal is only sound for a *composed* reading. A
+    digit-by-digit rendering repeats words legitimately ("11" -> "um um"),
+    which is why the caller applies the check only when digits ==
+    FULL_NUMBER. Asserted here on the helper rather than through
+    pronounce_number, because the digit-by-digit flag is not honoured by
+    every backend.
+    """
+
+    def test_detects_padded_scale_words(self):
+        self.assertTrue(_has_padded_scale_words(
+            "doze mil quinhentos sextiliões vigintiliões vigintiliões"))
+        self.assertTrue(_has_padded_scale_words("bostehun trilioi trilioi"))
+
+    def test_detects_unread_digits(self):
+        self.assertTrue(_has_unread_digits("125" + "0" * 400))
+
+    def test_accepts_real_readings(self):
+        for good in ("um vírgula vinte e cinco", "one million, two hundred"):
+            self.assertFalse(_has_padded_scale_words(good))
+            self.assertFalse(_has_unread_digits(good))
+        # short digit groups are ordinary, e.g. a year
+        self.assertFalse(_has_unread_digits("1984"))
+
+    def test_digit_by_digit_shape_would_be_rejected(self):
+        # exactly why the caller scopes the check to composed readings
+        self.assertTrue(_has_padded_scale_words("um um dois"))
+
+
+class TestKabyleCeilingPreserved(unittest.TestCase):
+    """Kabyle's finite ceiling is a documented contract, not a bug."""
+
+    def test_kab_still_raises_above_ceiling(self):
+        with self.assertRaises(OverflowError):
+            pronounce_number(HUGE, "kab")


### PR DESCRIPTION
Follow-up to #247, which noted this gap. The beyond-scale guard was an `except` block, so it only ever rescued backends that **raise**. Backends that return a value slipped straight through as successes:

```
pt   doze mil quinhentos sextiliões vigintiliões vigintiliões vigintiliões
eu   bostehun trilioi trilioi trilioi trilioi trilioi
fr   1250000000000000000000000000...000        (400 digits, unread)
```

The first shape pads the magnitude by repeating the largest scale word the backend knows. All of it reached a TTS engine and was spoken aloud.

Large composed readings are now validated, with the two failure shapes treated **differently** because they are not equally wrong:

- **Repeated adjacent scale words** are never a reading in any language — always replaced.
- **A bare numeral** is a defensible fallback: a TTS reads the digits itself. It is only replaced where the scientific reading is *fully localized*, since swapping it for one glued together with English words would be a downgrade. Finnish and Estonian have no connective yet and keep their numeral — their existing `test_boundary_beyond_scale` assertions were right and still pass.

The check is scoped to composed readings, because a digit-by-digit rendering repeats words legitimately (`11` -> `um um`). Kabyle's finite ceiling stays a documented contract.

Adds localized connectives for nl, ca, gl, ro, da, sv.

Tests cover both detectors as units, all-language absence of digits and padding, exponent correctness, ordinary magnitudes still using named scales, and the Kabyle ceiling. Suite green (1507 passed).