### PR TITLE
fix: restore the 'e' conjunction between Portuguese numeral classes

### DIFF
--- a/ovos_number_parser/numbers_pt.py
+++ b/ovos_number_parser/numbers_pt.py
@@ -78,7 +78,15 @@ _PT_PT = NumberVocabulary(
     JOIN_WORD=["e"],
     JOINER_ON_TWENTYS = True,  # add JOIN_WORD from 20-30 - "vinte e um"
     JOINER_ON_HUNDREDS = True,   # add JOIN_WORD from 100-1000 - "duzentos e um"
-    JOINER_ON_THOUSANDS = False,  # add JOIN_WORD from 1000-10000 - "mil e duzentos"
+    # Cunha & Cintra, "Nova Gramática do Português Contemporâneo" (1984),
+    # p. 372: "Não se emprega a conjunção entre os milhares e as centenas,
+    # salvo quando o número terminar numa centena com dois zeros" -- so
+    # 1892 = "mil oitocentos e noventa e dois" but 1800 = "mil e oitocentos".
+    # Ciberdúvidas (ISCTE-IUL, resposta 34389) adds the other half: the
+    # conjunction also joins the two rightmost classes when the second begins
+    # with a zero ("mil e vinte", "mil e um"). Together: join when the
+    # remainder is below 100 or is a whole number of hundreds.
+    JOINER_ON_THOUSANDS = True,  # "mil e duzentos", "mil e cem"
 
     DECIMAL_MARKER=["vírgula", "virgula", "ponto", ".", ","],
     NEGATIVE_SIGN=["menos"],
@@ -284,7 +292,15 @@ _PT_BR = NumberVocabulary(
     JOIN_WORD=_PT_PT.JOIN_WORD,
     JOINER_ON_TWENTYS=True,  # add JOIN_WORD from 20-30 - "vinte e um"
     JOINER_ON_HUNDREDS=True,  # add JOIN_WORD from 100-1000 - "duzentos e um"
-    JOINER_ON_THOUSANDS=False,  # add JOIN_WORD from 1000-10000 - "mil e duzentos"
+    # Cunha & Cintra, "Nova Gramática do Português Contemporâneo" (1984),
+    # p. 372: "Não se emprega a conjunção entre os milhares e as centenas,
+    # salvo quando o número terminar numa centena com dois zeros" -- so
+    # 1892 = "mil oitocentos e noventa e dois" but 1800 = "mil e oitocentos".
+    # Ciberdúvidas (ISCTE-IUL, resposta 34389) adds the other half: the
+    # conjunction also joins the two rightmost classes when the second begins
+    # with a zero ("mil e vinte", "mil e um"). Together: join when the
+    # remainder is below 100 or is a whole number of hundreds.
+    JOINER_ON_THOUSANDS=True,  # "mil e duzentos", "mil e cem"
     DECIMAL_MARKER=_PT_PT.DECIMAL_MARKER,
     NEGATIVE_SIGN=_PT_PT.NEGATIVE_SIGN,
     UNITS=_PT_PT.UNITS,

--- a/tests/test_pt_thousands_conjunction.py
+++ b/tests/test_pt_thousands_conjunction.py
@@ -1,0 +1,93 @@
+"""When Portuguese joins numeral classes with "e".
+
+Source: Celso Cunha & Lindley Cintra, "Nova Gramática do Português
+Contemporâneo" (1984), p. 372:
+
+    "Não se emprega a conjunção entre os milhares e as centenas, salvo
+     quando o número terminar numa centena com dois zeros"
+
+so 1892 is "mil oitocentos e noventa e dois" but 1800 is "mil e oitocentos".
+Ciberdúvidas da Língua Portuguesa (ISCTE-IUL, resposta 34389) states the other
+half of the rule: the conjunction also joins the two rightmost classes when
+the second "começa por zero" -- "mil e vinte", "mil e um", "dois milhões e
+sete mil".
+
+Combining both: the remainder takes "e" when it is **below 100** or is a
+**whole number of hundreds**, and takes none otherwise. The library had the
+rule implemented but disabled for Portuguese, so every round-hundred
+remainder lost its conjunction ("mil quinhentos" for 1500).
+
+Both sources are archived under papers/linguistics/pt/.
+"""
+import unittest
+
+from ovos_number_parser import pronounce_number
+
+
+class TestConjunctionRequired(unittest.TestCase):
+    """Remainder below 100, or a whole number of hundreds."""
+
+    ROUND_HUNDREDS = [
+        (1100, "mil e cem"),
+        (1200, "mil e duzentos"),
+        (1500, "mil e quinhentos"),
+        (1800, "mil e oitocentos"),      # Cunha & Cintra's own example
+        (2100, "dois mil e cem"),
+        (2500, "dois mil e quinhentos"),
+        (1000100, "um milhão e cem"),
+    ]
+
+    BELOW_HUNDRED = [
+        (1001, "mil e um"),              # Ciberdúvidas' example
+        (1005, "mil e cinco"),
+        (1020, "mil e vinte"),           # Ciberdúvidas' example
+        (1050, "mil e cinquenta"),
+    ]
+
+    def test_round_hundred_remainder_takes_conjunction(self):
+        for value, expected in self.ROUND_HUNDREDS:
+            with self.subTest(value=value):
+                self.assertEqual(pronounce_number(value, "pt"), expected)
+
+    def test_sub_hundred_remainder_takes_conjunction(self):
+        for value, expected in self.BELOW_HUNDRED:
+            with self.subTest(value=value):
+                self.assertEqual(pronounce_number(value, "pt"), expected)
+
+
+class TestConjunctionOmitted(unittest.TestCase):
+    """Any other remainder carries its own "e" and takes none after the scale."""
+
+    CASES = [
+        (1101, "mil cento e um"),
+        (1150, "mil cento e cinquenta"),
+        (1250, "mil duzentos e cinquenta"),
+        (1501, "mil quinhentos e um"),
+        (1892, "mil oitocentos e noventa e dois"),   # Cunha & Cintra
+    ]
+
+    def test_structured_remainder_has_no_conjunction(self):
+        for value, expected in self.CASES:
+            with self.subTest(value=value):
+                self.assertEqual(pronounce_number(value, "pt"), expected)
+
+
+class TestBothVariants(unittest.TestCase):
+    """The rule is orthographic, so it holds for pt-PT and pt-BR alike."""
+
+    def test_variants_agree_on_the_conjunction(self):
+        for value in (1500, 1800, 1001, 1250, 1892):
+            with self.subTest(value=value):
+                self.assertEqual(pronounce_number(value, "pt-PT"),
+                                 pronounce_number(value, "pt-BR"))
+
+
+class TestRoundTrip(unittest.TestCase):
+    """What we say must be what we can read back."""
+
+    def test_spoken_forms_parse_back(self):
+        from ovos_number_parser import extract_number
+        for value in (1001, 1050, 1100, 1200, 1500, 1800, 1892, 2500):
+            with self.subTest(value=value):
+                spoken = pronounce_number(value, "pt")
+                self.assertEqual(extract_number(spoken, "pt"), value)


### PR DESCRIPTION
`pronounce_number(1500, 'pt')` returned **"mil quinhentos"**. Portuguese requires **"mil e quinhentos"**.

The engine already implemented the rule correctly (`remainder < 100 or remainder % 100 == 0`), but `JOINER_ON_THOUSANDS` was set to `False` for both Portuguese vocabularies — with the comment on that very line reading `# "mil e duzentos"`, the exact form it was suppressing. Spanish and Catalan are correctly `False`; this was Portuguese-specific.

**Authoritative source.** Celso Cunha & Lindley Cintra, *Nova Gramática do Português Contemporâneo* (1984), p. 372:

> "Não se emprega a conjunção entre os milhares e as centenas, salvo quando o número terminar numa centena com dois zeros"

giving 1892 = "mil oitocentos e noventa e dois" but 1800 = "mil e oitocentos". [Ciberdúvidas da Língua Portuguesa](https://ciberduvidas.iscte-iul.pt/consultorio/perguntas/a-obrigatoriedade-da-conjuncao-e-na-escrita-dos-numerais/34389) (ISCTE-IUL, resposta 34389) supplies the other half — the conjunction also joins when the second class "começa por zero" ("mil e vinte", "mil e um"). Both pages are archived under `papers/linguistics/pt/` and the quoted text was cross-checked against the downloaded copy.

Cited in the vocabulary and in the test module. Tests use the grammars' own examples (1800, 1892, 1001, 1020), cover the omission cases, assert pt-PT and pt-BR agree (the rule is orthographic, not dialectal), and round-trip every spoken form back through `extract_number`.

Found by a differential harness against ICU RBNF; Portuguese now has **zero** disagreements with ICU across 0-100 plus the class boundaries. Suite green (1521 passed).