### PR TITLE
feat: add differential harness against ICU RBNF spellout

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,44 @@
+# Benchmarks
+
+## `icu_diff.py` — differential harness against ICU RBNF
+
+ICU's `RuleBasedNumberFormat` is the reference implementation for spelling
+numbers out, so it is the natural yardstick for `pronounce_number`. The
+harness round-trips a value set through both and reports a per-language
+scoreboard plus the individual disagreements.
+
+```bash
+uv venv icuenv && uv pip install --python icuenv/bin/python PyICU -e .
+icuenv/bin/python benchmarks/icu_diff.py          # all languages
+icuenv/bin/python benchmarks/icu_diff.py pt es    # selected languages
+```
+
+PyICU needs the ICU development headers (`pkg-config --modversion icu-i18n`).
+It is intentionally **not** a dependency of the library — this is a
+development tool.
+
+### ICU is a yardstick, not an oracle
+
+A disagreement means one of the two is wrong, and which one is a question for
+the language's canonical grammar — never for ICU. Expected values in tests are
+justified by a cited source and are never pinned to ICU output. Real
+divergences found so far, all correct on both sides:
+
+| language | ours | ICU | why |
+| --- | --- | --- | --- |
+| en | `one hundred and one` | `one hundred one` | British vs American convention |
+| pt | `dezasseis` | `dezesseis` | we default to European, ICU's plain `pt` is Brazilian |
+| pt | `mil milhões` (10^9) | `um bilhão` | long scale vs short scale |
+| es | `un millardo` (10^9) | `mil millones` | both accepted; ICU prefers the common form |
+
+### Locales ICU cannot judge
+
+ICU resolves a locale it has no rules for by falling back to another one, and
+the substitute is **not** necessarily English — it hands `gl`, `eu`, `oc`,
+`ast`, `an`, `mwl`, `kab` and `fy` a *Portuguese* formatter. Scoring Galician
+against Portuguese spellings produces confident nonsense, so the harness asks
+ICU which locale it actually resolved to (`ACTUAL_LOCALE`) and excludes any
+language ICU is only pretending to support.
+
+Those 8 languages are precisely where we offer coverage ICU does not, and they
+must be validated against their own grammars instead.

--- a/benchmarks/icu_diff.py
+++ b/benchmarks/icu_diff.py
@@ -1,0 +1,131 @@
+"""Differential harness: ovos-number-parser pronounce_number vs ICU RBNF spellout.
+
+ICU's RuleBasedNumberFormat is the reference implementation for spelling
+numbers out, so it is the natural yardstick. It is *not* an oracle: where the
+two disagree, either side may be wrong, and each disagreement has to be
+adjudicated against the language's canonical source. Nothing here is pinned to
+ICU output.
+
+Two things are deliberately normalised away before comparing, because they are
+orthography conventions rather than readings:
+
+* hyphen / underscore / space between words -- we already treat these as
+  interchangeable, and ICU's choice differs per locale;
+* commas and full stops used as group separators in the spelled form.
+
+Locales ICU has no rules for are detected and excluded rather than counted as
+Those are detected and reported as "no ICU rules" rather than counted as
+mismatches, so the scoreboard never claims coverage ICU does not have.
+"""
+import re
+import sys
+from collections import OrderedDict
+
+import icu
+
+from ovos_number_parser import pronounce_number
+
+#: values worth comparing: every small integer (where most irregularity
+#: lives), the teens/tens boundaries, hundred and thousand joins, and each
+#: scale boundary
+VALUES = (
+    list(range(0, 101))
+    + [101, 110, 111, 115, 120, 121, 130, 171, 180, 181, 190, 199,
+       200, 201, 300, 500, 700, 900, 999,
+       1000, 1001, 1100, 1500, 2000, 2500, 10000, 21000, 100000, 123456,
+       1000000, 1000001, 2000000, 10 ** 9, 10 ** 12]
+    + [-1, -21, -100, -1000]
+)
+
+_PUNCT = re.compile(r"[,\.]")
+_JOIN = re.compile(r"[-_\s]+")
+
+
+def norm(text):
+    """Collapse orthography differences that are not reading differences."""
+    text = _PUNCT.sub(" ", text.lower())
+    return " ".join(_JOIN.sub(" ", text).split())
+
+
+def icu_formatter(lang):
+    """RBNF spellout formatter for a language, or None if ICU lacks rules.
+
+    ICU resolves a locale it has no rules for by falling back to another one,
+    and the substitute is not necessarily English -- ICU hands `gl`, `eu`,
+    `oc`, `ast`, `kab` and others a Portuguese formatter. Comparing against
+    that would score our Galician against Portuguese spellings and report
+    nonsense, so the *actual* locale ICU resolved to is what decides whether
+    a comparison is meaningful.
+    """
+    try:
+        fmt = icu.RuleBasedNumberFormat(icu.URBNFRuleSetTag.SPELLOUT,
+                                        icu.Locale(lang))
+        actual = fmt.getLocale(icu.ULocDataLocaleType.ACTUAL_LOCALE).getName()
+    except Exception:
+        return None
+    # "pt" may legitimately resolve to "pt_PT"; a different base language is a
+    # fallback and makes the comparison meaningless
+    if actual.split("_")[0] != lang.split("_")[0]:
+        return None
+    return fmt
+
+
+def compare(lang):
+    fmt = icu_formatter(lang)
+    if fmt is None:
+        return None
+    agree, diffs, errors = 0, [], []
+    for value in VALUES:
+        try:
+            ours = pronounce_number(value, lang)
+        except Exception as exc:
+            errors.append((value, f"{type(exc).__name__}: {exc}"))
+            continue
+        theirs = fmt.format(value)
+        if norm(ours) == norm(theirs):
+            agree += 1
+        else:
+            diffs.append((value, ours, theirs))
+    return agree, diffs, errors
+
+
+def main(langs):
+    results = OrderedDict()
+    skipped = []
+    for lang in langs:
+        out = compare(lang)
+        if out is None:
+            skipped.append(lang)
+            continue
+        results[lang] = out
+
+    total = len(VALUES)
+    print(f"{'lang':6} {'agree':>12}  {'diffs':>5} {'errors':>6}")
+    print("-" * 40)
+    for lang, (agree, diffs, errors) in sorted(
+            results.items(), key=lambda kv: kv[1][0] / total):
+        pct = 100.0 * agree / total
+        print(f"{lang:6} {agree:5}/{total:<4} {pct:5.1f}% "
+              f"{len(diffs):5} {len(errors):6}")
+    if skipped:
+        print(f"\nno ICU spellout rules ({len(skipped)}): {' '.join(skipped)}")
+
+    print("\n" + "=" * 60)
+    for lang, (agree, diffs, errors) in results.items():
+        if not diffs and not errors:
+            continue
+        print(f"\n### {lang}  ({len(diffs)} diffs, {len(errors)} errors)")
+        for value, exc in errors[:5]:
+            print(f"  !! {value}: {exc}")
+        for value, ours, theirs in diffs[:12]:
+            print(f"  {value}:\n     ours: {ours}\n      icu: {theirs}")
+        if len(diffs) > 12:
+            print(f"  ... {len(diffs) - 12} more")
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:] or [
+        'an', 'ar', 'ast', 'az', 'bg', 'ca', 'cs', 'da', 'de', 'el', 'en',
+        'es', 'et', 'eu', 'fa', 'fi', 'fr', 'fy', 'gl', 'he', 'hr', 'hu',
+        'id', 'it', 'kab', 'ms', 'mwl', 'nb', 'nl', 'nn', 'no', 'oc', 'pl',
+        'pt', 'ro', 'ru', 'sk', 'sl', 'sv', 'tr', 'uk'])


### PR DESCRIPTION
Compares `pronounce_number` against ICU `RuleBasedNumberFormat` for every supported language and prints a per-language scoreboard plus the individual disagreements. This is the tool that found #252 (Portuguese losing its `e` conjunction).

**ICU is a yardstick, not an oracle.** A disagreement means one of the two is wrong, and which one is a question for the language's grammar — never for ICU. Test expectations stay justified by cited sources and are never pinned to ICU output. Documented divergences where both sides are correct (British vs American `one hundred and one`, European vs Brazilian `dezasseis`, long vs short scale at 10^9) are tabulated in the README so they are not re-investigated each run.

**The subtle part.** ICU resolves a locale it lacks rules for by falling back to another — and *not* necessarily English. It hands `gl`, `eu`, `oc`, `ast`, `an`, `mwl`, `kab` and `fy` a **Portuguese** formatter. My first cut probed for an English fallback and missed this, producing a scoreboard that scored Galician against Portuguese spellings and ranked it at 34% — confident nonsense. The harness now asks ICU which locale it actually resolved to (`ACTUAL_LOCALE`) and excludes anything it is only pretending to support.

Current standing on the languages ICU can judge — `fr` and `tr` at 100%, `es` 99.3%, `pt` now 100% after #252, and a long tail (`hu`, `fi`, `nl`, `sv`, `da`, `de`, `it` all under 30%) that is next to triage. Those low scores are **not** yet bug counts: German and Dutch write compounds as one word, which the current normalizer does not fold, so a large share will be orthographic rather than real. Triage before conclusions.

Those 8 excluded languages are also exactly where we offer coverage ICU does not have.

PyICU is a development dependency only, deliberately not added to the library's requirements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for running the number pronunciation benchmark and interpreting its results.
  * Documented locale handling and validation behavior for clearer, more reliable comparisons.

* **Tests**
  * Added a benchmarking tool that compares number pronunciation across supported languages.
  * Reports agreements, mismatches, formatting errors, and unsupported locale rules.
  * Supports default language coverage and custom language selections from the command line.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->