### PR TITLE
fix: write the trema in Dutch compound numerals

### DIFF
--- a/ovos_number_parser/numbers_nl.py
+++ b/ovos_number_parser/numbers_nl.py
@@ -372,9 +372,19 @@ def pronounce_number_nl(number, places=2, short_scale=True, scientific=False,
             ones = num % 10
             tens = num - ones
             if ones > 0:
-                result += _NUM_STRING_NL[ones] + _EXTRA_SPACE_NL
+                ones_word = _NUM_STRING_NL[ones]
+                result += ones_word + _EXTRA_SPACE_NL
                 if tens > 0:
-                    result += 'en' + _EXTRA_SPACE_NL
+                    # Klinkerbotsing: "twee" and "drie" end in a vowel, so the
+                    # "e" of the joining "en" would be read together with it
+                    # ("tweeen"). Taaladvies.net (Nederlandse Taalunie), entry
+                    # "Klinkerbotsing": the ambiguity is resolved by separating
+                    # the vowels with a trema "in afleidingen en samengestelde
+                    # telwoorden" -- compound numerals are an explicit
+                    # exception to the hyphen used in ordinary compounds, and
+                    # "tweeentwintig" is cited there as "tweeëntwintig".
+                    joiner = 'ën' if ones_word.endswith(('e', 'ie')) else 'en'
+                    result += joiner + _EXTRA_SPACE_NL
             if tens > 0:
                 result += _NUM_STRING_NL[tens] + _EXTRA_SPACE_NL
         return result

--- a/tests/test_nl_trema.py
+++ b/tests/test_nl_trema.py
@@ -1,0 +1,99 @@
+"""Dutch compound numerals take a trema at a vowel collision.
+
+"twee" and "drie" end in a vowel, so the "e" of the joining "en" would be read
+together with it -- "tweeen" invites the reading "twee-en" as one sound. Dutch
+resolves this with a trema.
+
+Source: Taaladvies.net (Nederlandse Taalunie), entry "Klinkerbotsing":
+
+    "Deze dubbelzinnigheid wordt opgeheven door de aparte klinkers van elkaar
+     te scheiden met een trema (in afleidingen en samengestelde telwoorden) of
+     een koppelteken (in samenstellingen). Voorbeelden: zeeën, geëvenaard,
+     tweeëntwintig, ..."
+
+Compound numerals are an explicit *exception* to the hyphen used in ordinary
+compounds (`gala-avond`, `zee-egel`): they take a trema, and `tweeëntwintig`
+is the Taalunie's own example. Archived under papers/linguistics/nl/.
+
+Only "twee" and "drie" end in a vowel; every other unit ends in a consonant
+and joins with a plain "en" (`vierentwintig`, `vijfenveertig`).
+
+Parsing already accepted both spellings and must keep doing so -- an ASR
+transcript or a user typing without the diacritic is still a valid input.
+"""
+import unittest
+
+from ovos_number_parser import pronounce_number, extract_number
+
+
+class TestTremaWritten(unittest.TestCase):
+    """Units ending in a vowel take "ën"."""
+
+    CASES = [
+        (22, "tweeëntwintig"),          # the Taalunie's own example
+        (23, "drieëntwintig"),
+        (32, "tweeëndertig"),
+        (33, "drieëndertig"),           # cited by Taaladvies as drieëndertig
+        (42, "tweeënveertig"),
+        (52, "tweeënvijftig"),
+        (53, "drieënvijftig"),
+        (93, "drieënnegentig"),
+    ]
+
+    def test_vowel_final_units_take_trema(self):
+        for value, expected in self.CASES:
+            with self.subTest(value=value):
+                self.assertEqual(pronounce_number(value, "nl"), expected)
+
+
+class TestNoTremaElsewhere(unittest.TestCase):
+    """Units ending in a consonant join with a plain "en"."""
+
+    CASES = [
+        (21, "eenentwintig"),
+        (24, "vierentwintig"),
+        (25, "vijfentwintig"),
+        (26, "zesentwintig"),
+        (27, "zevenentwintig"),
+        (28, "achtentwintig"),
+        (29, "negenentwintig"),
+        (99, "negenennegentig"),
+    ]
+
+    def test_consonant_final_units_have_no_trema(self):
+        for value, expected in self.CASES:
+            with self.subTest(value=value):
+                out = pronounce_number(value, "nl")
+                self.assertEqual(out, expected)
+                self.assertNotIn("ë", out)
+
+
+class TestInsideLargerNumbers(unittest.TestCase):
+    """The trema survives when the pair sits inside a bigger numeral."""
+
+    def test_hundreds_and_thousands(self):
+        self.assertEqual(pronounce_number(122, "nl"),
+                         "eenhonderdtweeëntwintig")
+        self.assertIn("drieëntwintig", pronounce_number(1023, "nl"))
+
+
+class TestParsingStaysPermissive(unittest.TestCase):
+    """Both spellings must parse: ASR and typing often drop the diacritic."""
+
+    def test_both_spellings_accepted(self):
+        for spelled, bare, value in [("tweeëntwintig", "tweeentwintig", 22),
+                                     ("drieëndertig", "drieendertig", 33),
+                                     ("drieënvijftig", "drieenvijftig", 53)]:
+            with self.subTest(value=value):
+                self.assertEqual(extract_number(spelled, "nl"), value)
+                self.assertEqual(extract_number(bare, "nl"), value)
+
+
+class TestRoundTrip(unittest.TestCase):
+    """What we write must read back as the same number."""
+
+    def test_round_trip(self):
+        for value in list(range(20, 100)) + [122, 1023]:
+            with self.subTest(value=value):
+                spoken = pronounce_number(value, "nl")
+                self.assertEqual(extract_number(spoken, "nl"), value)

--- a/tests/test_number_parser_nl.py
+++ b/tests/test_number_parser_nl.py
@@ -7,13 +7,13 @@ class TestDutchPronounce(unittest.TestCase):
     """Anchors for spoken Dutch numbers."""
 
     def test_pronounce_number(self):
-        expected = {0: 'nul', 1: 'één', 2: 'twee', 3: 'drie', 4: 'vier', 5: 'vijf', 6: 'zes', 7: 'zeven', 8: 'acht', 9: 'negen', 10: 'tien', 11: 'elf', 12: 'twaalf', 13: 'dertien', 14: 'veertien', 15: 'vijftien', 16: 'zestien', 17: 'zeventien', 18: 'achttien', 19: 'negentien', 20: 'twintig', 21: 'eenentwintig', 30: 'dertig', 42: 'tweeenveertig', 50: 'vijftig', 66: 'zesenzestig', 70: 'zeventig', 80: 'tachtig', 90: 'negentig', 99: 'negenennegentig', 100: 'eenhonderd', 101: 'eenhonderdeen', 123: 'eenhonderddrieentwintig', 200: 'tweehonderd', 500: 'vijfhonderd', 999: 'negenhonderdnegenennegentig', 1000: 'eenduizend', 2000: 'tweeduizend', 2023: 'tweeduizenddrieentwintig', 1000000: 'één miljoen ', 2000000: 'twee miljoen '}
+        expected = {0: 'nul', 1: 'één', 2: 'twee', 3: 'drie', 4: 'vier', 5: 'vijf', 6: 'zes', 7: 'zeven', 8: 'acht', 9: 'negen', 10: 'tien', 11: 'elf', 12: 'twaalf', 13: 'dertien', 14: 'veertien', 15: 'vijftien', 16: 'zestien', 17: 'zeventien', 18: 'achttien', 19: 'negentien', 20: 'twintig', 21: 'eenentwintig', 30: 'dertig', 42: 'tweeënveertig', 50: 'vijftig', 66: 'zesenzestig', 70: 'zeventig', 80: 'tachtig', 90: 'negentig', 99: 'negenennegentig', 100: 'eenhonderd', 101: 'eenhonderdeen', 123: 'eenhonderddrieëntwintig', 200: 'tweehonderd', 500: 'vijfhonderd', 999: 'negenhonderdnegenennegentig', 1000: 'eenduizend', 2000: 'tweeduizend', 2023: 'tweeduizenddrieëntwintig', 1000000: 'één miljoen ', 2000000: 'twee miljoen '}
         for number, spoken in expected.items():
             with self.subTest(number=number):
                 self.assertEqual(pronounce_number(number, lang="nl"), spoken)
 
     def test_pronounce_negative_and_decimal(self):
-        expected = {-7: 'min zeven', -42: 'min tweeenveertig', 2.5: 'twee komma vijf nul nul', 3.14: 'drie komma een vier nul', -3.5: 'min drie komma vijf nul nul', 0.5: 'nul komma vijf nul nul'}
+        expected = {-7: 'min zeven', -42: 'min tweeënveertig', 2.5: 'twee komma vijf nul nul', 3.14: 'drie komma een vier nul', -3.5: 'min drie komma vijf nul nul', 0.5: 'nul komma vijf nul nul'}
         for number, spoken in expected.items():
             with self.subTest(number=number):
                 self.assertEqual(pronounce_number(number, lang="nl"), spoken)
@@ -23,13 +23,13 @@ class TestDutchExtract(unittest.TestCase):
     """Anchors for extracting numbers from Dutch text."""
 
     def test_extract_number(self):
-        expected = {0: 'nul', 1: 'één', 2: 'twee', 3: 'drie', 4: 'vier', 5: 'vijf', 6: 'zes', 7: 'zeven', 8: 'acht', 9: 'negen', 10: 'tien', 11: 'elf', 12: 'twaalf', 13: 'dertien', 14: 'veertien', 15: 'vijftien', 16: 'zestien', 17: 'zeventien', 18: 'achttien', 19: 'negentien', 20: 'twintig', 21: 'eenentwintig', 30: 'dertig', 42: 'tweeenveertig', 50: 'vijftig', 66: 'zesenzestig', 70: 'zeventig', 80: 'tachtig', 90: 'negentig', 99: 'negenennegentig', 100: 'eenhonderd', 101: 'eenhonderdeen', 123: 'eenhonderddrieentwintig', 200: 'tweehonderd', 500: 'vijfhonderd', 999: 'negenhonderdnegenennegentig', 1000: 'eenduizend', 2000: 'tweeduizend', 2023: 'tweeduizenddrieentwintig', 1000000: 'één miljoen ', 2000000: 'twee miljoen '}
+        expected = {0: 'nul', 1: 'één', 2: 'twee', 3: 'drie', 4: 'vier', 5: 'vijf', 6: 'zes', 7: 'zeven', 8: 'acht', 9: 'negen', 10: 'tien', 11: 'elf', 12: 'twaalf', 13: 'dertien', 14: 'veertien', 15: 'vijftien', 16: 'zestien', 17: 'zeventien', 18: 'achttien', 19: 'negentien', 20: 'twintig', 21: 'eenentwintig', 30: 'dertig', 42: 'tweeënveertig', 50: 'vijftig', 66: 'zesenzestig', 70: 'zeventig', 80: 'tachtig', 90: 'negentig', 99: 'negenennegentig', 100: 'eenhonderd', 101: 'eenhonderdeen', 123: 'eenhonderddrieëntwintig', 200: 'tweehonderd', 500: 'vijfhonderd', 999: 'negenhonderdnegenennegentig', 1000: 'eenduizend', 2000: 'tweeduizend', 2023: 'tweeduizenddrieëntwintig', 1000000: 'één miljoen ', 2000000: 'twee miljoen '}
         for number, spoken in expected.items():
             with self.subTest(spoken=spoken):
                 self.assertEqual(extract_number(spoken, lang="nl"), number)
 
     def test_extract_negative_and_decimal(self):
-        expected = {-7: 'min zeven', -42: 'min tweeenveertig', 2.5: 'twee komma vijf nul nul', 3.14: 'drie komma een vier nul', -3.5: 'min drie komma vijf nul nul', 0.5: 'nul komma vijf nul nul'}
+        expected = {-7: 'min zeven', -42: 'min tweeënveertig', 2.5: 'twee komma vijf nul nul', 3.14: 'drie komma een vier nul', -3.5: 'min drie komma vijf nul nul', 0.5: 'nul komma vijf nul nul'}
         for number, spoken in expected.items():
             with self.subTest(spoken=spoken):
                 self.assertEqual(extract_number(spoken, lang="nl"), number)


### PR DESCRIPTION
`pronounce_number(22, 'nl')` returned `tweeentwintig`. Correct Dutch is **`tweeëntwintig`**.

`twee` and `drie` end in a vowel, so the `e` of the joining `en` runs into it and invites the wrong reading. Dutch resolves this vowel collision (*klinkerbotsing*) with a trema. Every other unit ends in a consonant and correctly joins with a plain `en` (`vierentwintig`, `vijfenveertig`), so the bug was confined to the 2x/3x pattern — 16 values.

**Authoritative source.** [Taaladvies.net](https://taaladvies.net/termen-klinkerbotsing/) (Nederlandse Taalunie), entry *Klinkerbotsing*:

> "Deze dubbelzinnigheid wordt opgeheven door de aparte klinkers van elkaar te scheiden met een trema (**in afleidingen en samengestelde telwoorden**) of een koppelteken (in samenstellingen). Voorbeelden: zeeën, geëvenaard, **tweeëntwintig**, ..."

Compound numerals are an explicit **exception** to the hyphen used in ordinary compounds (`gala-avond`, `zee-egel`) — and `tweeëntwintig` is the Taalunie's own cited example. Archived under `papers/linguistics/nl/` and cross-checked against the downloaded copy.

**Parsing stays permissive.** Extraction already accepted both spellings and still does — an ASR transcript or a user typing without the diacritic is a valid input, and there is a test pinning that. This changes only what we *write*.

Four existing expectations pinned the un-tremaed output and were updated; the extraction fixtures using bare spellings were deliberately left alone.

Found by the ICU differential harness (#254). Suite green (1526 passed).