### PR TITLE
fix: Danish hundreds and thousands per Retskrivningsordbogen

### DIFF
--- a/ovos_number_parser/numbers_da.py
+++ b/ovos_number_parser/numbers_da.py
@@ -1,3 +1,4 @@
+import re
 from math import floor, isfinite
 
 from ovos_number_parser.util import (invert_dict, convert_to_mixed_fraction, tokenize,
@@ -176,6 +177,10 @@ _LONG_SCALE = {
 _MULTIPLIER = set(_LONG_SCALE.values())
 
 _STRING_LONG_SCALE = invert_dict(_LONG_SCALE)
+# "tusind" is the count word for 1000 (Retskrivningsordbogen); "tusinde" also
+# occurs. Both must parse, so register the bare form alongside the inverted map.
+_STRING_LONG_SCALE['tusind'] = 1000
+_MULTIPLIER.add('tusind')
 
 # ending manipulation
 for number, item in _LONG_SCALE.items():
@@ -367,12 +372,24 @@ def pronounce_number_da(number, places=2, short_scale=True, scientific=False,
         if num > 99:
             hundreds = floor(num / 100)
             if hundreds > 0:
-                if hundreds == 1:
-                    result += 'et' + 'hundrede' + _EXTRA_SPACE_DA
-                else:
-                    result += _NUM_STRING_DA[hundreds] + \
-                              'hundrede' + _EXTRA_SPACE_DA
+                # 100 is "hundrede", never "et hundrede": Retskrivningsordbogen
+                # gives "hundrede" as the correct form (sproget.dk, Politikens
+                # sprogklumme "Den 101. dalmatiner moeder den 101. stryger":
+                # "en helt fjerde form, hundrede, er den korrekte form ifoelge
+                # Retskrivningsordbogen"). Numerals above 100 are also written
+                # as separate words -- "talord over 100 [...] deles op i
+                # modsaetning til talord under 100" -- so the hundreds group is
+                # spaced ("fem tusinde ni hundrede og treoghalvtreds"), while
+                # everything below 100 stays a single fused word.
+                if hundreds > 1:
+                    result += _NUM_STRING_DA[hundreds] + ' '
+                result += 'hundrede'
                 num -= hundreds * 100
+                if num > 0:
+                    # "og" links the hundreds to the remainder; the same source
+                    # marks it optional ("hundred(e) (og) syttende"), and it is
+                    # the conventional written form
+                    result += ' og '
         if num == 0:
             result += ''  # do nothing
         elif num == 1:
@@ -419,13 +436,18 @@ def pronounce_number_da(number, places=2, short_scale=True, scientific=False,
                 else:
                     result += "en"
             elif scale_level == 1:
-                result += 'et' + _EXTRA_SPACE_DA + 'tusinde' + _EXTRA_SPACE_DA
+                # 1000 is "tusind", not "et tusinde": Retskrivningsordbogen
+                # gives "tusind" as the count word (a bare "tusinde" also
+                # occurs, but the "et" prefix is not written)
+                result += 'tusind '
             else:
                 result += "en " + _NUM_POWERS_OF_TEN[scale_level] + ' '
         elif last_triplet > 1:
             result += pronounce_triplet_da(last_triplet)
             if scale_level == 1:
-                result += 'tusinde' + _EXTRA_SPACE_DA
+                # a space so the thousands stay a separate word from the
+                # hundreds below them ("fem tusinde ni hundrede ...")
+                result += ' tusinde '
             if scale_level >= 2:
                 result += ' ' + _NUM_POWERS_OF_TEN[scale_level]
             if scale_level >= 2:
@@ -445,7 +467,7 @@ def pronounce_number_da(number, places=2, short_scale=True, scientific=False,
         return "minus " + pronounce_number_da(abs(number), places)
     else:
         if number == int(number):
-            return pronounce_whole_number_da(number)
+            return re.sub(r'\s+', ' ', pronounce_whole_number_da(number)).strip()
         else:
             whole_number_part = floor(number)
             fractional_part = number - whole_number_part
@@ -453,7 +475,7 @@ def pronounce_number_da(number, places=2, short_scale=True, scientific=False,
             if places > 0:
                 result += " komma"
                 result += pronounce_fractional_da(fractional_part, places)
-            return result
+            return re.sub(r'\s+', ' ', result).strip()
 
 
 def pronounce_ordinal_da(number):
@@ -896,6 +918,73 @@ def _compound_value_da(parts):
     return total + current
 
 
+#: hundred and thousand compose additively across words; larger scales keep
+#: the token combiner's existing path
+_FOLDABLE_SCALES_DA = {'hundrede': 100, 'hunderede': 100,
+                       'tusinde': 1000, 'tusind': 1000}
+
+
+def _fold_scale_groups_da(text):
+    """Collapse a spelled hundreds/thousands group into one integer token.
+
+    Dansk Sprognaevn writes numerals above 100 as separate words -- "fem
+    tusinde ni hundrede og treoghalvtreds" (5953) -- so the value is spread
+    over several tokens joined by "og". The token combiner did not compose
+    these additively across a scale word, so "tusinde fem hundrede" read as
+    1000 with the 500 dropped. This pass walks each run of number words,
+    hundreds and thousands and the connecting "og", and replaces the run with
+    its summed value. Runs are left untouched once they reach a million-or-
+    larger scale so those keep their existing, working path, and any
+    non-number token ends the run so surrounding text is preserved.
+    """
+    toks = text.split()
+    out = []
+    i = 0
+    while i < len(toks):
+        result = current = 0
+        saw = saw_scale = False
+        j = i
+        while j < len(toks):
+            w = toks[j]
+            if w in _FOLDABLE_SCALES_DA:
+                mult = _FOLDABLE_SCALES_DA[w]
+                if mult == 100:
+                    current = (current or 1) * 100
+                else:
+                    result += (current or 1) * 1000
+                    current = 0
+                saw = saw_scale = True
+                j += 1
+                continue
+            # a plain sub-1000 addend extends the run; a million-or-larger
+            # multiplier, a fraction or a non-number ends it. Guard the digit
+            # test against overflow: a several-hundred-digit token is a number
+            # but nowhere near a foldable addend, so reject it before float().
+            if w.lstrip('-').isdigit():
+                val = int(w) if len(w.lstrip('-')) < 4 else None
+            else:
+                val = is_number_da(w)
+            if isinstance(val, (int, float)) and val is not True \
+                    and float(val).is_integer() and 0 <= val < 1000:
+                current += int(val)
+                saw = True
+                j += 1
+                continue
+            if w == 'og' and saw and j + 1 < len(toks):
+                nxt = toks[j + 1]
+                if nxt in _FOLDABLE_SCALES_DA or nxt.lstrip('-').isdigit()                         or is_number_da(nxt) is not None:
+                    j += 1
+                    continue
+            break
+        if saw_scale and j - i > 1:
+            out.append(str(result + current))
+            i = j
+        else:
+            out.append(toks[i])
+            i += 1
+    return " ".join(out)
+
+
 def _expand_compound_numbers_da(text):
     """Rewrite compound number words as their digit value for parsing."""
     out = []
@@ -906,7 +995,7 @@ def _expand_compound_numbers_da(text):
             out.append(str(int(value)) if value is not None else w)
         else:
             out.append(w)
-    return " ".join(out)
+    return _fold_scale_groups_da(" ".join(out))
 
 
 def extract_number_da(text, short_scale=False, ordinals=False):

--- a/tests/test_da_hundreds_thousands.py
+++ b/tests/test_da_hundreds_thousands.py
@@ -1,0 +1,133 @@
+"""Danish writes numerals above 100 as separate words, and 100/1000 plainly.
+
+Sources (Dansk Sprognævn / Retskrivningsordbogen, via sproget.dk):
+
+* Politikens sprogklumme "Den 101. dalmatiner møder den 101. stryger"
+  (https://sproget.dk/.../den-101-dalmatiner-moeder-den-101-stryger/):
+  "en helt fjerde form, hundrede, er den korrekte form ifølge
+  Retskrivningsordbogen" -- 100 is "hundrede", not "et hundrede"; and
+  "talord over 100 [...] deles op i modsætning til talord under 100" --
+  numerals above 100 are split into separate words, those below 100 are one
+  word. The linking "og" is optional ("hundred(e) (og) syttende").
+* svarbase SV00000047 for the vigesimal tens (halvtreds 50 ... halvfems 90).
+
+The library previously fused everything and prefixed "et": 100 was
+"ethundrede", 1000 "ettusinde", 1500 "ettusindefemhundrede". The last even
+broke parsing -- it round-tripped to 100500.
+
+Archived under papers/linguistics/da/.
+"""
+import unittest
+
+from ovos_number_parser import pronounce_number, extract_number
+
+
+class TestHundredIsPlain(unittest.TestCase):
+    def test_100_has_no_et_prefix(self):
+        self.assertEqual(pronounce_number(100, "da"), "hundrede")
+
+    def test_1000_is_tusind(self):
+        self.assertEqual(pronounce_number(1000, "da"), "tusind")
+
+    def test_multiples_prefix_the_count(self):
+        self.assertEqual(pronounce_number(200, "da"), "to hundrede")
+        self.assertEqual(pronounce_number(500, "da"), "fem hundrede")
+
+
+class TestSplitAboveHundred(unittest.TestCase):
+    """Groups above 100 are separate words joined by "og" before the rest."""
+
+    CASES = [
+        (101, "hundrede og et"),
+        (111, "hundrede og elleve"),
+        (123, "hundrede og treogtyve"),
+        (253, "to hundrede og treoghalvtreds"),
+        (999, "ni hundrede og nioghalvfems"),
+        (5953, "fem tusinde ni hundrede og treoghalvtreds"),  # sproget.dk example
+    ]
+
+    def test_split_forms(self):
+        for value, expected in self.CASES:
+            with self.subTest(value=value):
+                self.assertEqual(pronounce_number(value, "da"), expected)
+
+    def test_below_hundred_stays_one_word(self):
+        # the split rule applies ONLY above 100
+        for value, word in [(24, "fireogtyve"), (42, "toogfyrre"),
+                            (99, "nioghalvfems")]:
+            with self.subTest(value=value):
+                self.assertEqual(pronounce_number(value, "da"), word)
+
+
+class TestParsingStillPermissive(unittest.TestCase):
+    """The old fused spellings must keep parsing -- they are valid input."""
+
+    FUSED = {
+        "ethundrede": 100,
+        "ettusinde": 1000,
+        "tohundrede": 200,
+        "ethundredeettusinde": 101000,
+        "nihundredenioghalvfems": 999,
+    }
+
+    def test_fused_forms_accepted(self):
+        for spelled, value in self.FUSED.items():
+            with self.subTest(spelled=spelled):
+                self.assertEqual(extract_number(spelled, "da"), value)
+
+    def test_new_split_forms_also_parse(self):
+        for spelled, value in [("hundrede", 100), ("tusind", 1000),
+                              ("tusind fem hundrede", 1500),
+                              ("fem tusinde ni hundrede og treoghalvtreds", 5953)]:
+            with self.subTest(spelled=spelled):
+                self.assertEqual(extract_number(spelled, "da"), value)
+
+
+class TestRoundTrip(unittest.TestCase):
+    """Every spoken form must read back as the same integer."""
+
+    def test_exhaustive_round_trip(self):
+        values = list(range(0, 1001)) + [
+            1001, 1500, 2000, 2023, 5953, 10000, 21000, 100000, 123456,
+            1000000, 2500000]
+        for value in values:
+            with self.subTest(value=value):
+                spoken = pronounce_number(value, "da")
+                self.assertEqual(extract_number(spoken, "da"), value)
+
+
+class TestNaturalSentences(unittest.TestCase):
+    def test_sentences(self):
+        cases = [
+            ("jeg har hundrede kroner", 100),
+            ("der var fem hundrede mennesker", 500),
+            ("bogen koster tusind kroner", 1000),
+            ("tusind fem hundrede meter", 1500),
+        ]
+        for sentence, value in cases:
+            with self.subTest(sentence=sentence):
+                self.assertEqual(extract_number(sentence, "da"), value)
+
+
+class TestAdversarial(unittest.TestCase):
+    """Cases written to break the folder, not to confirm it."""
+
+    def test_bare_addends_not_summed(self):
+        # "tre en halv" is 3 and a half, not 3+1 folded to 4
+        self.assertEqual(extract_number("tre en halv", "da"), 3.5)
+
+    def test_decimal_digits_not_folded(self):
+        # digits after "komma" are read one by one, never summed
+        self.assertEqual(extract_number("tre komma et fire", "da"), 3.14)
+
+    def test_scale_word_without_multiplier(self):
+        self.assertEqual(extract_number("hundrede", "da"), 100)
+        self.assertEqual(extract_number("tusind", "da"), 1000)
+
+    def test_non_number_text_survives_folding(self):
+        # a folded group must not eat following words
+        self.assertEqual(extract_number("to hundrede og halvtreds huse", "da"),
+                         250)
+
+    def test_negative_scaled_group(self):
+        self.assertEqual(extract_number("minus to tusinde", "da"), -2000)

--- a/tests/test_number_parser_da.py
+++ b/tests/test_number_parser_da.py
@@ -7,13 +7,13 @@ class TestDanishPronounce(unittest.TestCase):
     """Anchors for spoken Danish numbers."""
 
     def test_pronounce_number(self):
-        expected = {0: 'nul', 1: 'en', 2: 'to', 3: 'tre', 4: 'fire', 5: 'fem', 6: 'seks', 7: 'syv', 8: 'otte', 9: 'ni', 10: 'ti', 11: 'elleve', 12: 'tolv', 13: 'tretten', 14: 'fjorten', 15: 'femten', 16: 'seksten', 17: 'sytten', 18: 'atten', 19: 'nitten', 20: 'tyve', 21: 'enogtyve', 30: 'tredive', 42: 'toogfyrre', 50: 'halvtreds', 66: 'seksogtres', 70: 'halvfjerds', 80: 'firs', 90: 'halvfems', 99: 'nioghalvfems', 100: 'ethundrede', 101: 'ethundredeet', 123: 'ethundredetreogtyve', 200: 'tohundrede', 500: 'femhundrede', 999: 'nihundredenioghalvfems', 1000: 'ettusinde', 2000: 'totusinde', 2023: 'totusindetreogtyve', 1000000: 'en million ', 2000000: 'to millioner '}
+        expected = {0: 'nul', 1: 'en', 2: 'to', 3: 'tre', 4: 'fire', 5: 'fem', 6: 'seks', 7: 'syv', 8: 'otte', 9: 'ni', 10: 'ti', 11: 'elleve', 12: 'tolv', 13: 'tretten', 14: 'fjorten', 15: 'femten', 16: 'seksten', 17: 'sytten', 18: 'atten', 19: 'nitten', 20: 'tyve', 21: 'enogtyve', 30: 'tredive', 42: 'toogfyrre', 50: 'halvtreds', 66: 'seksogtres', 70: 'halvfjerds', 80: 'firs', 90: 'halvfems', 99: 'nioghalvfems', 100: 'hundrede', 101: 'hundrede og et', 123: 'hundrede og treogtyve', 200: 'to hundrede', 500: 'fem hundrede', 999: 'ni hundrede og nioghalvfems', 1000: 'tusind', 2000: 'to tusinde', 2023: 'to tusinde treogtyve', 1000000: 'en million', 2000000: 'to millioner'}
         for number, spoken in expected.items():
             with self.subTest(number=number):
                 self.assertEqual(pronounce_number(number, lang="da"), spoken)
 
     def test_pronounce_negative_and_decimal(self):
-        expected = {-7: 'minus syv', -42: 'minus toogfyrre', 2.5: 'to komma fem nul nul', 3.14: 'tre komma en fire nul', -3.5: 'minus tre komma fem nul nul', 0.5: ' komma fem nul nul'}
+        expected = {-7: 'minus syv', -42: 'minus toogfyrre', 2.5: 'to komma fem nul nul', 3.14: 'tre komma en fire nul', -3.5: 'minus tre komma fem nul nul', 0.5: 'komma fem nul nul'}
         for number, spoken in expected.items():
             with self.subTest(number=number):
                 self.assertEqual(pronounce_number(number, lang="da"), spoken)
@@ -58,13 +58,13 @@ class TestDanishExtract(unittest.TestCase):
     """Anchors for extracting numbers from Danish text."""
 
     def test_extract_number(self):
-        expected = {0: 'nul', 1: 'en', 2: 'to', 3: 'tre', 4: 'fire', 5: 'fem', 6: 'seks', 7: 'syv', 8: 'otte', 9: 'ni', 10: 'ti', 11: 'elleve', 12: 'tolv', 13: 'tretten', 14: 'fjorten', 15: 'femten', 16: 'seksten', 17: 'sytten', 18: 'atten', 19: 'nitten', 20: 'tyve', 21: 'enogtyve', 30: 'tredive', 42: 'toogfyrre', 50: 'halvtreds', 66: 'seksogtres', 70: 'halvfjerds', 80: 'firs', 90: 'halvfems', 99: 'nioghalvfems', 100: 'ethundrede', 101: 'ethundredeet', 123: 'ethundredetreogtyve', 200: 'tohundrede', 500: 'femhundrede', 999: 'nihundredenioghalvfems', 1000: 'ettusinde', 2000: 'totusinde', 2023: 'totusindetreogtyve', 1000000: 'en million ', 2000000: 'to millioner '}
+        expected = {0: 'nul', 1: 'en', 2: 'to', 3: 'tre', 4: 'fire', 5: 'fem', 6: 'seks', 7: 'syv', 8: 'otte', 9: 'ni', 10: 'ti', 11: 'elleve', 12: 'tolv', 13: 'tretten', 14: 'fjorten', 15: 'femten', 16: 'seksten', 17: 'sytten', 18: 'atten', 19: 'nitten', 20: 'tyve', 21: 'enogtyve', 30: 'tredive', 42: 'toogfyrre', 50: 'halvtreds', 66: 'seksogtres', 70: 'halvfjerds', 80: 'firs', 90: 'halvfems', 99: 'nioghalvfems', 100: 'hundrede', 101: 'hundrede og et', 123: 'hundrede og treogtyve', 200: 'to hundrede', 500: 'fem hundrede', 999: 'ni hundrede og nioghalvfems', 1000: 'tusind', 2000: 'to tusinde', 2023: 'to tusinde treogtyve', 1000000: 'en million', 2000000: 'to millioner'}
         for number, spoken in expected.items():
             with self.subTest(spoken=spoken):
                 self.assertEqual(extract_number(spoken, lang="da"), number)
 
     def test_extract_negative_and_decimal(self):
-        expected = {-7: 'minus syv', -42: 'minus toogfyrre', 2.5: 'to komma fem nul nul', 3.14: 'tre komma en fire nul', -3.5: 'minus tre komma fem nul nul', 0.5: ' komma fem nul nul'}
+        expected = {-7: 'minus syv', -42: 'minus toogfyrre', 2.5: 'to komma fem nul nul', 3.14: 'tre komma en fire nul', -3.5: 'minus tre komma fem nul nul', 0.5: 'komma fem nul nul'}
         for number, spoken in expected.items():
             with self.subTest(spoken=spoken):
                 self.assertEqual(extract_number(spoken, lang="da"), number)


### PR DESCRIPTION
`pronounce_number(100, 'da')` returned `ethundrede`; correct Danish is **`hundrede`**. `1500` returned `ettusindefemhundrede`, which — being wrong — even **broke parsing**: it round-tripped to **100500**.

Two rules from Dansk Sprognævn (Retskrivningsordbogen), via [sproget.dk](https://sproget.dk/sprogviden/artikler-fra-blade-og-tidsskrifter/sprogligt-politikens-sprogklumme/den-101-dalmatiner-moeder-den-101-stryger/) (Politikens sprogklumme):

> "en helt fjerde form, **hundrede**, er den korrekte form ifølge Retskrivningsordbogen"

> "talord over 100 [...] **deles op** i modsætning til talord under 100"

So 100 is `hundrede` (no `et`), 1000 is `tusind`, and numerals **above** 100 are written as separate words joined by `og` (`fem tusinde ni hundrede og treoghalvtreds` = 5953 — the source's own example), while those **below** 100 stay a single fused word (`fireogtyve`). `og` is optional per the source and kept as the conventional written form.

**Parsing stays permissive and gets stronger.** The split spellings now compose additively across hundreds and thousands via a deterministic scale-folder in the extraction pre-pass — and the old fused spellings (`ethundrede`, `ettusinde`, `nihundredenioghalvfems`) still parse, pinned by tests. The folder only fires on a genuine scale group, so bare addends (`tre en halv` = 3.5) and decimal digits (`tre komma et fire` = 3.14) are untouched; a several-hundred-digit token can't overflow it.

Tests: exhaustive round-trip 0–1000 plus large values, the split forms with the grammar's own examples, permissive parsing of both spellings, natural sentences, and adversarial cases (bare addends, decimals, non-number text after a folded group, negative scaled group). Sources archived under `papers/linguistics/da/`.

Found by the ICU differential harness. Suite green (1540 passed).