### PR TITLE
fix: drop the leading 'een' before Dutch honderd and duizend

### DIFF
--- a/ovos_number_parser/numbers_nl.py
+++ b/ovos_number_parser/numbers_nl.py
@@ -362,7 +362,14 @@ def pronounce_number_nl(number, places=2, short_scale=True, scientific=False,
         if num > 99:
             hundreds = floor(num / 100)
             if hundreds > 0:
-                result += _NUM_STRING_NL[hundreds] + _EXTRA_SPACE_NL + 'honderd' + _EXTRA_SPACE_NL
+                # 100 is "honderd", never "eenhonderd": Dutch drops the "een"
+                # before "honderd" and "duizend" (Nederlandse Taalunie,
+                # Taaladvies "Aaneenschrijven van telwoorden": 800 =
+                # "achthonderd", 135 = "honderdvijfendertig"), so the leading
+                # "one" is written only from two hundred up.
+                if hundreds > 1:
+                    result += _NUM_STRING_NL[hundreds] + _EXTRA_SPACE_NL
+                result += 'honderd' + _EXTRA_SPACE_NL
                 num -= hundreds * 100
         if num == 0:
             result += ''  # do nothing
@@ -417,8 +424,12 @@ def pronounce_number_nl(number, places=2, short_scale=True, scientific=False,
             if scale_level == 0:
                 result += "een"
             elif scale_level == 1:
-                result += 'een' + _EXTRA_SPACE_NL + 'duizend' + _EXTRA_SPACE_NL
+                # 1000 is "duizend", not "eenduizend" (same Taalunie rule)
+                result += 'duizend' + _EXTRA_SPACE_NL
             else:
+                # from a million up the count word IS written ("één miljoen"):
+                # here "een" would read as the article "a million", so the
+                # accented "één" marks the numeral
                 result += "één " + _NUM_POWERS_OF_TEN[scale_level] + ' '
         elif last_triplet > 1:
             result += pronounce_triplet_nl(last_triplet)

--- a/tests/test_nl_honderd_duizend.py
+++ b/tests/test_nl_honderd_duizend.py
@@ -1,0 +1,74 @@
+"""Dutch drops the "een" before "honderd" and "duizend".
+
+100 is "honderd", not "eenhonderd"; 1000 is "duizend", not "eenduizend". The
+leading "one" is written only from two hundred / two thousand up.
+
+Source: Nederlandse Taalunie, Taaladvies "Aaneenschrijven van telwoorden
+(algemeen)" (https://taaladvies.net/aaneenschrijven-van-telwoorden-algemeen/),
+whose own examples are "achthonderd" (800), "honderdvijfendertig" (135) and
+"honderdduizend" (100 000) -- never "een" before the scale word. Confirmed
+against ICU RBNF and num2words, which both spell "honderd" / "duizend".
+Archived under papers/linguistics/nl/.
+
+From a million up the count word IS written, and there "één miljoen" (accented)
+marks the numeral apart from the article "een" ("a million"), so that form is
+intentionally left in place.
+"""
+import unittest
+
+from ovos_number_parser import pronounce_number, extract_number
+
+
+class TestNoLeadingEen(unittest.TestCase):
+    CASES = [
+        (100, "honderd"),
+        (101, "honderdeen"),
+        (135, "honderdvijfendertig"),       # Taalunie example
+        (1000, "duizend"),
+        (1135, "duizendhonderdvijfendertig"),
+        (100000, "honderdduizend"),          # Taalunie example
+    ]
+
+    def test_no_een_prefix(self):
+        for value, expected in self.CASES:
+            with self.subTest(value=value):
+                out = pronounce_number(value, "nl")
+                self.assertEqual(out, expected)
+                self.assertFalse(out.startswith("een"),
+                                 f"{value} kept a leading een: {out!r}")
+
+
+class TestLeadingCountFromTwoUp(unittest.TestCase):
+    CASES = [(200, "tweehonderd"), (800, "achthonderd"),   # Taalunie example
+             (235, "tweehonderdvijfendertig"), (2000, "tweeduizend")]
+
+    def test_count_written_from_two(self):
+        for value, expected in self.CASES:
+            with self.subTest(value=value):
+                self.assertEqual(pronounce_number(value, "nl"), expected)
+
+
+class TestMillionKeepsAccentedEen(unittest.TestCase):
+    """"één miljoen" is intentional: it marks the numeral, not the article."""
+
+    def test_million(self):
+        self.assertEqual(pronounce_number(1000000, "nl").strip(), "één miljoen")
+
+
+class TestRoundTrip(unittest.TestCase):
+    def test_round_trip(self):
+        for value in list(range(0, 1001)) + [
+                1100, 1135, 2000, 21000, 100000, 123456, 1000000]:
+            with self.subTest(value=value):
+                spoken = pronounce_number(value, "nl")
+                self.assertEqual(extract_number(spoken, "nl"), value)
+
+
+class TestParsingPermissive(unittest.TestCase):
+    """The old "eenhonderd"/"eenduizend" spellings must still parse."""
+
+    def test_old_spellings_accepted(self):
+        for spelled, value in [("eenhonderd", 100), ("eenduizend", 1000),
+                              ("honderd", 100), ("duizend", 1000)]:
+            with self.subTest(spelled=spelled):
+                self.assertEqual(extract_number(spelled, "nl"), value)

--- a/tests/test_nl_trema.py
+++ b/tests/test_nl_trema.py
@@ -73,7 +73,7 @@ class TestInsideLargerNumbers(unittest.TestCase):
 
     def test_hundreds_and_thousands(self):
         self.assertEqual(pronounce_number(122, "nl"),
-                         "eenhonderdtweeëntwintig")
+                         "honderdtweeëntwintig")
         self.assertIn("drieëntwintig", pronounce_number(1023, "nl"))
 
 

--- a/tests/test_number_parser_nl.py
+++ b/tests/test_number_parser_nl.py
@@ -7,7 +7,7 @@ class TestDutchPronounce(unittest.TestCase):
     """Anchors for spoken Dutch numbers."""
 
     def test_pronounce_number(self):
-        expected = {0: 'nul', 1: 'één', 2: 'twee', 3: 'drie', 4: 'vier', 5: 'vijf', 6: 'zes', 7: 'zeven', 8: 'acht', 9: 'negen', 10: 'tien', 11: 'elf', 12: 'twaalf', 13: 'dertien', 14: 'veertien', 15: 'vijftien', 16: 'zestien', 17: 'zeventien', 18: 'achttien', 19: 'negentien', 20: 'twintig', 21: 'eenentwintig', 30: 'dertig', 42: 'tweeënveertig', 50: 'vijftig', 66: 'zesenzestig', 70: 'zeventig', 80: 'tachtig', 90: 'negentig', 99: 'negenennegentig', 100: 'eenhonderd', 101: 'eenhonderdeen', 123: 'eenhonderddrieëntwintig', 200: 'tweehonderd', 500: 'vijfhonderd', 999: 'negenhonderdnegenennegentig', 1000: 'eenduizend', 2000: 'tweeduizend', 2023: 'tweeduizenddrieëntwintig', 1000000: 'één miljoen ', 2000000: 'twee miljoen '}
+        expected = {0: 'nul', 1: 'één', 2: 'twee', 3: 'drie', 4: 'vier', 5: 'vijf', 6: 'zes', 7: 'zeven', 8: 'acht', 9: 'negen', 10: 'tien', 11: 'elf', 12: 'twaalf', 13: 'dertien', 14: 'veertien', 15: 'vijftien', 16: 'zestien', 17: 'zeventien', 18: 'achttien', 19: 'negentien', 20: 'twintig', 21: 'eenentwintig', 30: 'dertig', 42: 'tweeënveertig', 50: 'vijftig', 66: 'zesenzestig', 70: 'zeventig', 80: 'tachtig', 90: 'negentig', 99: 'negenennegentig', 100: 'honderd', 101: 'honderdeen', 123: 'honderddrieëntwintig', 200: 'tweehonderd', 500: 'vijfhonderd', 999: 'negenhonderdnegenennegentig', 1000: 'duizend', 2000: 'tweeduizend', 2023: 'tweeduizenddrieëntwintig', 1000000: 'één miljoen ', 2000000: 'twee miljoen '}
         for number, spoken in expected.items():
             with self.subTest(number=number):
                 self.assertEqual(pronounce_number(number, lang="nl"), spoken)
@@ -23,7 +23,7 @@ class TestDutchExtract(unittest.TestCase):
     """Anchors for extracting numbers from Dutch text."""
 
     def test_extract_number(self):
-        expected = {0: 'nul', 1: 'één', 2: 'twee', 3: 'drie', 4: 'vier', 5: 'vijf', 6: 'zes', 7: 'zeven', 8: 'acht', 9: 'negen', 10: 'tien', 11: 'elf', 12: 'twaalf', 13: 'dertien', 14: 'veertien', 15: 'vijftien', 16: 'zestien', 17: 'zeventien', 18: 'achttien', 19: 'negentien', 20: 'twintig', 21: 'eenentwintig', 30: 'dertig', 42: 'tweeënveertig', 50: 'vijftig', 66: 'zesenzestig', 70: 'zeventig', 80: 'tachtig', 90: 'negentig', 99: 'negenennegentig', 100: 'eenhonderd', 101: 'eenhonderdeen', 123: 'eenhonderddrieëntwintig', 200: 'tweehonderd', 500: 'vijfhonderd', 999: 'negenhonderdnegenennegentig', 1000: 'eenduizend', 2000: 'tweeduizend', 2023: 'tweeduizenddrieëntwintig', 1000000: 'één miljoen ', 2000000: 'twee miljoen '}
+        expected = {0: 'nul', 1: 'één', 2: 'twee', 3: 'drie', 4: 'vier', 5: 'vijf', 6: 'zes', 7: 'zeven', 8: 'acht', 9: 'negen', 10: 'tien', 11: 'elf', 12: 'twaalf', 13: 'dertien', 14: 'veertien', 15: 'vijftien', 16: 'zestien', 17: 'zeventien', 18: 'achttien', 19: 'negentien', 20: 'twintig', 21: 'eenentwintig', 30: 'dertig', 42: 'tweeënveertig', 50: 'vijftig', 66: 'zesenzestig', 70: 'zeventig', 80: 'tachtig', 90: 'negentig', 99: 'negenennegentig', 100: 'honderd', 101: 'honderdeen', 123: 'honderddrieëntwintig', 200: 'tweehonderd', 500: 'vijfhonderd', 999: 'negenhonderdnegenennegentig', 1000: 'duizend', 2000: 'tweeduizend', 2023: 'tweeduizenddrieëntwintig', 1000000: 'één miljoen ', 2000000: 'twee miljoen '}
         for number, spoken in expected.items():
             with self.subTest(spoken=spoken):
                 self.assertEqual(extract_number(spoken, lang="nl"), number)


### PR DESCRIPTION
`pronounce_number(100, 'nl')` returned `eenhonderd`; `1000` returned `eenduizend`. Correct Dutch is **`honderd`** and **`duizend`** — the leading count is written only from *two* hundred / thousand up (`tweehonderd`, `tweeduizend`).

**Two independent references agree against us.** This was found by extending the differential harness with **num2words** alongside ICU RBNF — both spell `honderd` / `duizend`, and where two independent implementations agree with each other but not us, that is the strongest possible bug signal.

**Authoritative source.** Nederlandse Taalunie, [Taaladvies "Aaneenschrijven van telwoorden"](https://taaladvies.net/aaneenschrijven-van-telwoorden-algemeen/), whose own examples are `achthonderd` (800), `honderdvijfendertig` (135) and `honderdduizend` (100 000) — never `een` before the scale word. Archived under `papers/linguistics/nl/` and cross-checked against the downloaded copy.

**`één miljoen` is deliberately kept.** From a million up the count word is written, and there `een` would read as the article `a million`; the acute accent marks the numeral. This is the one place the references and we differ where *we* are arguably more correct, so it is left in place and pinned by a test.

Same bug class as the Danish `ethundrede` fix (#258) — a spurious leading "one" before a scale word. Parsing still accepts the old spellings. Suite green (1544 passed).