### PR TITLE
fix: Swedish bare cardinal 1 is the neuter counting form 'ett'

### DIFF
--- a/ovos_number_parser/numbers_sv.py
+++ b/ovos_number_parser/numbers_sv.py
@@ -212,7 +212,10 @@ def pronounce_number_sv(number, places=2, short_scale=True, scientific=False,
             if ones > 0:
                 result += _NUM_STRING_SV[ones]
             if tens > 0:
-                result += _NUM_STRING_SV[tens]
+                # a bare cardinal ends in the neuter counting form: 21 is
+                # "tjugoett", not "tjugoen" ("en" is the common-gender
+                # attributive form, used only before a noun)
+                result += 'ett' if tens == 1 else _NUM_STRING_SV[tens]
 
         return result
 
@@ -239,10 +242,9 @@ def pronounce_number_sv(number, places=2, short_scale=True, scientific=False,
 
         if last_triplet == 1:
             if scale_level == 0:
-                if result != '':
-                    result += '' + 'ett'
-                else:
-                    result += 'en'
+                # the counting form of 1 is "ett" (räkna: ett, två, tre),
+                # not the common-gender "en"
+                result += 'ett'
             elif scale_level == 1:
                 result += 'ettusen' + _EXTRA_SPACE_SV
             else:
@@ -253,8 +255,9 @@ def pronounce_number_sv(number, places=2, short_scale=True, scientific=False,
             if scale_level == 1:
                 result += 'tusen' + _EXTRA_SPACE_SV
             if scale_level >= 2:
-                result += _NUM_POWERS_OF_TEN_SV[scale_level]
-            if scale_level >= 2:
+                # miljon/miljard are separate words ("två miljoner"), unlike
+                # the glued "tusen" ("tvåtusen")
+                result += ' ' + _NUM_POWERS_OF_TEN_SV[scale_level]
                 result += 'er' + _EXTRA_SPACE_SV  # MiljonER
 
         num = floor(num / 1000)

--- a/tests/test_number_parser_sv.py
+++ b/tests/test_number_parser_sv.py
@@ -104,7 +104,7 @@ class TestSwedishPronounce(unittest.TestCase):
     """Anchors for spoken Swedish numbers."""
 
     def test_pronounce_number(self):
-        expected = {0: 'noll', 1: 'en', 2: 'två', 3: 'tre', 4: 'fyra', 5: 'fem', 6: 'sex', 7: 'sju', 8: 'åtta', 9: 'nio', 10: 'tio', 11: 'elva', 12: 'tolv', 13: 'tretton', 14: 'fjorton', 15: 'femton', 16: 'sexton', 17: 'sjutton', 18: 'arton', 19: 'nitton', 20: 'tjugo', 21: 'tjugoen', 30: 'trettio', 42: 'fyrtiotvå', 50: 'femtio', 66: 'sextiosex', 70: 'sjuttio', 80: 'åttio', 90: 'nittio', 99: 'nittionio', 100: 'etthundra', 101: 'etthundraett', 123: 'etthundratjugotre', 200: 'tvåhundra', 500: 'femhundra', 999: 'niohundranittionio', 1000: 'ettusen ', 2000: 'tvåtusen ', 2023: 'tvåtusen tjugotre', 1000000: 'en miljon ', 2000000: 'tvåmiljoner '}
+        expected = {0: 'noll', 1: 'ett', 2: 'två', 3: 'tre', 4: 'fyra', 5: 'fem', 6: 'sex', 7: 'sju', 8: 'åtta', 9: 'nio', 10: 'tio', 11: 'elva', 12: 'tolv', 13: 'tretton', 14: 'fjorton', 15: 'femton', 16: 'sexton', 17: 'sjutton', 18: 'arton', 19: 'nitton', 20: 'tjugo', 21: 'tjugoett', 30: 'trettio', 42: 'fyrtiotvå', 50: 'femtio', 66: 'sextiosex', 70: 'sjuttio', 80: 'åttio', 90: 'nittio', 99: 'nittionio', 100: 'etthundra', 101: 'etthundraett', 123: 'etthundratjugotre', 200: 'tvåhundra', 500: 'femhundra', 999: 'niohundranittionio', 1000: 'ettusen ', 2000: 'tvåtusen ', 2023: 'tvåtusen tjugotre', 1000000: 'en miljon ', 2000000: 'två miljoner '}
         for number, spoken in expected.items():
             with self.subTest(number=number):
                 self.assertEqual(pronounce_number(number, lang="sv"), spoken)
@@ -120,7 +120,7 @@ class TestSwedishExtract(unittest.TestCase):
     """Anchors for extracting numbers from Swedish text."""
 
     def test_extract_number(self):
-        expected = {0: 'noll', 1: 'en', 2: 'två', 3: 'tre', 4: 'fyra', 5: 'fem', 6: 'sex', 7: 'sju', 8: 'åtta', 9: 'nio', 10: 'tio', 11: 'elva', 12: 'tolv', 13: 'tretton', 14: 'fjorton', 15: 'femton', 16: 'sexton', 17: 'sjutton', 18: 'arton', 19: 'nitton', 20: 'tjugo', 21: 'tjugoen', 30: 'trettio', 42: 'fyrtiotvå', 50: 'femtio', 66: 'sextiosex', 70: 'sjuttio', 80: 'åttio', 90: 'nittio', 99: 'nittionio', 100: 'etthundra', 101: 'etthundraett', 123: 'etthundratjugotre', 200: 'tvåhundra', 500: 'femhundra', 999: 'niohundranittionio', 1000: 'ettusen ', 2000: 'tvåtusen ', 2023: 'tvåtusen tjugotre', 1000000: 'en miljon ', 2000000: 'tvåmiljoner '}
+        expected = {0: 'noll', 1: 'ett', 2: 'två', 3: 'tre', 4: 'fyra', 5: 'fem', 6: 'sex', 7: 'sju', 8: 'åtta', 9: 'nio', 10: 'tio', 11: 'elva', 12: 'tolv', 13: 'tretton', 14: 'fjorton', 15: 'femton', 16: 'sexton', 17: 'sjutton', 18: 'arton', 19: 'nitton', 20: 'tjugo', 21: 'tjugoett', 30: 'trettio', 42: 'fyrtiotvå', 50: 'femtio', 66: 'sextiosex', 70: 'sjuttio', 80: 'åttio', 90: 'nittio', 99: 'nittionio', 100: 'etthundra', 101: 'etthundraett', 123: 'etthundratjugotre', 200: 'tvåhundra', 500: 'femhundra', 999: 'niohundranittionio', 1000: 'ettusen ', 2000: 'tvåtusen ', 2023: 'tvåtusen tjugotre', 1000000: 'en miljon ', 2000000: 'två miljoner '}
         for number, spoken in expected.items():
             with self.subTest(spoken=spoken):
                 self.assertEqual(extract_number(spoken, lang="sv"), number)

--- a/tests/test_sv_counting_form.py
+++ b/tests/test_sv_counting_form.py
@@ -1,0 +1,71 @@
+"""Swedish spells a bare cardinal 1 as the neuter counting form "ett".
+
+Swedish inflects only the numeral 1: "en" is the common-gender form (used
+before an en-word: "en person") and "ett" the neuter form ("ett äpple"). The
+bare *counting* form -- how you recite the numbers -- is the neuter one:
+"ett, två, tre ... tjugo, tjugoett, trettio ..." (Wikipedia "Räkneord"; the
+standard cardinal series). The library emitted the common-gender "en" for a
+lone 1 and for the ones digit of the round tens ("tjugoen"), while already
+using "ett" inside the hundreds ("etthundraett") -- an internal inconsistency
+that both ICU RBNF and num2words resolve to "ett".
+
+Millions and milliards are separate common-gender nouns, so 1 before them keeps
+"en" ("en miljon", "en miljard") and they are written as separate words
+("två miljoner"), unlike the glued "tvåtusen".
+
+Sources archived under papers/linguistics/sv/.
+"""
+import unittest
+
+from ovos_number_parser import pronounce_number, extract_number
+
+
+class TestCountingFormIsEtt(unittest.TestCase):
+    CASES = [
+        (1, "ett"),
+        (21, "tjugoett"),
+        (31, "trettioett"),
+        (41, "fyrtioett"),
+        (91, "nittioett"),
+        (101, "etthundraett"),
+        (121, "etthundratjugoett"),
+        (1021, "ettusen tjugoett"),
+    ]
+
+    def test_bare_cardinal_uses_ett(self):
+        for value, expected in self.CASES:
+            with self.subTest(value=value):
+                self.assertEqual(pronounce_number(value, "sv"), expected)
+
+
+class TestMillionKeepsEnAndSpace(unittest.TestCase):
+    """miljon/miljard are en-words and stand as separate words."""
+
+    def test_million(self):
+        self.assertEqual(pronounce_number(1000000, "sv").strip(), "en miljon")
+        self.assertEqual(pronounce_number(2000000, "sv").strip(),
+                         "två miljoner")
+        self.assertEqual(pronounce_number(1000000000, "sv").strip(),
+                         "en miljard")
+
+
+class TestParsingPermissive(unittest.TestCase):
+    """Both "en" and "ett" forms must parse -- speakers and ASR use both."""
+
+    def test_both_forms_accepted(self):
+        for spelled, value in [("ett", 1), ("en", 1),
+                              ("tjugoett", 21), ("tjugoen", 21),
+                              ("trettioett", 31), ("trettioen", 31)]:
+            with self.subTest(spelled=spelled):
+                self.assertEqual(extract_number(spelled, "sv"), value)
+
+
+class TestRoundTrip(unittest.TestCase):
+    def test_round_trip(self):
+        values = list(range(0, 101)) + [
+            101, 121, 1000, 1001, 1021, 21000, 100000, 1000000, 2000000,
+            21000000]
+        for value in values:
+            with self.subTest(value=value):
+                spoken = pronounce_number(value, "sv")
+                self.assertEqual(extract_number(spoken, "sv"), value)


### PR DESCRIPTION
`pronounce_number(21, 'sv')` returned `tjugoen`; the Swedish counting form is `tjugoett`. `pronounce_number(1, 'sv')` returned `en`; it should be `ett`.

Swedish inflects only the numeral 1: `en` is the common-gender form (`en person`) and `ett` the neuter (`ett äpple`). The **counting** form — reciting the numbers — is the neuter `ett, två, tre … tjugo, tjugoett`. The library used `en` for a lone 1 and the ones digit of the round tens, while already using `ett` inside the hundreds (`etthundraett`) — an internal inconsistency that **both ICU RBNF and num2words** resolve to `ett`.

**Millions kept correct.** `miljon`/`miljard` are common-gender nouns, so 1 stays `en` before them (`en miljon`) and they are written as separate words (`två miljoner`) — fixed a missing space there too, both references agree. The ones digit *before* `miljoner` (e.g. 21 million) is deliberately left as `tjugoett`: ICU says `tjugoen`, num2words says `tjugoett`, so the two references **disagree** — a contested case, not a bug, and ours matches num2words.

**Parsing stays permissive:** both `en`/`ett` and `tjugoen`/`tjugoett` still parse, pinned by a test — ASR and speakers use both.

Same bug class as the gender-of-one issues flagged across da/sv. Source: Wikipedia `Räkneord` (the standard cardinal series), archived under `papers/linguistics/sv/`. Verified against ICU + num2words; downstream date-parser Swedish tests still green (53 passed). Suite green (1555 passed).