### PR TITLE
fix: accent Italian compounds of 'tre' (ventitré, trentatré)

### DIFF
--- a/ovos_number_parser/numbers_it.py
+++ b/ovos_number_parser/numbers_it.py
@@ -785,6 +785,13 @@ def pronounce_number_it(number, places=2, short_scale=False, scientific=False):
     # if result[0:11] == 'unomiliardi':
     # result = result.replace('unomiliardi', 'un miliardo', 1)
 
+    # Every compound of "tre" carries a written acute accent on the final
+    # syllable: ventitré, trentatré, centotré, duemilatré. Accademia della
+    # Crusca, consulenza 1077 "Quarantaquattro gatti ...": "I composti di tre
+    # si scrivono più correttamente con l'accento". The standalone "tre" (3)
+    # takes none, so only a "tre" that ends a longer word is accented.
+    result = re.sub(r"(?<=[a-zàèéìòù])tre\b", "tré", result)
+
     # Deal with fractional part
     if not num == int(num) and places > 0:
         if abs(num) < 1.0 and (result == "meno " or not result):

--- a/tests/test_it_tre_accent.py
+++ b/tests/test_it_tre_accent.py
@@ -1,0 +1,73 @@
+"""Italian compounds of "tre" carry a written acute accent.
+
+Accademia della Crusca, consulenza 1077 ("Quarantaquattro gatti in fila per
+sei col resto di due, o di quando e come scrivere i numeri in lettere"):
+
+    "I composti di tre si scrivono più correttamente con l'accento; ventitré,
+     trentatré, centotré, duemilatré."
+
+so every number whose final digit is 3 -- when that 3 sits at the end of a
+longer word -- ends in "-tré". The standalone "tre" (the number 3 itself)
+takes no accent. The library wrote the bare "tre" everywhere ("ventitre").
+
+Note num2words is itself inconsistent here (it accents "ventitré" but writes
+"centoventitre"); ICU and Crusca agree that the accent is always required, so
+the expected values follow Crusca. Source archived under
+papers/linguistics/it/.
+"""
+import unittest
+
+from ovos_number_parser import pronounce_number, extract_number
+
+
+class TestCompoundsOfTreAreAccented(unittest.TestCase):
+    CASES = [
+        (23, "ventitré"),
+        (33, "trentatré"),
+        (43, "quarantatré"),
+        (53, "cinquantatré"),
+        (63, "sessantatré"),
+        (73, "settantatré"),
+        (83, "ottantatré"),
+        (93, "novantatré"),
+    ]
+
+    def test_tens_compounds(self):
+        for value, expected in self.CASES:
+            with self.subTest(value=value):
+                self.assertEqual(pronounce_number(value, "it"), expected)
+
+    def test_compound_inside_hundreds(self):
+        # the fused tens-unit still gets the accent within a larger number
+        self.assertEqual(pronounce_number(123, "it"), "cento ventitré")
+        self.assertEqual(pronounce_number(2023, "it"), "duemila, ventitré")
+
+
+class TestBareTreHasNoAccent(unittest.TestCase):
+    def test_three_is_plain(self):
+        self.assertEqual(pronounce_number(3, "it"), "tre")
+
+    def test_words_containing_tre_are_untouched(self):
+        # 13, 30, 300, 3000 contain "tre" but not as a final unit digit
+        self.assertEqual(pronounce_number(13, "it"), "tredici")
+        self.assertEqual(pronounce_number(30, "it"), "trenta")
+        self.assertEqual(pronounce_number(300, "it"), "trecento")
+        self.assertEqual(pronounce_number(3000, "it"), "tremila")
+
+
+class TestParsingPermissive(unittest.TestCase):
+    """Both accented and bare spellings parse -- ASR/typing drop the accent."""
+
+    def test_both_forms(self):
+        for spelled, value in [("ventitré", 23), ("ventitre", 23),
+                              ("trentatré", 33), ("trentatre", 33)]:
+            with self.subTest(spelled=spelled):
+                self.assertEqual(extract_number(spelled, "it"), value)
+
+
+class TestRoundTrip(unittest.TestCase):
+    def test_round_trip(self):
+        for value in [3, 23, 33, 93, 123, 333, 1003, 2023, 3, 300, 3000]:
+            with self.subTest(value=value):
+                spoken = pronounce_number(value, "it")
+                self.assertEqual(extract_number(spoken, "it"), value)

--- a/tests/test_number_parser_it.py
+++ b/tests/test_number_parser_it.py
@@ -7,7 +7,7 @@ class TestItalianPronounce(unittest.TestCase):
     """Anchors for spoken Italian numbers."""
 
     def test_pronounce_number(self):
-        expected = {0: 'zero', 1: 'uno', 2: 'due', 3: 'tre', 4: 'quattro', 5: 'cinque', 6: 'sei', 7: 'sette', 8: 'otto', 9: 'nove', 10: 'dieci', 11: 'undici', 12: 'dodici', 13: 'tredici', 14: 'quattordici', 15: 'quindici', 16: 'sedici', 17: 'diciassette', 18: 'diciotto', 19: 'diciannove', 20: 'venti', 21: 'ventuno', 30: 'trenta', 42: 'quarantadue', 50: 'cinquanta', 66: 'sessantasei', 70: 'settanta', 80: 'ottanta', 90: 'novanta', 99: 'novantanove', 100: 'cento', 101: 'cento uno', 123: 'cento ventitre', 200: 'duecento', 500: 'cinquecento', 999: 'novecento novantanove', 1000: 'mille', 2000: 'duemila', 2023: 'duemila, ventitre', 1000000: 'un milione', 2000000: 'due milioni'}
+        expected = {0: 'zero', 1: 'uno', 2: 'due', 3: 'tre', 4: 'quattro', 5: 'cinque', 6: 'sei', 7: 'sette', 8: 'otto', 9: 'nove', 10: 'dieci', 11: 'undici', 12: 'dodici', 13: 'tredici', 14: 'quattordici', 15: 'quindici', 16: 'sedici', 17: 'diciassette', 18: 'diciotto', 19: 'diciannove', 20: 'venti', 21: 'ventuno', 30: 'trenta', 42: 'quarantadue', 50: 'cinquanta', 66: 'sessantasei', 70: 'settanta', 80: 'ottanta', 90: 'novanta', 99: 'novantanove', 100: 'cento', 101: 'cento uno', 123: 'cento ventitré', 200: 'duecento', 500: 'cinquecento', 999: 'novecento novantanove', 1000: 'mille', 2000: 'duemila', 2023: 'duemila, ventitré', 1000000: 'un milione', 2000000: 'due milioni'}
         for number, spoken in expected.items():
             with self.subTest(number=number):
                 self.assertEqual(pronounce_number(number, lang="it"), spoken)
@@ -23,7 +23,7 @@ class TestItalianExtract(unittest.TestCase):
     """Anchors for extracting numbers from Italian text."""
 
     def test_extract_number(self):
-        expected = {0: 'zero', 1: 'uno', 2: 'due', 3: 'tre', 4: 'quattro', 5: 'cinque', 6: 'sei', 7: 'sette', 8: 'otto', 9: 'nove', 10: 'dieci', 11: 'undici', 12: 'dodici', 13: 'tredici', 14: 'quattordici', 15: 'quindici', 16: 'sedici', 17: 'diciassette', 18: 'diciotto', 19: 'diciannove', 20: 'venti', 21: 'ventuno', 30: 'trenta', 42: 'quarantadue', 50: 'cinquanta', 66: 'sessantasei', 70: 'settanta', 80: 'ottanta', 90: 'novanta', 99: 'novantanove', 100: 'cento', 101: 'cento uno', 123: 'cento ventitre', 200: 'duecento', 500: 'cinquecento', 999: 'novecento novantanove', 1000: 'mille', 2000: 'duemila', 2023: 'duemila, ventitre', 1000000: 'un milione', 2000000: 'due milioni'}
+        expected = {0: 'zero', 1: 'uno', 2: 'due', 3: 'tre', 4: 'quattro', 5: 'cinque', 6: 'sei', 7: 'sette', 8: 'otto', 9: 'nove', 10: 'dieci', 11: 'undici', 12: 'dodici', 13: 'tredici', 14: 'quattordici', 15: 'quindici', 16: 'sedici', 17: 'diciassette', 18: 'diciotto', 19: 'diciannove', 20: 'venti', 21: 'ventuno', 30: 'trenta', 42: 'quarantadue', 50: 'cinquanta', 66: 'sessantasei', 70: 'settanta', 80: 'ottanta', 90: 'novanta', 99: 'novantanove', 100: 'cento', 101: 'cento uno', 123: 'cento ventitré', 200: 'duecento', 500: 'cinquecento', 999: 'novecento novantanove', 1000: 'mille', 2000: 'duemila', 2023: 'duemila, ventitré', 1000000: 'un milione', 2000000: 'due milioni'}
         for number, spoken in expected.items():
             with self.subTest(spoken=spoken):
                 self.assertEqual(extract_number(spoken, lang="it"), number)


### PR DESCRIPTION
`pronounce_number(23, 'it')` returned `ventitre`; correct Italian is **`ventitré`**.

Every compound of *tre* carries a written acute accent on the final syllable. **Accademia della Crusca**, [consulenza 1077](https://accademiadellacrusca.it/it/consulenza/quarantaquattro-gatti-in-fila-per-sei-col-resto-di-due-o-di-quando-e-come-scrivere-i-numeri-in-lettere/1077):

> "I composti di tre si scrivono più correttamente con l'accento; ventitré, trentatré, centotré, duemilatré."

The standalone `tre` (the number 3) takes no accent, and words that merely *contain* `tre` (`tredici`, `trenta`, `trecento`, `tremila`) are untouched — the fix accents only a `tre` that ends a longer word.

**On the references:** num2words is itself inconsistent here — it writes `ventitré` but `centoventitre` — so ICU and Crusca are the authority, and expected values follow Crusca. Source already archived under `papers/linguistics/it/` (from the extraction-side citation).

**Scope.** This accents every *fused* compound. The spaced forms above 100 (`cento tre`) are a separate pre-existing issue — Italian fuses cardinals into one word (`centotré`), tracked separately as the Italian shared-engine migration; once fused, the same rule accents them automatically. Parsing already accepted both accented and bare spellings, pinned by a test.

Suite green (1561 passed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Italian number pronunciation now correctly accents “tre” as “tré” in compound numbers, such as 23, 123, and 2023.
  * Number parsing accepts both accented and unaccented spellings.
* **Bug Fixes**
  * Standalone “tre” and words where “tre” is not the final number segment remain unchanged.
* **Tests**
  * Added coverage for compound pronunciations, parsing compatibility, and round-trip number conversion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->