### PR TITLE
fix: fuse Italian cardinals into one word below a million

### DIFF
--- a/ovos_number_parser/numbers_it.py
+++ b/ovos_number_parser/numbers_it.py
@@ -251,6 +251,16 @@ _LONG_SCALE_IT = collections.OrderedDict([
     (1e366, "unsexagintilione")
 ])
 
+#: singular form of the large scale words, used when the count is exactly one
+#: ("un milione", "un miliardo"). The scale tables hold the plurals; most go
+#: -i -> -e, but miliardi -> miliardo is irregular.
+_LONG_SCALE_SINGULAR_IT = {
+    'milioni': 'milione',
+    'miliardi': 'miliardo',
+    'bilioni': 'bilione',
+    'triliardi': 'triliardo',
+}
+
 _SHORT_SCALE_IT = collections.OrderedDict([
     (100, 'cento'),
     (1000, 'mila'),
@@ -495,8 +505,10 @@ def _split_fused_it(word: str) -> str:
     is returned unchanged, so non-numbers ("trentini") stay non-numbers.
     """
     w = word.lower().replace('é', 'e').replace('è', 'e')
-    # cento elides its final -o before uno/otto (centuno, centotto)
-    w = w.replace('centuno', 'centouno').replace('centotto', 'centootto')
+    # cento elides its final -o before uno and before any o-word (otto,
+    # ottanta...): "centuno", "centottanta", "trecentottantotto". Restore the
+    # dropped vowel so the morpheme splitter sees "cento" + remainder.
+    w = w.replace('centuno', 'centouno').replace('centott', 'centoott')
     out = []
     i = 0
     while i < len(w):
@@ -712,8 +724,16 @@ def pronounce_number_it(number, places=2, short_scale=False, scientific=False):
                     _partial = "cento"
                 else:
                     _partial = digits[q] + "cento"
-                _partial += (
-                    " " + _sub_thousand(r) if r else "")  # separa centinaia
+                # Crusca (consulenza 1077): "la grafia prevista è, tranne rare
+                # eccezioni, senza spazi: duecentodiecimila". Cardinals below a
+                # million are one fused word, so the hundreds join directly.
+                rest = _sub_thousand(r) if r else ""
+                # "cento" drops its final -o before a word beginning with o
+                # (otto, ottanta...): "centottanta", "trecentottantotto", not
+                # "centoottanta". Both ICU and num2words agree.
+                if rest.startswith("o"):
+                    _partial = _partial[:-1]
+                _partial += rest
                 return _partial
 
         def _short_scale(n):
@@ -734,7 +754,8 @@ def pronounce_number_it(number, places=2, short_scale=False, scientific=False):
                     number = number.replace(" ", "") + hundreds[i]
                 res.append(number)
 
-            return ", ".join(reversed(res))
+            # one fused word below a million ("millecentoventidue")
+            return "".join(reversed(res))
 
         def _split_by(n, split=1000):
             assert 0 <= n
@@ -753,18 +774,27 @@ def pronounce_number_it(number, places=2, short_scale=False, scientific=False):
             for i, z in enumerate(_split_by(n, 1000000)):
                 if not z:
                     continue
-                number = pronounce_number_it(z, places, True, scientific)
-                # strip off the comma after the thousand
-                if i:
-                    # plus one as we skip 'thousand'
-                    # (and 'hundred', but this is excluded by index value)
-                    # collapse the group to a single token so the following
-                    # scale word ("milioni") multiplies the whole group and
-                    # not just its trailing word
-                    number = number.replace(',', '').replace(" ", "")
-                    number += " " + hundreds[i + 1]
+                if not i:
+                    # the sub-million group is one fused word
+                    number = pronounce_number_it(z, places, True, scientific)
+                    res.append(number)
+                    continue
+                # milione/miliardo are separate words, unlike the fused "mila":
+                # "un milione", "due milioni", "un miliardo" (Crusca allows the
+                # spaced form for these large scale words). The plural table
+                # holds "milioni"/"miliardi"; 1 takes the apocopated "un" and
+                # the singular.
+                plural = hundreds[i + 1]
+                singular = _LONG_SCALE_SINGULAR_IT.get(
+                    plural, plural[:-1] + "e")
+                if z == 1:
+                    number = "un " + singular
+                else:
+                    count = pronounce_number_it(z, places, True, scientific)
+                    number = count + " " + plural
                 res.append(number)
-            return ", ".join(reversed(res))
+            # scale groups are separated by a space ("un milione duecentomila")
+            return " ".join(reversed(res))
 
         if short_scale:
             result += _short_scale(num)

--- a/tests/test_it_fusion.py
+++ b/tests/test_it_fusion.py
@@ -1,0 +1,95 @@
+"""Italian writes a cardinal below a million as one fused word.
+
+Accademia della Crusca, consulenza 1077: "la grafia prevista è, tranne rare
+eccezioni, senza spazi: duecentodiecimila e non *duecento dieci mila". So the
+whole number up to 999999 is a single word with no spaces and no commas:
+"centoventidue", "millecentoventidue", "novecentonovantanovemilanovecento-
+novantanove". The library used to insert a space inside the hundreds and a
+comma between scale groups ("mille, cento ventidue").
+
+From a million up, milione/miliardo stand as separate words -- "un milione",
+"due milioni", "un milione duecentomila" -- which Crusca notes as the practical
+form for such large numbers; both ICU and num2words agree.
+
+Two elisions surface once the word is fused, both confirmed by ICU + num2words:
+"cento" drops its -o before an o-word ("centottanta", "trecentottantotto"), and
+the singular scale word apocopates to "un" ("un milione", not "uno milioni").
+
+Source archived under papers/linguistics/it/.
+"""
+import unittest
+
+from ovos_number_parser import pronounce_number, extract_number
+
+
+class TestFusedBelowMillion(unittest.TestCase):
+    CASES = [
+        (122, "centoventidue"),
+        (123, "centoventitré"),
+        (999, "novecentonovantanove"),
+        (1122, "millecentoventidue"),
+        (1234, "milleduecentotrentaquattro"),
+        (2023, "duemilaventitré"),
+        (100000, "centomila"),
+        (210000, "duecentodiecimila"),         # Crusca's own example
+        (999999, "novecentonovantanovemilanovecentonovantanove"),
+    ]
+
+    def test_one_fused_word(self):
+        for value, expected in self.CASES:
+            with self.subTest(value=value):
+                out = pronounce_number(value, "it")
+                self.assertEqual(out, expected)
+                self.assertNotIn(" ", out)
+                self.assertNotIn(",", out)
+
+
+class TestCentoElision(unittest.TestCase):
+    """cento drops -o before an o-word (both refs agree)."""
+
+    CASES = [(108, "centotto"), (180, "centottanta"),
+             (188, "centottantotto"), (380, "trecentottanta"),
+             (788, "settecentottantotto"), (880, "ottocentottanta")]
+
+    def test_elision(self):
+        for value, expected in self.CASES:
+            with self.subTest(value=value):
+                self.assertEqual(pronounce_number(value, "it"), expected)
+
+    def test_no_elision_before_non_o(self):
+        # cento + uno keeps both vowels (centouno, not centuno)
+        self.assertEqual(pronounce_number(101, "it"), "centouno")
+
+
+class TestMillionsAreSeparateWords(unittest.TestCase):
+    CASES = [
+        (1000000, "un milione"),
+        (2000000, "due milioni"),
+        (1000000000, "un miliardo"),
+        (1234567, "un milione duecentotrentaquattromilacinquecentosessantasette"),
+    ]
+
+    def test_millions(self):
+        for value, expected in self.CASES:
+            with self.subTest(value=value):
+                self.assertEqual(pronounce_number(value, "it"), expected)
+
+
+class TestRoundTrip(unittest.TestCase):
+    """Every fused form must read back -- the extractor un-fuses and un-elides."""
+
+    def test_exhaustive(self):
+        values = list(range(0, 2001)) + [
+            10000, 21000, 100000, 210000, 999999, 1000000, 1234567,
+            3456789, 1000000000]
+        for value in values:
+            with self.subTest(value=value):
+                spoken = pronounce_number(value, "it")
+                self.assertEqual(extract_number(spoken, "it"), value)
+
+    def test_old_spaced_forms_still_parse(self):
+        # permissive: pre-fusion spellings remain valid input
+        for spelled, value in [("cento ventidue", 122),
+                              ("mille duecento", 1200)]:
+            with self.subTest(spelled=spelled):
+                self.assertEqual(extract_number(spelled, "it"), value)

--- a/tests/test_it_tre_accent.py
+++ b/tests/test_it_tre_accent.py
@@ -39,8 +39,8 @@ class TestCompoundsOfTreAreAccented(unittest.TestCase):
 
     def test_compound_inside_hundreds(self):
         # the fused tens-unit still gets the accent within a larger number
-        self.assertEqual(pronounce_number(123, "it"), "cento ventitré")
-        self.assertEqual(pronounce_number(2023, "it"), "duemila, ventitré")
+        self.assertEqual(pronounce_number(123, "it"), "centoventitré")
+        self.assertEqual(pronounce_number(2023, "it"), "duemilaventitré")
 
 
 class TestBareTreHasNoAccent(unittest.TestCase):

--- a/tests/test_number_parser_it.py
+++ b/tests/test_number_parser_it.py
@@ -7,7 +7,7 @@ class TestItalianPronounce(unittest.TestCase):
     """Anchors for spoken Italian numbers."""
 
     def test_pronounce_number(self):
-        expected = {0: 'zero', 1: 'uno', 2: 'due', 3: 'tre', 4: 'quattro', 5: 'cinque', 6: 'sei', 7: 'sette', 8: 'otto', 9: 'nove', 10: 'dieci', 11: 'undici', 12: 'dodici', 13: 'tredici', 14: 'quattordici', 15: 'quindici', 16: 'sedici', 17: 'diciassette', 18: 'diciotto', 19: 'diciannove', 20: 'venti', 21: 'ventuno', 30: 'trenta', 42: 'quarantadue', 50: 'cinquanta', 66: 'sessantasei', 70: 'settanta', 80: 'ottanta', 90: 'novanta', 99: 'novantanove', 100: 'cento', 101: 'cento uno', 123: 'cento ventitré', 200: 'duecento', 500: 'cinquecento', 999: 'novecento novantanove', 1000: 'mille', 2000: 'duemila', 2023: 'duemila, ventitré', 1000000: 'un milione', 2000000: 'due milioni'}
+        expected = {0: 'zero', 1: 'uno', 2: 'due', 3: 'tre', 4: 'quattro', 5: 'cinque', 6: 'sei', 7: 'sette', 8: 'otto', 9: 'nove', 10: 'dieci', 11: 'undici', 12: 'dodici', 13: 'tredici', 14: 'quattordici', 15: 'quindici', 16: 'sedici', 17: 'diciassette', 18: 'diciotto', 19: 'diciannove', 20: 'venti', 21: 'ventuno', 30: 'trenta', 42: 'quarantadue', 50: 'cinquanta', 66: 'sessantasei', 70: 'settanta', 80: 'ottanta', 90: 'novanta', 99: 'novantanove', 100: 'cento', 101: 'centouno', 123: 'centoventitré', 200: 'duecento', 500: 'cinquecento', 999: 'novecentonovantanove', 1000: 'mille', 2000: 'duemila', 2023: 'duemilaventitré', 1000000: 'un milione', 2000000: 'due milioni'}
         for number, spoken in expected.items():
             with self.subTest(number=number):
                 self.assertEqual(pronounce_number(number, lang="it"), spoken)
@@ -23,7 +23,7 @@ class TestItalianExtract(unittest.TestCase):
     """Anchors for extracting numbers from Italian text."""
 
     def test_extract_number(self):
-        expected = {0: 'zero', 1: 'uno', 2: 'due', 3: 'tre', 4: 'quattro', 5: 'cinque', 6: 'sei', 7: 'sette', 8: 'otto', 9: 'nove', 10: 'dieci', 11: 'undici', 12: 'dodici', 13: 'tredici', 14: 'quattordici', 15: 'quindici', 16: 'sedici', 17: 'diciassette', 18: 'diciotto', 19: 'diciannove', 20: 'venti', 21: 'ventuno', 30: 'trenta', 42: 'quarantadue', 50: 'cinquanta', 66: 'sessantasei', 70: 'settanta', 80: 'ottanta', 90: 'novanta', 99: 'novantanove', 100: 'cento', 101: 'cento uno', 123: 'cento ventitré', 200: 'duecento', 500: 'cinquecento', 999: 'novecento novantanove', 1000: 'mille', 2000: 'duemila', 2023: 'duemila, ventitré', 1000000: 'un milione', 2000000: 'due milioni'}
+        expected = {0: 'zero', 1: 'uno', 2: 'due', 3: 'tre', 4: 'quattro', 5: 'cinque', 6: 'sei', 7: 'sette', 8: 'otto', 9: 'nove', 10: 'dieci', 11: 'undici', 12: 'dodici', 13: 'tredici', 14: 'quattordici', 15: 'quindici', 16: 'sedici', 17: 'diciassette', 18: 'diciotto', 19: 'diciannove', 20: 'venti', 21: 'ventuno', 30: 'trenta', 42: 'quarantadue', 50: 'cinquanta', 66: 'sessantasei', 70: 'settanta', 80: 'ottanta', 90: 'novanta', 99: 'novantanove', 100: 'cento', 101: 'centouno', 123: 'centoventitré', 200: 'duecento', 500: 'cinquecento', 999: 'novecentonovantanove', 1000: 'mille', 2000: 'duemila', 2023: 'duemilaventitré', 1000000: 'un milione', 2000000: 'due milioni'}
         for number, spoken in expected.items():
             with self.subTest(spoken=spoken):
                 self.assertEqual(extract_number(spoken, lang="it"), number)

--- a/tests/test_pronounce_nonfinite_bignum.py
+++ b/tests/test_pronounce_nonfinite_bignum.py
@@ -75,7 +75,7 @@ class TestHugeFiniteIntegers(unittest.TestCase):
     def test_ordinary_numbers_unchanged(self):
         # the fallback must not touch in-range values
         self.assertEqual(pronounce_number(1234, "it"),
-                         "mille, duecento trentaquattro")
+                         "milleduecentotrentaquattro")
         self.assertEqual(pronounce_number(10 ** 20, "en"),
                          "one hundred quintillion")
 


### PR DESCRIPTION
`pronounce_number(1122, 'it')` returned `mille, cento ventidue` — a comma and a space that Italian never writes. Correct is **`millecentoventidue`**.

**Authority (not the libraries).** Accademia della Crusca, [consulenza 1077](https://accademiadellacrusca.it/it/consulenza/quarantaquattro-gatti-in-fila-per-sei-col-resto-di-due-o-di-quando-e-come-scrivere-i-numeri-in-lettere/1077):

> "la grafia prevista è, tranne rare eccezioni, **senza spazi**: duecentodiecimila e non *duecento dieci mila"

So a cardinal up to 999999 is one fused word. `210000` (Crusca's own example) is now `duecentodiecimila`; `999999` is `novecentonovantanovemilanovecentonovantanove`.

**Millions.** `milione`/`miliardo` stay separate words — Crusca notes the spaced form is what's used for such large numbers, and both ICU and num2words agree. The singular apocopates: `un milione`, `due milioni`, `un milione duecentomila` — fixing the old `uno milioni` bug.

**Two elisions, each adjudicated:**
- `cento` drops its `-o` before an o-word: `centottanta`, `trecentottantotto`. **Both refs agree** → fixed.
- `ventuno` before `mila`: ICU says `ventunmila`, num2words says `ventunomila`. The references **disagree** → contested, left as `ventunomila` (matches num2words).

**Round-trip preserved.** Fusing broke parsing until the extractor learned to un-fuse and un-elide (`centottanta` → `cento ottanta`); exhaustive round-trip 0–2000 plus large values and millions all pass, and the old spaced spellings still parse. The `-tré` accent (#268) now applies to the fused compounds automatically.

Folded against ICU: **zero** diffs across 0–999 plus large numbers. Suite green (1577 passed); downstream date-parser Italian unchanged (299 passed).

Completes the Italian half of the shared-engine migration item (fr still legacy — its 70/80/90 are vigesimal, a separate task).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved Italian number pronunciation with naturally fused forms for numbers below one million.
  - Added correct singular forms for large scales, such as “un milione” and “un miliardo.”
  - Improved pronunciation of hundreds before words beginning with “o.”

- **Bug Fixes**
  - Italian number extraction now reliably round-trips fused pronunciations.
  - Existing spaced number spellings remain supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->