### PR TITLE
fix: drop the plural -s on French quatre-vingt/cent before mille

### DIFF
--- a/ovos_number_parser/numbers_fr.py
+++ b/ovos_number_parser/numbers_fr.py
@@ -394,9 +394,27 @@ class FrenchNumberExtractor(RomanceNumberExtractor):
             if number == int(number):
                 number = int(number)
 
-        return super().pronounce_number(number, places, scale, ordinals,
-                                        digits, gender,
-                                        _force_hundreds_join, _under_higher_scale)
+        result = super().pronounce_number(number, places, scale, ordinals,
+                                          digits, gender,
+                                          _force_hundreds_join,
+                                          _under_higher_scale)
+        return _fix_vingt_cent_plural_fr(result)
+
+
+#: "quatre-vingts" and "cents" lose their plural -s directly before "mille".
+#: Académie française (Dictionnaire, 9e éd., "vingt"/"cent"): vingt and cent
+#: "restent invariables s'ils sont suivis d'un autre nombre ou de mille"
+#: ("quatre-vingt mille", "trois cent mille"), but they DO agree before
+#: millier/million/milliard, "qui sont des noms et non des adjectifs numéraux"
+#: ("deux cents millions"), so only " mille" drops the -s. The -s is added
+#: unconditionally when the group is a round hundred/eighty, which is correct
+#: when the group is terminal or precedes a noun scale; this trims it back for
+#: the one case where it is wrong.
+_VINGT_CENT_BEFORE_MILLE_FR = re.compile(r"(quatre-vingt|cent)s(?= mille\b)")
+
+
+def _fix_vingt_cent_plural_fr(text: str) -> str:
+    return _VINGT_CENT_BEFORE_MILLE_FR.sub(r"\1", text)
 
 
 FR = FrenchNumberExtractor(_FR)

--- a/tests/test_fr_vingt_cent_before_mille.py
+++ b/tests/test_fr_vingt_cent_before_mille.py
@@ -1,0 +1,70 @@
+"""French: "quatre-vingt" and "cent" drop their plural -s before "mille".
+
+Académie française (Dictionnaire, 9e éd., entries "vingt" / "cent"): vingt and
+cent take an -s "quand ils sont précédés d'un nombre qui les multiplie, mais
+ils restent invariables s'ils sont suivis d'un autre nombre ou de mille"
+-- so "quatre-vingt mille", "trois cent mille". They DO agree, however, before
+"millier/million/milliard, qui sont des noms et non des adjectifs numéraux":
+"deux cents millions". "mille" is the only scale word that is a numeral
+adjective, so it is the only one that strips the -s.
+
+The library kept the -s before "mille" ("quatre-vingts mille", "trois cents
+mille"). It was already correct before "millions" and when the round hundred
+ends the number. Source archived under papers/linguistics/fr/.
+
+Note ICU RBNF drops the -s before "millions" too ("quatre-vingt millions"),
+which is wrong per the Académie; the expected values here follow the Académie,
+not ICU.
+"""
+import unittest
+
+from ovos_number_parser import pronounce_number, extract_number
+
+
+class TestNoSBeforeMille(unittest.TestCase):
+    CASES = [
+        (80000, "quatre-vingt mille"),
+        (300000, "trois cent mille"),
+        (380000, "trois cent quatre-vingt mille"),
+        (280000, "deux cent quatre-vingt mille"),
+        (2080000, "deux millions quatre-vingt mille"),
+    ]
+
+    def test_drops_s(self):
+        for value, expected in self.CASES:
+            with self.subTest(value=value):
+                self.assertEqual(pronounce_number(value, "fr"), expected)
+
+
+class TestSKeptBeforeNounScalesAndWhenTerminal(unittest.TestCase):
+    """-s stays before million/milliard (nouns) and at the end of the number."""
+
+    CASES = [
+        (80, "quatre-vingts"),
+        (200, "deux cents"),
+        (280, "deux cent quatre-vingts"),
+        (80000000, "quatre-vingts millions"),
+        (300000000, "trois cents millions"),
+        (80000000000, "quatre-vingts milliards"),
+    ]
+
+    def test_keeps_s(self):
+        for value, expected in self.CASES:
+            with self.subTest(value=value):
+                self.assertEqual(pronounce_number(value, "fr"), expected)
+
+
+class TestUnaffectedCases(unittest.TestCase):
+    def test_hundred_and_ninety_forms(self):
+        # h==1 has no -s anyway; quatre-vingt-dix has no trailing -s
+        self.assertEqual(pronounce_number(100000, "fr"), "cent mille")
+        self.assertEqual(pronounce_number(90000, "fr"), "quatre-vingt-dix mille")
+
+
+class TestRoundTrip(unittest.TestCase):
+    def test_round_trip(self):
+        for value in [80, 200, 280, 80000, 90000, 100000, 300000, 380000,
+                      2080000, 80000000, 300000000]:
+            with self.subTest(value=value):
+                spoken = pronounce_number(value, "fr")
+                self.assertEqual(extract_number(spoken, "fr"), value)


### PR DESCRIPTION
`pronounce_number(80000, 'fr')` returned `quatre-vingts mille`; correct French is `quatre-vingt mille` (no `-s`). Surfaced by the French engine migration (#276) — pre-existing, not introduced by it.

**Authority — and a case where the libraries are wrong.** Académie française, [Dictionnaire 9e éd.](https://www.dictionnaire-academie.fr/article/QDL057) (entries *vingt*/*cent*):

> vingt and cent "se terminent par un s quand ils sont précédés d'un nombre qui les multiplie, mais ils **restent invariables s'ils sont suivis d'un autre nombre ou de mille**" — "quatre-vingt mille", "trois cent mille".
> "En revanche, vingt et cent **varient devant millier, million, milliard, qui sont des noms et non des adjectifs numéraux** : deux cents millions d'années."

So `mille` (a numeral adjective) strips the `-s`; `million`/`milliard` (nouns) keep it. The fix is scoped to exactly that: `quatre-vingts mille` → `quatre-vingt mille`, `trois cents mille` → `trois cent mille`, while `quatre-vingts millions`, `deux cents millions` and terminal `deux cents` are untouched.

**ICU RBNF is wrong here** — it also drops the `-s` before `millions` (`quatre-vingt millions`), contradicting the Académie. Expected values follow the grammar, not ICU. Archived under `papers/linguistics/fr/`.

Implemented as a post-composition rule in `FrenchNumberExtractor.pronounce_number`, since the `mille`-vs-`million` distinction is only known once the scale word is chosen. Tests cover the drop cases, the keep cases (nouns + terminal), the unaffected `cent mille`/`quatre-vingt-dix mille`, and round-trip. Suite green (1581 passed).