### PR TITLE
docs: rewrite README in Simplified Technical English

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,15 +9,15 @@ small dependency-light library.
 
 `ovos-number-parser` goes both ways:
 
-- **words → digits** — turn spoken-form text into numbers
-  (`extract_number`, `numbers_to_digits`). Ideal for **ASR post-processing /
+- **words to digits**: turn spoken-form text into numbers
+  (`extract_number`, `numbers_to_digits`). Use it for **ASR post-processing /
   inverse text normalization** and **numeric entity extraction**.
-- **digits → words** — turn numbers into natural spoken text
-  (`pronounce_number`, `pronounce_ordinal`, `pronounce_fraction`). Ideal for
+- **digits to words**: turn numbers into natural spoken text
+  (`pronounce_number`, `pronounce_ordinal`, `pronounce_fraction`). Use it for
   **TTS normalization** before synthesis.
 
-It ships as part of the [OpenVoiceOS](https://openvoiceos.org) voice stack, but
-it is **plain Python with no assistant dependencies** — every example below runs
+It ships as part of the [OpenVoiceOS](https://openvoiceos.org) voice stack. It
+is **plain Python with no assistant dependencies**. Every example below runs
 after a single `pip install`, with no voice assistant involved.
 
 ## Install
@@ -53,7 +53,7 @@ is_ordinal("third", "en")                 # 3
 extract_number("hello world", "en")       # False
 ```
 
-Pass a different language code and the same calls work — see the
+Pass a different language code and the same calls work. See the
 [matrix](#supported-languages) for the 40 supported languages.
 
 ## What it's good for (beyond voice assistants)
@@ -63,7 +63,7 @@ runnable script in [`examples/`](examples/):
 
 ### 1. ASR post-processing / inverse text normalization
 
-Speech-to-text emits numbers as words; most downstream systems want digits.
+Speech-to-text emits numbers as words. Most downstream systems want digits.
 
 ```python
 from ovos_number_parser import numbers_to_digits, extract_number
@@ -113,14 +113,14 @@ The same two functions cover 40 languages, with dialect prefixes
 
 ### In an OVOS skill vs. standalone
 
-The API is identical; only where you get the language code differs.
+The API is the same in both cases. Only where you get the language code differs.
 
 ```python
-# Standalone Python — you pass the language yourself
+# Standalone Python: you pass the language yourself
 from ovos_number_parser import extract_number
 n = extract_number(text, "en")
 
-# Inside an OVOS skill — the framework already knows the session language
+# Inside an OVOS skill: the framework already knows the session language
 class MySkill(OVOSSkill):
     def handle_intent(self, message):
         n = extract_number(message.data["utterance"], self.lang)
@@ -131,11 +131,11 @@ class MySkill(OVOSSkill):
 40 languages. Every language supports **every** public function: where a
 language has no hand-written implementation for a given function, a documented
 generic fallback fills in (`unicode-rbnf` for pronunciation, reverse-lookup for
-the rest — see [Full function parity](docs/languages.md#full-function-parity)),
+the rest: see [Full function parity](docs/languages.md#full-function-parity)),
 so the call always returns a sensible result rather than raising.
 
-- **Y** — dedicated hand-written implementation
-- **·** — supported via the documented generic fallback
+- **Y**: dedicated hand-written implementation
+- **·**: supported via the documented generic fallback
 
 | Code | Language | pronounce_number | pronounce_ordinal | extract_number | numbers_to_digits | is_fractional | is_ordinal |
 |------|----------|:--:|:--:|:--:|:--:|:--:|:--:|
@@ -197,16 +197,16 @@ pronounce_number(2, "pt", gender=GrammaticalGender.FEMININE)  # 'duas'
 
 ## Documentation
 
-- [API reference](docs/api.md) — every public function and its parameters
-- [Language notes](docs/languages.md) — per-language behaviour and known gaps
-- [Adding a language](docs/adding-a-language.md) — implementation guide
-- [examples/](examples/) — runnable scripts (each ends with its verified output)
+- [API reference](docs/api.md): every public function and its parameters
+- [Language notes](docs/languages.md): per-language behaviour and known gaps
+- [Adding a language](docs/adding-a-language.md): implementation guide
+- [examples/](examples/): runnable scripts (each ends with its verified output)
 
 ## Related projects
 
-- [ovos-date-parser](https://github.com/OpenVoiceOS/ovos-date-parser) — dates and times
-- [ovos-lang-parser](https://github.com/OVOSHatchery/ovos-lang-parser) — languages
-- [ovos-color-parser](https://github.com/OVOSHatchery/ovos-color-parser) — colors
+- [ovos-date-parser](https://github.com/OpenVoiceOS/ovos-date-parser): dates and times
+- [ovos-lang-parser](https://github.com/OVOSHatchery/ovos-lang-parser): languages
+- [ovos-color-parser](https://github.com/OVOSHatchery/ovos-color-parser): colors
 
 ## License
 

--- a/docs/adding-a-language.md
+++ b/docs/adding-a-language.md
@@ -6,7 +6,7 @@ and is wired into the dispatcher functions in `ovos_number_parser/__init__.py`.
 ## 1. Pick the implementation style
 
 **Romance languages** (or any language with unit/ten/hundred/scale structure
-and joiner words) should use the declarative vocabulary engine — describe the
+and joiner words) should use the declarative vocabulary engine: describe the
 language, don't reimplement the algorithm:
 
 ```python
@@ -39,8 +39,8 @@ articled scale groups ("o mie"), a count-to-scale linker word
 ("douăzeci **de** mii"), multiplicative hundreds words ("două sute" = 200)
 or particle-based ordinals ("al doilea"/"a doua") can describe those with
 `SCALE_ONE`, `SCALE_LINKER`, `SCALE_GENDERS`, `MULTIPLY_HUNDREDS`,
-`FRACTION_ONE`, `JOINER_ON_SCALE_REMAINDER` and the `ORDINAL_PREFIX` family —
-see `numbers_ro.py` for a worked example.
+`FRACTION_ONE`, `JOINER_ON_SCALE_REMAINDER` and the `ORDINAL_PREFIX` family.
+See `numbers_ro.py` for a worked example.
 
 **Other language families** implement the functions directly. Use an existing
 module of the same family as a template:
@@ -73,17 +73,20 @@ Add the language-prefix branch to each matching top-level function in
 Add `tests/test_number_parser_<code>.py` with three parts (see any existing
 language test for the pattern):
 
-1. **Pronounce anchors** — hand-verified spoken forms for a fixed set of
+1. **Pronounce anchors**: hand-verified spoken forms for a fixed set of
    values (0-20, tens, 100, 101, 123, 999, 1000, 2023, 1e6, ...).
-2. **Extract anchors** — the same table driven in reverse.
-3. **Round-trip sweep** — `extract_number(pronounce_number(n))` must return
+2. **Extract anchors**: the same table driven in reverse.
+3. **Round-trip sweep**: `extract_number(pronounce_number(n))` must return
    `n` over a wide range. This catches vocabulary typos and asymmetries
    cheaply.
 
-Anchor expectations must come from reference material or native usage —
-never trust engine output you haven't verified; a wrong anchor locks the
+Anchor expectations must come from reference material or native usage.
+Never trust engine output you have not verified. A wrong anchor locks the
 bug in.
 
 ## 5. README
 
 Add the language row to the support matrix in `README.md`.
+
+---
+[← Language notes](languages.md) · [Home](../README.md)

--- a/docs/api.md
+++ b/docs/api.md
@@ -8,20 +8,20 @@ handling where it matters, e.g. Brazilian vs European Portuguese).
 All 40 supported languages provide every public function. Where a language has
 no hand-written implementation, a documented generic fallback fills in:
 `pronounce_number` / `pronounce_ordinal` use
-[unicode-rbnf](https://github.com/rhasspy/unicode-rbnf); the rest use the
+[unicode-rbnf](https://github.com/rhasspy/unicode-rbnf). The rest use the
 parity fallbacks described in
 [Full function parity](languages.md#full-function-parity). A `lang` outside the
 supported set (or a value the fallback genuinely cannot handle) raises
 `NotImplementedError`.
 
-Every function returns `int`/`float`/`str`/`bool` as documented below; the
+Every function returns `int`/`float`/`str`/`bool` as documented below. The
 extraction and classification helpers return `False` (not `None`) when no
-number is present, so test with `is not False` rather than truthiness (a valid
-`0` or `0.0` is falsy).
+number is present. Test with `is not False` rather than truthiness, since a
+valid `0` or `0.0` is falsy.
 
 Language-specific `*_<code>` variants (e.g. `pronounce_number_de`,
 `nice_number_de`) are also importable from the top-level package if you want to
-skip the dispatcher; `nice_number_<code>` (formats a `float` as a mixed
+skip the dispatcher. `nice_number_<code>` (formats a `float` as a mixed
 fraction with a spoken denominator, e.g. `nice_number_de(5.5)` →
 `"5 und ein halb"`) has no top-level dispatcher and is only exposed
 per-language.
@@ -39,13 +39,13 @@ Convert a numeric value to its spoken form.
 'dous mil e vinte e tres'
 ```
 
-- `places` — decimal places to speak.
-- `short_scale` — short vs long scale for large numbers
+- `places`: decimal places to speak.
+- `short_scale`: short vs long scale for large numbers
   (https://en.wikipedia.org/wiki/Names_of_large_numbers).
-- `scientific` — read `5e-6` style notation aloud.
-- `ordinals` — speak `"first"` instead of `"one"`.
-- `digits` — `DigitPronunciation` enum; digit-by-digit reading styles.
-- `gender` — `GrammaticalGender` enum for languages whose numerals inflect
+- `scientific`: read `5e-6` style notation aloud.
+- `ordinals`: speak `"first"` instead of `"one"`.
+- `digits`: `DigitPronunciation` enum for digit-by-digit reading styles.
+- `gender`: `GrammaticalGender` enum for languages whose numerals inflect
   (e.g. Portuguese `"uma hora"` vs `"um minuto"`).
 
 ## `pronounce_ordinal(number, lang, short_scale=True, gender=...)`
@@ -97,6 +97,9 @@ the text intact.
 
 ## Enums
 
-- `Scale` — `Scale.SHORT` / `Scale.LONG` large-number scales.
-- `GrammaticalGender` — `MASCULINE` / `FEMININE` / `NEUTRAL`.
-- `DigitPronunciation` — full-number vs digit-by-digit reading styles.
+- `Scale`: `Scale.SHORT` / `Scale.LONG` large-number scales.
+- `GrammaticalGender`: `MASCULINE` / `FEMININE` / `NEUTRAL`.
+- `DigitPronunciation`: full-number vs digit-by-digit reading styles.
+
+---
+[Home](../README.md) · [Language notes →](languages.md)

--- a/docs/languages.md
+++ b/docs/languages.md
@@ -40,7 +40,7 @@ Portuguese, Galician, Mirandese, Asturian and Aragonese share a declarative
 `NumberVocabulary` + `RomanceNumberExtractor` implementation in
 `ovos_number_parser.util`. Each language is described by its vocabulary
 (units, tens, hundreds, scales, ordinals, fractions, gender rules and joiner
-placement); the shared engine handles pronunciation and extraction for all
+placement). The shared engine handles pronunciation and extraction for all
 of them. This is the preferred path for adding new Romance languages.
 
 Portuguese distinguishes European and Brazilian variants (`pt-PT` reads
@@ -51,7 +51,7 @@ Aragonese pronounces the general forms of the current academic norm
 (`cuatre`, `ueito`, `deciséis`, `vintiún`, `trenta y cinco`, `cient`) and
 accepts the dialectal variants (`quatre`, `güeito`, `setse`, `vente`,
 `noranta`) on extraction. Ordinals use the characteristic `-eno` series
-(`cuatreno`, `cinqueno`, `onceno`); tens ordinals above the attested range
+(`cuatreno`, `cinqueno`, `onceno`). Tens ordinals above the attested range
 follow the same productive `-eno` pattern.
 
 ## Spanish and Catalan
@@ -95,13 +95,13 @@ readings.
 ## Known gaps
 
 These are cases where the generic parity fallback (see below) is in use and
-its result is rougher than a dedicated implementation would be — the call still
+its result is rougher than a dedicated implementation would be: the call still
 returns, it is just less polished:
 
 - `fr`, `it`, `eu`, `fa` and other languages marked `·` for `numbers_to_digits`
   in the README matrix rely on the generic span-replacement fallback.
 - Polish extraction does not merge `tysiąc` groups written with the singular
-  form (`jeden tysiąc jeden`); plural forms (`dwa tysiące trzy`) work.
+  form (`jeden tysiąc jeden`). Plural forms (`dwa tysiące trzy`) work.
 - Czech pronounces four-digit numbers date-style (`1234` →
   `dvanáct třicet čtyři`), which extraction does not reverse.
 
@@ -111,7 +111,7 @@ Every supported language provides every public function. Where a language
 has no hand-written implementation, a documented generic fallback fills in:
 
 - `pronounce_fraction` reuses the language's `nice_number` fraction wording
-  (which carries its plural/declension rules) and spells out any digits; the
+  (which carries its plural/declension rules) and spells out any digits. The
   Slavic languages use feminine numerators (`dvě třetiny`, `две трети`) and
   Hungarian its `két` allomorph. Denominators outside the language's fraction
   vocabulary fall back to "cardinal numerator + ordinal denominator".
@@ -127,3 +127,6 @@ has no hand-written implementation, a documented generic fallback fills in:
 
 The parity guarantee is enforced by `tests/test_lang_parity.py`, which runs
 every public function against every supported language.
+
+---
+[← API reference](api.md) · [Home](../README.md) · [Adding a language →](adding-a-language.md)


### PR DESCRIPTION
Rewrites the README and docs/ pages for clarity: shorter sentences, no semicolons or em dashes, active voice. Adds the relative-link navigation footer to the three docs/ pages so each links back to the README and its neighbors. No facts, code examples, or the language-support matrix changed.

Rewritten by Claude Sonnet 5 using the ste-writing skill (authored and reviewed by Claude Fable 5); linted with ste_lint.py.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refined README wording, punctuation, and links.
  * Improved guidance for adding languages, testing, and navigating documentation.
  * Clarified API fallback behavior and number-extraction results.
  * Expanded language-specific notes, including ordinal, fraction, and pluralization behavior.
  * No functional or API behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->