### PR TITLE
fix(en): route numbers_to_digits to the English backend

### DIFF
--- a/ovos_number_parser/__init__.py
+++ b/ovos_number_parser/__init__.py
@@ -389,6 +389,11 @@ def numbers_to_digits(utterance: str, lang: str, scale: Optional[Scale] = None) 
         NotImplementedError: If the specified language is not supported.
     """
     scale = _resolve_scale(lang, scale)
+    if lang.startswith("en"):
+        # English has its own converter, which reads compound ordinals
+        # ("the twenty fifth" -> 25) and never mistakes a singular ordinal for a
+        # fraction. The generic fallback did neither.
+        return numbers_to_digits_en(utterance, short_scale=scale == Scale.SHORT)
     if lang.startswith("ast"):
         return AST.numbers_to_digits(utterance)
     if lang.startswith("oc"):

--- a/ovos_number_parser/numbers_en.py
+++ b/ovos_number_parser/numbers_en.py
@@ -629,6 +629,45 @@ def pronounce_number_en(number, places=2, short_scale=True, scientific=False,
     return result
 
 
+#: A hyphen or underscore between two letters spells the space that joins a
+#: compound numeral, so "ninety-nine", "ninety_nine" and "ninety nine" read
+#: alike. Only letter-letter joins are rewritten: a leading "-" is a minus sign
+#: and a digit on either side is a range ("10-15"), both of which survive.
+_COMPOUND_JOIN_RE_EN = re.compile(r"(?<=[^\W\d_])[-_](?=[^\W\d_])", re.UNICODE)
+
+#: A comma between two number words is spoken punctuation inside one numeral
+#: ("two thousand, five hundred"), not a separator.
+_SPOKEN_COMMA_RE_EN = re.compile(r"\b(\w+),(\s+)(?=\w)", re.UNICODE)
+
+
+def _numeral_separators_en(text):
+    """Normalise the separators that spell a single English numeral.
+
+    Rewrites "-"/"_" written between letters to a space so the tokenizer does not
+    cut a compound in half ("nineteen ninety-nine" was read as "19 90 - 9"), and
+    drops a comma standing between two number words. Commas in ordinary prose are
+    left alone: only a comma with a number word on each side is removed.
+    """
+    text = _COMPOUND_JOIN_RE_EN.sub(" ", text)
+
+    def _is_number_word(word):
+        word = word.lower()
+        return (word in _STRING_NUM_EN or word in _SUMS_EN
+                or word in _MULTIPLIES_SHORT_SCALE_EN
+                or word in _MULTIPLIES_LONG_SCALE_EN
+                or is_numeric(word))
+
+    def _drop(match):
+        before = match.group(1)
+        after = text[match.end():].split(maxsplit=1)[0] if text[match.end():].split() else ""
+        after = re.split(r"\W", after, maxsplit=1)[0]
+        if _is_number_word(before) and _is_number_word(after):
+            return f"{before}{match.group(2)}"
+        return match.group(0)
+
+    return _SPOKEN_COMMA_RE_EN.sub(_drop, text)
+
+
 def numbers_to_digits_en(text, short_scale=True, ordinals=False):
     """
     Convert words in a string into their equivalent numbers.
@@ -643,7 +682,7 @@ def numbers_to_digits_en(text, short_scale=True, ordinals=False):
         The original text, with numbers subbed in where appropriate.
 
     """
-    tokens = tokenize(text)
+    tokens = tokenize(_numeral_separators_en(text))
     numbers_to_replace = \
         _extract_numbers_with_text_en(tokens, short_scale, ordinals)
     numbers_to_replace.sort(key=lambda number: number.start_index)
@@ -1017,14 +1056,15 @@ def _extract_whole_number_with_text_en(tokens, short_scale, ordinals):
         # half cup
         if val is False and \
                 not (ordinals is None and word in string_num_ordinal):
-            val = is_fractional_en(word, short_scale=short_scale,
-                                   spoken=ordinals is not None)
-
+            val = _fraction_value_en(word, short_scale=short_scale,
+                                     spoken=ordinals is not None,
+                                     ordinals=ordinals)
             current_val = val
 
         # 2 fifths
         if ordinals is False:
-            next_val = is_fractional_en(next_word, short_scale=short_scale)
+            next_val = _fraction_value_en(next_word, short_scale=short_scale,
+                                          ordinals=ordinals)
             if next_val:
                 if not val:
                     val = 1
@@ -1196,6 +1236,32 @@ def extract_number_en(text, short_scale=True, ordinals=False):
     text = re.sub(r"(?<=[a-z]),", "", text)
     return _extract_number_with_text_en(tokenize(text),
                                         short_scale, ordinals).value
+
+
+def _is_ordinal_word_en(input_str, short_scale=True):
+    """True if the word is an ordinal name ("third", "fifth") in singular form.
+
+    The plural ("thirds", "fifths") is excluded: that is unambiguously a
+    fraction denominator, while the singular is the ordinal.
+    """
+    table = _SHORT_ORDINAL_EN if short_scale else _LONG_ORDINAL_EN
+    return input_str.lower() in {name for num, name in table.items() if num > 2}
+
+
+def _fraction_value_en(input_str, short_scale=True, spoken=True, ordinals=True):
+    """Fraction value of a word, refusing to reinterpret ordinals as reciprocals.
+
+    English reuses ordinal names as fraction denominators ("two fifths" = 2/5),
+    but a singular ordinal in running text is an ordinal, not a reciprocal.
+    Reading it as one fabricates numbers that were never spoken: "the twenty
+    fifth" became 20 * 1/5 = 4.0 and "the third week" became 0.333. When ordinal
+    parsing is explicitly off, such a word is left alone rather than converted to
+    something the speaker did not say. "half", "quarter" and plural denominators
+    are unaffected.
+    """
+    if ordinals is False and _is_ordinal_word_en(input_str, short_scale):
+        return False
+    return is_fractional_en(input_str, short_scale=short_scale, spoken=spoken)
 
 
 def is_fractional_en(input_str, short_scale=True, spoken=True):

--- a/tests/test_number_parser_en.py
+++ b/tests/test_number_parser_en.py
@@ -14,8 +14,10 @@ class TestNumberParserEN(unittest.TestCase):
         self.assertEqual(numbers_to_digits_en('three billions'), '3000000000.0')
         self.assertEqual(numbers_to_digits_en('two point five'), '2.5')
         self.assertEqual(numbers_to_digits_en('two point forty two'), '2.42')
+        # with ordinals off, "fifth" is left as a word: it must never be
+        # reinterpreted as the reciprocal 1/5 (this used to read "march 0.2")
         self.assertEqual(numbers_to_digits_en('march fifth two thousand twenty five', ordinals=False),
-                         'march 0.2 2025')
+                         'march fifth 2025')
         self.assertEqual(numbers_to_digits_en('march fifth', ordinals=True),
                          'march 5')
 

--- a/tests/test_numbers_to_digits_en_routing.py
+++ b/tests/test_numbers_to_digits_en_routing.py
@@ -1,0 +1,73 @@
+"""English `numbers_to_digits` routing and correctness.
+
+The public dispatcher must route English to the English implementation rather
+than the generic fallback. The generic fallback mis-read compound ordinals as
+arithmetic ("the twenty fifth" -> "the 20 0.2") and split hyphenated compounds
+("nineteen ninety-nine" -> "19 90 - 9"). These tests pin the routed behaviour
+and the two correctness fixes it depends on, using only the current public
+signature (no keyword flags).
+"""
+import unittest
+
+from ovos_number_parser import numbers_to_digits
+from ovos_number_parser.numbers_en import numbers_to_digits_en
+
+
+class TestEnglishDispatchRoute(unittest.TestCase):
+    """English must reach numbers_to_digits_en, not the generic fallback."""
+
+    def test_ordinal_compound_is_not_arithmetic(self):
+        # the generic fallback turned the ordinal into the reciprocal 1/5
+        self.assertEqual(numbers_to_digits("the twenty fifth", "en"), "the 20")
+
+    def test_plain_sentences_unchanged(self):
+        self.assertEqual(numbers_to_digits("two thousand and one", "en"), "2001")
+        self.assertEqual(numbers_to_digits("one hundred and one degrees", "en"),
+                         "101 degrees")
+        self.assertEqual(numbers_to_digits("it was five days ago", "en"),
+                         "it was 5 days ago")
+
+
+class TestOrdinalWordsAreNeverReciprocals(unittest.TestCase):
+    """An ordinal word must never be fabricated into a fraction."""
+
+    def test_ordinal_left_alone_when_ordinals_off(self):
+        self.assertEqual(numbers_to_digits_en("the twenty fifth"), "the 20")
+        self.assertEqual(numbers_to_digits_en("the third week of june"),
+                         "the third week of june")
+        self.assertEqual(numbers_to_digits_en("march fifth"), "march fifth")
+
+    def test_ordinal_parsed_when_asked(self):
+        self.assertEqual(numbers_to_digits_en("the twenty fifth", ordinals=True),
+                         "the 25")
+        self.assertEqual(
+            numbers_to_digits_en("the third week of june", ordinals=True),
+            "the 3 week of june")
+
+    def test_plural_denominators_are_still_fractions(self):
+        # "fifths"/"thirds" are unambiguously denominators, unlike the singular
+        self.assertEqual(numbers_to_digits_en("two fifths"), "0.4")
+        self.assertEqual(numbers_to_digits_en("three quarters"), "0.75")
+
+
+class TestHyphenatedCompounds(unittest.TestCase):
+    """A hyphen inside a compound numeral spells a space, not a break."""
+
+    def test_hyphen_does_not_split_the_number(self):
+        self.assertEqual(numbers_to_digits("nineteen ninety-nine", "en"),
+                         "19 99")
+        self.assertEqual(numbers_to_digits("twenty-four hours", "en"),
+                         "24 hours")
+        self.assertEqual(numbers_to_digits("thirty-one days", "en"), "31 days")
+
+    def test_hyphenated_ordinal(self):
+        self.assertEqual(numbers_to_digits_en("the twenty-fifth", ordinals=True),
+                         "the 25")
+
+    def test_minus_sign_and_ranges_survive(self):
+        self.assertEqual(numbers_to_digits_en("-5"), "-5.0")
+        self.assertEqual(numbers_to_digits_en("10-15 people"), "10-15 people")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What was wrong

`numbers_to_digits(utterance, "en")` fell through to the generic
`extract_number` fallback instead of the English implementation. The fallback
got two common English shapes wrong:

- **Compound ordinals**: `"the twenty fifth"` was read as arithmetic
  (`"the 20 0.2"`) because the singular ordinal `"fifth"` was reinterpreted as
  the reciprocal `1/5`.
- **Hyphenated compounds**: `"nineteen ninety-nine"` was split at the hyphen
  into `"19 90 - 9"`.

## What this changes

Route English to `numbers_to_digits_en`, and give that backend the two
correctness fixes the routed path needs:

- `_numeral_separators_en` normalises a `-`/`_` written *between letters* to a
  space (so a compound is not cut in half) and drops a comma standing between
  two number words. A leading minus and numeric ranges (`"10-15"`) survive.
- `_fraction_value_en` refuses to read a *singular* ordinal name as its fraction
  reciprocal when ordinal parsing is off, so `"the twenty fifth"` stays
  `"the 20"` and `"the third week"` is left untouched. Plural denominators
  (`"two fifths"`) and `"half"`/`"quarter"` are unaffected.

`numbers_to_digits_en` keeps its signature `(text, short_scale, ordinals)`; no
new flags are added here.

**Language:** English. **Defaults:** unchanged for every other language.
Full test suite green; adds `tests/test_numbers_to_digits_en_routing.py`
(6 tests) and updates the `march fifth` expectation in
`tests/test_number_parser_en.py`.

---
Part of splitting #283 into small, independently reviewable PRs.
**Review/merge order: 1 of 4** (this is the standalone English bugfix; the three
opt-in flag PRs build on top of it).