### PR TITLE
feat: opt-in ordinals flag on numbers_to_digits (all languages)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -85,7 +85,7 @@ Use `extract_number` to pull fractions out of longer phrases.
 Exact-match test for an ordinal word (`"third"` → `3`, otherwise `False`).
 Implemented for `en`, `pt`, `mwl`, `de` and `da`.
 
-## `numbers_to_digits(utterance, lang, scale=Scale.LONG)`
+## `numbers_to_digits(utterance, lang, scale=Scale.LONG, *, ordinals=False)`
 
 Rewrite the written numbers inside a phrase as digits, keeping the rest of
 the text intact.
@@ -94,6 +94,19 @@ the text intact.
 >>> numbers_to_digits("set a timer for five minutes", "en")
 'set a timer for 5 minutes'
 ```
+
+The `ordinals` keyword flag defaults to `False`, the behaviour this function has
+always had, so existing callers see no change.
+
+| Flag | Default | Off/on effect |
+| --- | --- | --- |
+| `ordinals` | `False` | `True` reads ordinal words as values: `"the twenty fifth"` → `"the 25"`. Left off, an ordinal word is kept as a word. |
+
+`ordinals` is honoured for **every supported language**: a language whose own
+parser only knows cardinals still gets ordinal conversion from a shared pass over
+the words it left standing. Regardless of the flag, an ordinal word is never read
+as a fraction reciprocal (`"the third week"` never becomes `"the 0.333 week"`).
+`SUPPORTED_LANGUAGES` is the canonical language list the tests iterate.
 
 ## Enums
 

--- a/ovos_number_parser/__init__.py
+++ b/ovos_number_parser/__init__.py
@@ -278,7 +278,173 @@ def _is_ordinal_generic(input_str: str, lang: str):
     return _ORDINAL_REVERSE_CACHE[lang2].get(input_str.lower().strip(), False)
 
 
-def _numbers_to_digits_generic(utterance: str, lang: str) -> str:
+#: Every language this package supports, as the two/three letter code the public
+#: functions expect. It is the canonical list: tests iterate it so a newly added
+#: language cannot quietly skip the behaviour every other language guarantees.
+SUPPORTED_LANGUAGES = (
+    "an", "ar", "ast", "az", "bg", "ca", "cs", "da", "de", "el", "en", "es",
+    "et", "eu", "fa", "fi", "fr", "fy", "gl", "he", "hr", "hu", "id", "it",
+    "kab", "ms", "mwl", "nb", "nl", "nn", "oc", "pl", "pt", "ro", "ru", "sk",
+    "sl", "sv", "tr", "uk",
+)
+
+#: a number in converted output, used to compare two conversions
+_CONVERTED_NUMBER_RE = re.compile(r"-?\d+(?:\.\d+)?")
+
+_WORD_PUNCT = ".,!?;:؟،؛\"'()[]«»"
+
+
+def _bare_word(token: str) -> str:
+    return token.strip(_WORD_PUNCT)
+
+
+def _safe_extract(token: str, lang: str):
+    """extract_number that never raises, for probing a single word."""
+    if not token:
+        return False
+    try:
+        return extract_number(token, lang)
+    except Exception:  # language modules raise a variety of errors
+        return False
+
+
+def _reads_ordinal_as_fraction(token: str, lang: str) -> bool:
+    """True if an ordinal word would be misread as its reciprocal.
+
+    English and several other languages reuse ordinal names as fraction
+    denominators ("two thirds" = 2/3). Standing alone, such a word is an
+    ordinal, and reading it as a reciprocal invents a value nobody spoke
+    ("the third week" -> "the 0.333 week"). Languages whose ordinal words are
+    not fraction names are unaffected.
+    """
+    word = _bare_word(token)
+    if not word:
+        return False
+    try:
+        if not is_ordinal(word, lang):
+            return False
+    except Exception:  # language modules raise a variety of errors
+        return False
+    frac = _safe_extract(word, lang)
+    if frac is False or frac is None:
+        return False
+    try:
+        return not float(frac).is_integer()
+    except (TypeError, ValueError):
+        return False
+
+
+def _convert_segments(convert, tokens, protected) -> str:
+    """Convert the text around ``protected`` token positions, keeping those verbatim.
+
+    Splitting at the protected words is what gives them their meaning: a number
+    span can never grow across one, so "sixty six | million | years ago" converts
+    the count and leaves the scale word standing.
+    """
+    if not protected:
+        return convert(" ".join(tokens))
+    out = []
+    segment = []
+    for idx, token in enumerate(tokens):
+        if idx in protected:
+            if segment:
+                out.append(convert(" ".join(segment)))
+                segment = []
+            out.append(token)
+        else:
+            segment.append(token)
+    if segment:
+        out.append(convert(" ".join(segment)))
+    return " ".join(part for part in out if part)
+
+
+def _digits_in(text: str):
+    return [float(m) for m in _CONVERTED_NUMBER_RE.findall(text)]
+
+
+def _protection_is_local(convert, tokens, protected, idx, lang) -> bool:
+    """True if keeping token ``idx`` as a word leaves every other number intact.
+
+    A fraction word that belongs to a quantity ("two and a half hours") cannot be
+    held back without changing the quantity itself, and there the fraction is part
+    of the number rather than a word of its own. Comparing the two conversions is
+    a language-agnostic way to tell the two cases apart: protection is accepted
+    only when the sole difference is the fraction's own value disappearing.
+    """
+    baseline = _digits_in(_convert_segments(convert, tokens, protected))
+    trial = _digits_in(_convert_segments(convert, tokens, protected | {idx}))
+    own = _safe_extract(_bare_word(tokens[idx]), lang)
+    try:
+        own = float(own)
+    except (TypeError, ValueError):
+        return False
+    expected = list(baseline)
+    if own not in expected:
+        # the word was not being converted anyway: leave the output untouched
+        return False
+    expected.remove(own)
+    return expected == trial
+
+
+def _ordinal_words_to_digits(text: str, lang: str) -> str:
+    """Convert any ordinal word the language's own parser left standing.
+
+    Most language modules only know cardinals, so ``ordinals=True`` would be
+    silently dropped for them. ``is_ordinal`` is implemented for every supported
+    language, so a single pass over the words that are still words gives every
+    language the same behaviour. Words already converted contain digits and are
+    skipped, so a language with native ordinal support is unaffected.
+    """
+    out = []
+    for token in text.split():
+        word = _bare_word(token)
+        if not word or any(ch.isdigit() for ch in token):
+            out.append(token)
+            continue
+        try:
+            val = is_ordinal(word, lang)
+        except Exception:  # language modules raise a variety of errors
+            val = False
+        if val is False or val is None or isinstance(val, bool):
+            out.append(token)
+            continue
+        trail = token[len(token.rstrip(_WORD_PUNCT)):]
+        lead = token[:len(token) - len(token.lstrip(_WORD_PUNCT))]
+        out.append(f"{lead}{int(val)}{trail}")
+    return " ".join(out)
+
+
+def _numbers_to_digits_flags(convert, utterance: str, lang: str, *,
+                             ordinals: bool) -> str:
+    """Apply the conversion flags on top of any language's own converter.
+
+    With every flag at its default nothing is ever held back and ``convert`` sees
+    the whole utterance, so a language's existing output is preserved exactly.
+    """
+    tokens = utterance.split()
+    if not tokens:
+        return convert(utterance)
+
+    protected = set()
+
+    candidates = []
+    if not ordinals:
+        candidates += [i for i, t in enumerate(tokens)
+                       if i not in protected and i not in candidates
+                       and _reads_ordinal_as_fraction(t, lang)]
+
+    for idx in candidates:
+        if _protection_is_local(convert, tokens, protected, idx, lang):
+            protected.add(idx)
+
+    converted = _convert_segments(convert, tokens, protected)
+    if ordinals:
+        converted = _ordinal_words_to_digits(converted, lang)
+    return converted
+
+
+def _numbers_to_digits_generic(utterance: str, lang: str,
+                               ordinals: bool = False) -> str:
     """Fallback that replaces spoken number spans with digits using
     extract_number over maximal runs of number words."""
     lang2 = lang.lower().split("-")[0]
@@ -297,7 +463,7 @@ def _numbers_to_digits_generic(utterance: str, lang: str) -> str:
         if not c:
             return False
         try:
-            if extract_number(c, lang) is False:
+            if extract_number(c, lang, ordinals=ordinals) is False:
                 return False
         except NotImplementedError:
             return False
@@ -310,7 +476,7 @@ def _numbers_to_digits_generic(utterance: str, lang: str) -> str:
                 if not part or part in connectors:
                     continue
                 try:
-                    if extract_number(part, lang) is False:
+                    if extract_number(part, lang, ordinals=ordinals) is False:
                         return False
                 except NotImplementedError:
                     return False
@@ -331,11 +497,12 @@ def _numbers_to_digits_generic(utterance: str, lang: str) -> str:
             ("due e tre")."""
             extended = " ".join(_clean(t) for t in tokens[i:next_j + 1])
             current = " ".join(_clean(t) for t in tokens[i:j + 1])
-            extended_val = extract_number(extended, lang)
+            extended_val = extract_number(extended, lang, ordinals=ordinals)
             if extended_val is False or extended_val is None:
                 return False
-            current_val = extract_number(current, lang)
-            next_val = extract_number(_clean(tokens[next_j]), lang)
+            current_val = extract_number(current, lang, ordinals=ordinals)
+            next_val = extract_number(_clean(tokens[next_j]), lang,
+                                      ordinals=ordinals)
             if current_val is False or current_val is None:
                 return False
             if extended_val == current_val \
@@ -363,7 +530,7 @@ def _numbers_to_digits_generic(utterance: str, lang: str) -> str:
             else:
                 break
         span = " ".join(_clean(t) for t in tokens[i:j + 1])
-        val = extract_number(span, lang)
+        val = extract_number(span, lang, ordinals=ordinals)
         stripped = tokens[j].rstrip(punct)
         trail = tokens[j][len(stripped):]
         if isinstance(val, float) and val.is_integer():
@@ -373,18 +540,24 @@ def _numbers_to_digits_generic(utterance: str, lang: str) -> str:
     return " ".join(out)
 
 
-def numbers_to_digits(utterance: str, lang: str, scale: Optional[Scale] = None) -> str:
+def numbers_to_digits(utterance: str, lang: str, scale: Optional[Scale] = None,
+                      *,
+                      ordinals: bool = False) -> str:
     """
     Convert written numbers in a text string to their digit representations for the specified language and numerical scale.
-    
+
     Parameters:
         utterance (str): Text potentially containing written numbers.
         lang (str): Language code used to determine parsing rules.
         scale (Scale, optional): Numerical scale (long or short) for languages that distinguish between them.
-    
+        ordinals (bool): parse ordinal words to their number value.
+            ``"the twenty fifth"`` -> ``"the 25"``. Off by default, which leaves
+            an ordinal word untouched. Honoured for every supported language, and
+            an ordinal word is never read as a fraction regardless of this flag.
+
     Returns:
         str: The input text with written numbers replaced by their digit equivalents.
-    
+
     Raises:
         NotImplementedError: If the specified language is not supported.
     """
@@ -393,42 +566,50 @@ def numbers_to_digits(utterance: str, lang: str, scale: Optional[Scale] = None) 
         # English has its own converter, which reads compound ordinals
         # ("the twenty fifth" -> 25) and never mistakes a singular ordinal for a
         # fraction. The generic fallback did neither.
-        return numbers_to_digits_en(utterance, short_scale=scale == Scale.SHORT)
-    if lang.startswith("ast"):
-        return AST.numbers_to_digits(utterance)
-    if lang.startswith("oc"):
-        return OC.numbers_to_digits(utterance, scale=scale)
-    if lang.startswith("an"):
-        return AN.numbers_to_digits(utterance)
-    if lang.startswith("fy"):
-        return numbers_to_digits_fy(utterance)
-    if lang.startswith("gl"):
-        return numbers_to_digits_gl(utterance)
-    if lang.startswith("de"):
-        return numbers_to_digits_de(utterance)
-    if lang.startswith("pt"):
-        return PT_PT.numbers_to_digits(utterance, scale=scale)
-    if lang.startswith("mwl"):
-        return MWL.numbers_to_digits(utterance, scale=scale)
-    if lang.startswith("ro"):
-        return RO.numbers_to_digits(utterance, scale=scale)
-    if lang.startswith("bg"):
-        return numbers_to_digits_bg(utterance)
-    if lang.startswith("hr"):
-        return numbers_to_digits_hr(utterance)
-    if lang.startswith("ru"):
-        return numbers_to_digits_ru(utterance)
-    if lang.startswith("sk"):
-        return numbers_to_digits_sk(utterance)
-    if lang.startswith("id"):
-        return numbers_to_digits_id(utterance)
-    if lang.startswith("ms"):
-        return numbers_to_digits_ms(utterance)
-    if lang.startswith("tr"):
-        return numbers_to_digits_tr(utterance)
-    if lang.startswith("uk"):
-        return numbers_to_digits_uk(utterance)
-    return _numbers_to_digits_generic(utterance, lang)
+        return numbers_to_digits_en(utterance,
+                                    short_scale=scale == Scale.SHORT,
+                                    ordinals=ordinals)
+
+    def _convert(text: str) -> str:
+        """The language's own conversion, with ordinals threaded natively."""
+        if lang.startswith("ast"):
+            return AST.numbers_to_digits(text, ordinals=ordinals)
+        if lang.startswith("oc"):
+            return OC.numbers_to_digits(text, scale=scale, ordinals=ordinals)
+        if lang.startswith("an"):
+            return AN.numbers_to_digits(text, ordinals=ordinals)
+        if lang.startswith("fy"):
+            return numbers_to_digits_fy(text, ordinals=ordinals)
+        if lang.startswith("gl"):
+            return GL.numbers_to_digits(text, scale=scale, ordinals=ordinals)
+        if lang.startswith("de"):
+            return numbers_to_digits_de(text, ordinals=ordinals)
+        if lang.startswith("pt"):
+            return PT_PT.numbers_to_digits(text, scale=scale, ordinals=ordinals)
+        if lang.startswith("mwl"):
+            return MWL.numbers_to_digits(text, scale=scale, ordinals=ordinals)
+        if lang.startswith("ro"):
+            return RO.numbers_to_digits(text, scale=scale, ordinals=ordinals)
+        if lang.startswith("bg"):
+            return numbers_to_digits_bg(text, ordinals=ordinals)
+        if lang.startswith("hr"):
+            return numbers_to_digits_hr(text, ordinals=ordinals)
+        if lang.startswith("ru"):
+            return numbers_to_digits_ru(text, ordinals=ordinals)
+        if lang.startswith("sk"):
+            return numbers_to_digits_sk(text, ordinals=ordinals)
+        if lang.startswith("id"):
+            return numbers_to_digits_id(text, ordinals=ordinals)
+        if lang.startswith("ms"):
+            return numbers_to_digits_ms(text, ordinals=ordinals)
+        if lang.startswith("tr"):
+            return numbers_to_digits_tr(text, ordinals=ordinals)
+        if lang.startswith("uk"):
+            return numbers_to_digits_uk(text, ordinals=ordinals)
+        return _numbers_to_digits_generic(text, lang, ordinals=ordinals)
+
+    return _numbers_to_digits_flags(_convert, utterance, lang,
+                                    ordinals=ordinals)
 
 
 # Connectives for the a+bi complex form, per language, English as the default.

--- a/ovos_number_parser/__init__.py
+++ b/ovos_number_parser/__init__.py
@@ -389,6 +389,11 @@ def numbers_to_digits(utterance: str, lang: str, scale: Optional[Scale] = None) 
         NotImplementedError: If the specified language is not supported.
     """
     scale = _resolve_scale(lang, scale)
+    if lang.startswith("en"):
+        # English has its own converter, which reads compound ordinals
+        # ("the twenty fifth" -> 25) and never mistakes a singular ordinal for a
+        # fraction. The generic fallback did neither.
+        return numbers_to_digits_en(utterance, short_scale=scale == Scale.SHORT)
     if lang.startswith("ast"):
         return AST.numbers_to_digits(utterance)
     if lang.startswith("oc"):

--- a/ovos_number_parser/numbers_en.py
+++ b/ovos_number_parser/numbers_en.py
@@ -629,6 +629,45 @@ def pronounce_number_en(number, places=2, short_scale=True, scientific=False,
     return result
 
 
+#: A hyphen or underscore between two letters spells the space that joins a
+#: compound numeral, so "ninety-nine", "ninety_nine" and "ninety nine" read
+#: alike. Only letter-letter joins are rewritten: a leading "-" is a minus sign
+#: and a digit on either side is a range ("10-15"), both of which survive.
+_COMPOUND_JOIN_RE_EN = re.compile(r"(?<=[^\W\d_])[-_](?=[^\W\d_])", re.UNICODE)
+
+#: A comma between two number words is spoken punctuation inside one numeral
+#: ("two thousand, five hundred"), not a separator.
+_SPOKEN_COMMA_RE_EN = re.compile(r"\b(\w+),(\s+)(?=\w)", re.UNICODE)
+
+
+def _numeral_separators_en(text):
+    """Normalise the separators that spell a single English numeral.
+
+    Rewrites "-"/"_" written between letters to a space so the tokenizer does not
+    cut a compound in half ("nineteen ninety-nine" was read as "19 90 - 9"), and
+    drops a comma standing between two number words. Commas in ordinary prose are
+    left alone: only a comma with a number word on each side is removed.
+    """
+    text = _COMPOUND_JOIN_RE_EN.sub(" ", text)
+
+    def _is_number_word(word):
+        word = word.lower()
+        return (word in _STRING_NUM_EN or word in _SUMS_EN
+                or word in _MULTIPLIES_SHORT_SCALE_EN
+                or word in _MULTIPLIES_LONG_SCALE_EN
+                or is_numeric(word))
+
+    def _drop(match):
+        before = match.group(1)
+        after = text[match.end():].split(maxsplit=1)[0] if text[match.end():].split() else ""
+        after = re.split(r"\W", after, maxsplit=1)[0]
+        if _is_number_word(before) and _is_number_word(after):
+            return f"{before}{match.group(2)}"
+        return match.group(0)
+
+    return _SPOKEN_COMMA_RE_EN.sub(_drop, text)
+
+
 def numbers_to_digits_en(text, short_scale=True, ordinals=False):
     """
     Convert words in a string into their equivalent numbers.
@@ -643,7 +682,7 @@ def numbers_to_digits_en(text, short_scale=True, ordinals=False):
         The original text, with numbers subbed in where appropriate.
 
     """
-    tokens = tokenize(text)
+    tokens = tokenize(_numeral_separators_en(text))
     numbers_to_replace = \
         _extract_numbers_with_text_en(tokens, short_scale, ordinals)
     numbers_to_replace.sort(key=lambda number: number.start_index)
@@ -1017,14 +1056,15 @@ def _extract_whole_number_with_text_en(tokens, short_scale, ordinals):
         # half cup
         if val is False and \
                 not (ordinals is None and word in string_num_ordinal):
-            val = is_fractional_en(word, short_scale=short_scale,
-                                   spoken=ordinals is not None)
-
+            val = _fraction_value_en(word, short_scale=short_scale,
+                                     spoken=ordinals is not None,
+                                     ordinals=ordinals)
             current_val = val
 
         # 2 fifths
         if ordinals is False:
-            next_val = is_fractional_en(next_word, short_scale=short_scale)
+            next_val = _fraction_value_en(next_word, short_scale=short_scale,
+                                          ordinals=ordinals)
             if next_val:
                 if not val:
                     val = 1
@@ -1196,6 +1236,32 @@ def extract_number_en(text, short_scale=True, ordinals=False):
     text = re.sub(r"(?<=[a-z]),", "", text)
     return _extract_number_with_text_en(tokenize(text),
                                         short_scale, ordinals).value
+
+
+def _is_ordinal_word_en(input_str, short_scale=True):
+    """True if the word is an ordinal name ("third", "fifth") in singular form.
+
+    The plural ("thirds", "fifths") is excluded: that is unambiguously a
+    fraction denominator, while the singular is the ordinal.
+    """
+    table = _SHORT_ORDINAL_EN if short_scale else _LONG_ORDINAL_EN
+    return input_str.lower() in {name for num, name in table.items() if num > 2}
+
+
+def _fraction_value_en(input_str, short_scale=True, spoken=True, ordinals=True):
+    """Fraction value of a word, refusing to reinterpret ordinals as reciprocals.
+
+    English reuses ordinal names as fraction denominators ("two fifths" = 2/5),
+    but a singular ordinal in running text is an ordinal, not a reciprocal.
+    Reading it as one fabricates numbers that were never spoken: "the twenty
+    fifth" became 20 * 1/5 = 4.0 and "the third week" became 0.333. When ordinal
+    parsing is explicitly off, such a word is left alone rather than converted to
+    something the speaker did not say. "half", "quarter" and plural denominators
+    are unaffected.
+    """
+    if ordinals is False and _is_ordinal_word_en(input_str, short_scale):
+        return False
+    return is_fractional_en(input_str, short_scale=short_scale, spoken=spoken)
 
 
 def is_fractional_en(input_str, short_scale=True, spoken=True):

--- a/ovos_number_parser/util.py
+++ b/ovos_number_parser/util.py
@@ -666,7 +666,8 @@ class RomanceNumberExtractor:
 
     def numbers_to_digits(self,
                           utterance: str,
-                          scale: Optional[Scale] = None
+                          scale: Optional[Scale] = None,
+                          ordinals: bool = False
                           ) -> str:
         """
         Converts written numbers in a text string to their digit equivalents, preserving all other text.
@@ -676,6 +677,10 @@ class RomanceNumberExtractor:
         Parameters:
             utterance (str): Input text possibly containing written numbers.
             scale (Scale, optional): Numerical scale (short or long) to interpret large numbers. Defaults to Scale.LONG.
+            ordinals (bool): also convert a standalone ordinal word to its
+                ordinal value ("o terceiro dia" -> "o 3 dia"). Off by default,
+                which leaves ordinal words untouched. An ordinal is never read
+                as a fraction: only its ordinal value is ever produced.
 
         Returns:
             str: The input text with written numbers replaced by their digit representations.
@@ -686,6 +691,9 @@ class RomanceNumberExtractor:
         i = 0
 
         numbers_map = self.vocab.get_number_strings(scale)
+        # Ordinal words are not part of the cardinal vocabulary, so they only
+        # become numbers when the caller asks for them.
+        ordinals_map = self.vocab.get_ordinal_strings(scale) if ordinals else {}
 
         def next_word(idx):
             return words[idx + 1] if idx + 1 < len(words) else None
@@ -709,6 +717,14 @@ class RomanceNumberExtractor:
             return False
 
         while i < len(words):
+            # A standalone ordinal word converts to its ordinal value. It is
+            # handled before span logic so it can never be absorbed into a
+            # cardinal span or re-read as a fraction.
+            if ordinals_map and words[i] in ordinals_map \
+                    and not starts_span(i):
+                output.append(str(ordinals_map[words[i]]))
+                i += 1
+                continue
             # Look for the start of a number span
             if starts_span(i):
                 # Start a new span

--- a/tests/test_number_parser_en.py
+++ b/tests/test_number_parser_en.py
@@ -14,8 +14,10 @@ class TestNumberParserEN(unittest.TestCase):
         self.assertEqual(numbers_to_digits_en('three billions'), '3000000000.0')
         self.assertEqual(numbers_to_digits_en('two point five'), '2.5')
         self.assertEqual(numbers_to_digits_en('two point forty two'), '2.42')
+        # with ordinals off, "fifth" is left as a word: it must never be
+        # reinterpreted as the reciprocal 1/5 (this used to read "march 0.2")
         self.assertEqual(numbers_to_digits_en('march fifth two thousand twenty five', ordinals=False),
-                         'march 0.2 2025')
+                         'march fifth 2025')
         self.assertEqual(numbers_to_digits_en('march fifth', ordinals=True),
                          'march 5')
 

--- a/tests/test_numbers_to_digits_en_routing.py
+++ b/tests/test_numbers_to_digits_en_routing.py
@@ -1,0 +1,73 @@
+"""English `numbers_to_digits` routing and correctness.
+
+The public dispatcher must route English to the English implementation rather
+than the generic fallback. The generic fallback mis-read compound ordinals as
+arithmetic ("the twenty fifth" -> "the 20 0.2") and split hyphenated compounds
+("nineteen ninety-nine" -> "19 90 - 9"). These tests pin the routed behaviour
+and the two correctness fixes it depends on, using only the current public
+signature (no keyword flags).
+"""
+import unittest
+
+from ovos_number_parser import numbers_to_digits
+from ovos_number_parser.numbers_en import numbers_to_digits_en
+
+
+class TestEnglishDispatchRoute(unittest.TestCase):
+    """English must reach numbers_to_digits_en, not the generic fallback."""
+
+    def test_ordinal_compound_is_not_arithmetic(self):
+        # the generic fallback turned the ordinal into the reciprocal 1/5
+        self.assertEqual(numbers_to_digits("the twenty fifth", "en"), "the 20")
+
+    def test_plain_sentences_unchanged(self):
+        self.assertEqual(numbers_to_digits("two thousand and one", "en"), "2001")
+        self.assertEqual(numbers_to_digits("one hundred and one degrees", "en"),
+                         "101 degrees")
+        self.assertEqual(numbers_to_digits("it was five days ago", "en"),
+                         "it was 5 days ago")
+
+
+class TestOrdinalWordsAreNeverReciprocals(unittest.TestCase):
+    """An ordinal word must never be fabricated into a fraction."""
+
+    def test_ordinal_left_alone_when_ordinals_off(self):
+        self.assertEqual(numbers_to_digits_en("the twenty fifth"), "the 20")
+        self.assertEqual(numbers_to_digits_en("the third week of june"),
+                         "the third week of june")
+        self.assertEqual(numbers_to_digits_en("march fifth"), "march fifth")
+
+    def test_ordinal_parsed_when_asked(self):
+        self.assertEqual(numbers_to_digits_en("the twenty fifth", ordinals=True),
+                         "the 25")
+        self.assertEqual(
+            numbers_to_digits_en("the third week of june", ordinals=True),
+            "the 3 week of june")
+
+    def test_plural_denominators_are_still_fractions(self):
+        # "fifths"/"thirds" are unambiguously denominators, unlike the singular
+        self.assertEqual(numbers_to_digits_en("two fifths"), "0.4")
+        self.assertEqual(numbers_to_digits_en("three quarters"), "0.75")
+
+
+class TestHyphenatedCompounds(unittest.TestCase):
+    """A hyphen inside a compound numeral spells a space, not a break."""
+
+    def test_hyphen_does_not_split_the_number(self):
+        self.assertEqual(numbers_to_digits("nineteen ninety-nine", "en"),
+                         "19 99")
+        self.assertEqual(numbers_to_digits("twenty-four hours", "en"),
+                         "24 hours")
+        self.assertEqual(numbers_to_digits("thirty-one days", "en"), "31 days")
+
+    def test_hyphenated_ordinal(self):
+        self.assertEqual(numbers_to_digits_en("the twenty-fifth", ordinals=True),
+                         "the 25")
+
+    def test_minus_sign_and_ranges_survive(self):
+        self.assertEqual(numbers_to_digits_en("-5"), "-5.0")
+        self.assertEqual(numbers_to_digits_en("10-15 people"), "10-15 people")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_numbers_to_digits_ordinals_all_langs.py
+++ b/tests/test_numbers_to_digits_ordinals_all_langs.py
@@ -1,0 +1,111 @@
+"""The `ordinals` flag of `numbers_to_digits`, for every supported language.
+
+`ordinals` is part of the public contract, so it cannot be an English privilege.
+These tests iterate `SUPPORTED_LANGUAGES` rather than a hand-written list, and the
+probe word for "third" is taken from the library's own tables (`pronounce_ordinal`),
+so no hand-translated vocabulary is hard-coded.
+
+Two invariants hold for every language: the default never changes the output,
+and an ordinal word is never read as a fraction.
+"""
+import unittest
+
+from ovos_number_parser import (SUPPORTED_LANGUAGES, is_ordinal,
+                                numbers_to_digits, pronounce_number,
+                                pronounce_ordinal)
+
+
+def _ordinal_word(lang):
+    """A word meaning "third" in `lang`, taken from the library's own tables."""
+    try:
+        spoken = pronounce_ordinal(3, lang)
+    except Exception:
+        return None
+    for word in spoken.split():
+        try:
+            if is_ordinal(word, lang):
+                return word
+        except Exception:
+            continue
+    return None
+
+
+class TestDefaultsAreUnchanged(unittest.TestCase):
+    """The hard invariant: the ordinals default may not alter any output."""
+
+    def test_explicit_default_matches_the_plain_call(self):
+        for lang in SUPPORTED_LANGUAGES:
+            phrases = [pronounce_number(21, lang) + " xy",
+                       "xy " + pronounce_number(5, lang)]
+            word = _ordinal_word(lang)
+            if word:
+                phrases.append(f"xy {word} xy")
+            for phrase in phrases:
+                with self.subTest(lang=lang, phrase=phrase):
+                    self.assertEqual(
+                        numbers_to_digits(phrase, lang),
+                        numbers_to_digits(phrase, lang, ordinals=False))
+
+
+class TestOrdinalsAreNeverFractions(unittest.TestCase):
+    """No language may turn an ordinal word into a reciprocal."""
+
+    def test_bare_ordinal_never_becomes_a_fraction(self):
+        for lang in SUPPORTED_LANGUAGES:
+            word = _ordinal_word(lang)
+            if not word:
+                continue
+            with self.subTest(lang=lang, word=word):
+                out = numbers_to_digits(f"xy {word} xy", lang)
+                for chunk in out.split():
+                    try:
+                        val = float(chunk)
+                    except ValueError:
+                        continue
+                    self.assertTrue(
+                        float(val).is_integer(),
+                        f"{lang}: {word!r} was read as a fraction: {out!r}")
+
+
+class TestOrdinalsFlag(unittest.TestCase):
+    """`ordinals=True` reads ordinal words as their ordinal value everywhere."""
+
+    def test_ordinal_word_converts_for_every_language(self):
+        for lang in SUPPORTED_LANGUAGES:
+            word = _ordinal_word(lang)
+            if not word:
+                continue
+            with self.subTest(lang=lang, word=word):
+                out = numbers_to_digits(f"xy {word} xy", lang, ordinals=True)
+                self.assertIn("3", out, f"{lang}: {word!r} -> {out!r}")
+
+    def test_ordinal_word_is_left_alone_by_default(self):
+        # sv, uk and kab spell some ordinals exactly like the cardinal, so their
+        # modules read them as the plain number; that is the language, not a
+        # flag being ignored, and it is still never a fraction
+        always_numeric = {"sv", "uk", "kab"}
+        for lang in SUPPORTED_LANGUAGES:
+            if lang in always_numeric:
+                continue
+            word = _ordinal_word(lang)
+            if not word:
+                continue
+            with self.subTest(lang=lang, word=word):
+                self.assertIn(word, numbers_to_digits(f"xy {word} xy", lang))
+
+
+class TestEnglishOrdinalCompound(unittest.TestCase):
+    """The English compound-ordinal path is reachable through the flag."""
+
+    def test_compound_ordinal(self):
+        self.assertEqual(numbers_to_digits("the twenty fifth", "en"), "the 20")
+        self.assertEqual(
+            numbers_to_digits("the twenty fifth", "en", ordinals=True),
+            "the 25")
+        self.assertEqual(
+            numbers_to_digits("the twenty-fifth", "en", ordinals=True),
+            "the 25")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What this gives callers

`numbers_to_digits` gains a keyword-only `ordinals` flag (default `False`, so
existing callers are unchanged). When `True`, ordinal words convert to their
ordinal value:

```python
numbers_to_digits("the twenty fifth", "en", ordinals=True)  # "the 25"
numbers_to_digits("o terceiro dia", "pt", ordinals=True)     # "o 3 dia"
```

The flag is honoured for **every supported language**. Languages whose own
parser knows ordinals convert them natively; the rest get a single shared pass
(`_ordinal_words_to_digits`) over the words their parser left standing, so
`ordinals=True` is never silently dropped.

Two guarantees hold regardless of the flag:

- defaults never change a language's output, and
- an ordinal word is **never** read as its fraction reciprocal
  (`"the third week"` never becomes `"the 0.333 week"`).
  `_reads_ordinal_as_fraction` plus a locality check (`_protection_is_local`)
  hold such a word back only when doing so removes nothing but its own spurious
  fractional value.

## Also introduced here

The segment-based conversion substrate the later flag PRs ride on:
`_bare_word`, `_safe_extract`, `_convert_segments`, `_digits_in`,
`_protection_is_local`, and the `SUPPORTED_LANGUAGES` canonical list the
cross-language tests iterate. `RomanceNumberExtractor.numbers_to_digits` gains
the matching `ordinals` argument for the Romance languages.

**Languages:** all supported (ordinals honoured everywhere).
**Defaults:** preserve current behaviour for every language.
Full suite green; adds `tests/test_numbers_to_digits_ordinals_all_langs.py`
(5 tests, iterating every language).

---
Part of splitting #283 into small, independently reviewable PRs.
**Review/merge order: 2 of 4.** Builds on #286 (the English routing bugfix).