### PR TITLE
feat: opt-in scale_words flag on numbers_to_digits (all languages)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -85,7 +85,7 @@ Use `extract_number` to pull fractions out of longer phrases.
 Exact-match test for an ordinal word (`"third"` → `3`, otherwise `False`).
 Implemented for `en`, `pt`, `mwl`, `de` and `da`.
 
-## `numbers_to_digits(utterance, lang, scale=Scale.LONG, *, ordinals=False, fractions=True)`
+## `numbers_to_digits(utterance, lang, scale=Scale.LONG, *, ordinals=False, fractions=True, scale_words=True)`
 
 Rewrite the written numbers inside a phrase as digits, keeping the rest of
 the text intact.
@@ -95,29 +95,43 @@ the text intact.
 'set a timer for 5 minutes'
 ```
 
-The keyword flags each default to the conversion this function has always done,
-so existing callers see no change.
+Three keyword flags tune what counts as a number. Each defaults to the
+conversion this function has always done, so existing callers see no change.
 
 | Flag | Default | Off/on effect |
 | --- | --- | --- |
 | `ordinals` | `False` | `True` reads ordinal words as values: `"the twenty fifth"` → `"the 25"`. Left off, an ordinal word is kept as a word. |
 | `fractions` | `True` | `False` keeps a *bare* fraction word: `"half past nine"` → `"half past 9"`. A fraction inside a quantity always converts: `"two and a half hours"` → `"2.5 hours"`. |
+| `scale_words` | `True` | `False` converts only the count and keeps the scale word: `"sixty six million years ago"` → `"66 million years ago"`. |
 
 ```python
 >>> numbers_to_digits("a quarter to five", "en", fractions=False)
 'a quarter to 5'
+>>> numbers_to_digits("sixty six million years ago", "en", scale_words=False)
+'66 million years ago'
 ```
 
-`ordinals` is honoured for **every supported language**: a language whose own
-parser only knows cardinals still gets ordinal conversion from a shared pass over
-the words it left standing. Regardless of the flag, an ordinal word is never read
-as a fraction reciprocal (`"the third week"` never becomes `"the 0.333 week"`).
+### Language support
 
-`fractions` is honoured for every language too. A handful of languages (`an`,
-`ast`, `fa`, `gl`, `id`, `ms`, `mwl`, `oc`, `pt`, `ro`) never converted a bare
-fraction word to begin with, so the word already survives and the flag has
-nothing left to do; no language returns something *other* than what the flag
-asks for. `SUPPORTED_LANGUAGES` is the canonical language list the tests iterate.
+All three flags are honoured for **every supported language**, and `ordinals`
+works everywhere without exception. Regardless of any flag, an ordinal word is
+never read as a fraction reciprocal (`"the third week"` never becomes
+`"the 0.333 week"`). For `fractions` and `scale_words` a handful of languages
+have nothing to suppress: their parser never converted that kind of word in the
+first place, so the word already survives and the flag has nothing left to do.
+
+| Flag | Fully applied | Nothing to suppress (word already survives) |
+| --- | --- | --- |
+| `ordinals` | all languages | — |
+| `fractions` | ar, az, bg, ca, cs, da, de, el, en, es, et, eu, fi, fr, fy, he, hr, hu, it, nb, nl, nn, pl, ru, sk, sl, sv, tr, uk | an, ast, fa, gl, id, ms, mwl, oc, pt, ro |
+| `scale_words` | an, ar, ast, az, bg, ca, cs, da, el, en, es, et, eu, fa, fi, fr, fy, gl, he, hr, hu, it, mwl, nb, nl, nn, oc, pl, pt, ro, ru, sk, sl, sv, tr, uk | de, id, ms |
+
+`kab` counts only to 9999 and has neither scale nor fraction vocabulary, so
+those two flags cannot apply to it; `ordinals` does.
+
+No language ever returns something *other* than what a flag asks for. The table
+lives in `tests/test_numbers_to_digits_flags_all_langs.py`, which iterates
+`SUPPORTED_LANGUAGES` and fails if a newly added language is not declared.
 
 ## Enums
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -85,7 +85,7 @@ Use `extract_number` to pull fractions out of longer phrases.
 Exact-match test for an ordinal word (`"third"` → `3`, otherwise `False`).
 Implemented for `en`, `pt`, `mwl`, `de` and `da`.
 
-## `numbers_to_digits(utterance, lang, scale=Scale.LONG, *, ordinals=False)`
+## `numbers_to_digits(utterance, lang, scale=Scale.LONG, *, ordinals=False, fractions=True)`
 
 Rewrite the written numbers inside a phrase as digits, keeping the rest of
 the text intact.
@@ -95,18 +95,29 @@ the text intact.
 'set a timer for 5 minutes'
 ```
 
-The `ordinals` keyword flag defaults to `False`, the behaviour this function has
-always had, so existing callers see no change.
+The keyword flags each default to the conversion this function has always done,
+so existing callers see no change.
 
 | Flag | Default | Off/on effect |
 | --- | --- | --- |
 | `ordinals` | `False` | `True` reads ordinal words as values: `"the twenty fifth"` → `"the 25"`. Left off, an ordinal word is kept as a word. |
+| `fractions` | `True` | `False` keeps a *bare* fraction word: `"half past nine"` → `"half past 9"`. A fraction inside a quantity always converts: `"two and a half hours"` → `"2.5 hours"`. |
+
+```python
+>>> numbers_to_digits("a quarter to five", "en", fractions=False)
+'a quarter to 5'
+```
 
 `ordinals` is honoured for **every supported language**: a language whose own
 parser only knows cardinals still gets ordinal conversion from a shared pass over
 the words it left standing. Regardless of the flag, an ordinal word is never read
 as a fraction reciprocal (`"the third week"` never becomes `"the 0.333 week"`).
-`SUPPORTED_LANGUAGES` is the canonical language list the tests iterate.
+
+`fractions` is honoured for every language too. A handful of languages (`an`,
+`ast`, `fa`, `gl`, `id`, `ms`, `mwl`, `oc`, `pt`, `ro`) never converted a bare
+fraction word to begin with, so the word already survives and the flag has
+nothing left to do; no language returns something *other* than what the flag
+asks for. `SUPPORTED_LANGUAGES` is the canonical language list the tests iterate.
 
 ## Enums
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -85,7 +85,7 @@ Use `extract_number` to pull fractions out of longer phrases.
 Exact-match test for an ordinal word (`"third"` → `3`, otherwise `False`).
 Implemented for `en`, `pt`, `mwl`, `de` and `da`.
 
-## `numbers_to_digits(utterance, lang, scale=Scale.LONG)`
+## `numbers_to_digits(utterance, lang, scale=Scale.LONG, *, ordinals=False)`
 
 Rewrite the written numbers inside a phrase as digits, keeping the rest of
 the text intact.
@@ -94,6 +94,19 @@ the text intact.
 >>> numbers_to_digits("set a timer for five minutes", "en")
 'set a timer for 5 minutes'
 ```
+
+The `ordinals` keyword flag defaults to `False`, the behaviour this function has
+always had, so existing callers see no change.
+
+| Flag | Default | Off/on effect |
+| --- | --- | --- |
+| `ordinals` | `False` | `True` reads ordinal words as values: `"the twenty fifth"` → `"the 25"`. Left off, an ordinal word is kept as a word. |
+
+`ordinals` is honoured for **every supported language**: a language whose own
+parser only knows cardinals still gets ordinal conversion from a shared pass over
+the words it left standing. Regardless of the flag, an ordinal word is never read
+as a fraction reciprocal (`"the third week"` never becomes `"the 0.333 week"`).
+`SUPPORTED_LANGUAGES` is the canonical language list the tests iterate.
 
 ## Enums
 

--- a/ovos_number_parser/__init__.py
+++ b/ovos_number_parser/__init__.py
@@ -278,7 +278,173 @@ def _is_ordinal_generic(input_str: str, lang: str):
     return _ORDINAL_REVERSE_CACHE[lang2].get(input_str.lower().strip(), False)
 
 
-def _numbers_to_digits_generic(utterance: str, lang: str) -> str:
+#: Every language this package supports, as the two/three letter code the public
+#: functions expect. It is the canonical list: tests iterate it so a newly added
+#: language cannot quietly skip the behaviour every other language guarantees.
+SUPPORTED_LANGUAGES = (
+    "an", "ar", "ast", "az", "bg", "ca", "cs", "da", "de", "el", "en", "es",
+    "et", "eu", "fa", "fi", "fr", "fy", "gl", "he", "hr", "hu", "id", "it",
+    "kab", "ms", "mwl", "nb", "nl", "nn", "oc", "pl", "pt", "ro", "ru", "sk",
+    "sl", "sv", "tr", "uk",
+)
+
+#: a number in converted output, used to compare two conversions
+_CONVERTED_NUMBER_RE = re.compile(r"-?\d+(?:\.\d+)?")
+
+_WORD_PUNCT = ".,!?;:؟،؛\"'()[]«»"
+
+
+def _bare_word(token: str) -> str:
+    return token.strip(_WORD_PUNCT)
+
+
+def _safe_extract(token: str, lang: str):
+    """extract_number that never raises, for probing a single word."""
+    if not token:
+        return False
+    try:
+        return extract_number(token, lang)
+    except Exception:  # language modules raise a variety of errors
+        return False
+
+
+def _reads_ordinal_as_fraction(token: str, lang: str) -> bool:
+    """True if an ordinal word would be misread as its reciprocal.
+
+    English and several other languages reuse ordinal names as fraction
+    denominators ("two thirds" = 2/3). Standing alone, such a word is an
+    ordinal, and reading it as a reciprocal invents a value nobody spoke
+    ("the third week" -> "the 0.333 week"). Languages whose ordinal words are
+    not fraction names are unaffected.
+    """
+    word = _bare_word(token)
+    if not word:
+        return False
+    try:
+        if not is_ordinal(word, lang):
+            return False
+    except Exception:  # language modules raise a variety of errors
+        return False
+    frac = _safe_extract(word, lang)
+    if frac is False or frac is None:
+        return False
+    try:
+        return not float(frac).is_integer()
+    except (TypeError, ValueError):
+        return False
+
+
+def _convert_segments(convert, tokens, protected) -> str:
+    """Convert the text around ``protected`` token positions, keeping those verbatim.
+
+    Splitting at the protected words is what gives them their meaning: a number
+    span can never grow across one, so "sixty six | million | years ago" converts
+    the count and leaves the scale word standing.
+    """
+    if not protected:
+        return convert(" ".join(tokens))
+    out = []
+    segment = []
+    for idx, token in enumerate(tokens):
+        if idx in protected:
+            if segment:
+                out.append(convert(" ".join(segment)))
+                segment = []
+            out.append(token)
+        else:
+            segment.append(token)
+    if segment:
+        out.append(convert(" ".join(segment)))
+    return " ".join(part for part in out if part)
+
+
+def _digits_in(text: str):
+    return [float(m) for m in _CONVERTED_NUMBER_RE.findall(text)]
+
+
+def _protection_is_local(convert, tokens, protected, idx, lang) -> bool:
+    """True if keeping token ``idx`` as a word leaves every other number intact.
+
+    A fraction word that belongs to a quantity ("two and a half hours") cannot be
+    held back without changing the quantity itself, and there the fraction is part
+    of the number rather than a word of its own. Comparing the two conversions is
+    a language-agnostic way to tell the two cases apart: protection is accepted
+    only when the sole difference is the fraction's own value disappearing.
+    """
+    baseline = _digits_in(_convert_segments(convert, tokens, protected))
+    trial = _digits_in(_convert_segments(convert, tokens, protected | {idx}))
+    own = _safe_extract(_bare_word(tokens[idx]), lang)
+    try:
+        own = float(own)
+    except (TypeError, ValueError):
+        return False
+    expected = list(baseline)
+    if own not in expected:
+        # the word was not being converted anyway: leave the output untouched
+        return False
+    expected.remove(own)
+    return expected == trial
+
+
+def _ordinal_words_to_digits(text: str, lang: str) -> str:
+    """Convert any ordinal word the language's own parser left standing.
+
+    Most language modules only know cardinals, so ``ordinals=True`` would be
+    silently dropped for them. ``is_ordinal`` is implemented for every supported
+    language, so a single pass over the words that are still words gives every
+    language the same behaviour. Words already converted contain digits and are
+    skipped, so a language with native ordinal support is unaffected.
+    """
+    out = []
+    for token in text.split():
+        word = _bare_word(token)
+        if not word or any(ch.isdigit() for ch in token):
+            out.append(token)
+            continue
+        try:
+            val = is_ordinal(word, lang)
+        except Exception:  # language modules raise a variety of errors
+            val = False
+        if val is False or val is None or isinstance(val, bool):
+            out.append(token)
+            continue
+        trail = token[len(token.rstrip(_WORD_PUNCT)):]
+        lead = token[:len(token) - len(token.lstrip(_WORD_PUNCT))]
+        out.append(f"{lead}{int(val)}{trail}")
+    return " ".join(out)
+
+
+def _numbers_to_digits_flags(convert, utterance: str, lang: str, *,
+                             ordinals: bool) -> str:
+    """Apply the conversion flags on top of any language's own converter.
+
+    With every flag at its default nothing is ever held back and ``convert`` sees
+    the whole utterance, so a language's existing output is preserved exactly.
+    """
+    tokens = utterance.split()
+    if not tokens:
+        return convert(utterance)
+
+    protected = set()
+
+    candidates = []
+    if not ordinals:
+        candidates += [i for i, t in enumerate(tokens)
+                       if i not in protected and i not in candidates
+                       and _reads_ordinal_as_fraction(t, lang)]
+
+    for idx in candidates:
+        if _protection_is_local(convert, tokens, protected, idx, lang):
+            protected.add(idx)
+
+    converted = _convert_segments(convert, tokens, protected)
+    if ordinals:
+        converted = _ordinal_words_to_digits(converted, lang)
+    return converted
+
+
+def _numbers_to_digits_generic(utterance: str, lang: str,
+                               ordinals: bool = False) -> str:
     """Fallback that replaces spoken number spans with digits using
     extract_number over maximal runs of number words."""
     lang2 = lang.lower().split("-")[0]
@@ -297,7 +463,7 @@ def _numbers_to_digits_generic(utterance: str, lang: str) -> str:
         if not c:
             return False
         try:
-            if extract_number(c, lang) is False:
+            if extract_number(c, lang, ordinals=ordinals) is False:
                 return False
         except NotImplementedError:
             return False
@@ -310,7 +476,7 @@ def _numbers_to_digits_generic(utterance: str, lang: str) -> str:
                 if not part or part in connectors:
                     continue
                 try:
-                    if extract_number(part, lang) is False:
+                    if extract_number(part, lang, ordinals=ordinals) is False:
                         return False
                 except NotImplementedError:
                     return False
@@ -331,11 +497,12 @@ def _numbers_to_digits_generic(utterance: str, lang: str) -> str:
             ("due e tre")."""
             extended = " ".join(_clean(t) for t in tokens[i:next_j + 1])
             current = " ".join(_clean(t) for t in tokens[i:j + 1])
-            extended_val = extract_number(extended, lang)
+            extended_val = extract_number(extended, lang, ordinals=ordinals)
             if extended_val is False or extended_val is None:
                 return False
-            current_val = extract_number(current, lang)
-            next_val = extract_number(_clean(tokens[next_j]), lang)
+            current_val = extract_number(current, lang, ordinals=ordinals)
+            next_val = extract_number(_clean(tokens[next_j]), lang,
+                                      ordinals=ordinals)
             if current_val is False or current_val is None:
                 return False
             if extended_val == current_val \
@@ -363,7 +530,7 @@ def _numbers_to_digits_generic(utterance: str, lang: str) -> str:
             else:
                 break
         span = " ".join(_clean(t) for t in tokens[i:j + 1])
-        val = extract_number(span, lang)
+        val = extract_number(span, lang, ordinals=ordinals)
         stripped = tokens[j].rstrip(punct)
         trail = tokens[j][len(stripped):]
         if isinstance(val, float) and val.is_integer():
@@ -373,18 +540,24 @@ def _numbers_to_digits_generic(utterance: str, lang: str) -> str:
     return " ".join(out)
 
 
-def numbers_to_digits(utterance: str, lang: str, scale: Optional[Scale] = None) -> str:
+def numbers_to_digits(utterance: str, lang: str, scale: Optional[Scale] = None,
+                      *,
+                      ordinals: bool = False) -> str:
     """
     Convert written numbers in a text string to their digit representations for the specified language and numerical scale.
-    
+
     Parameters:
         utterance (str): Text potentially containing written numbers.
         lang (str): Language code used to determine parsing rules.
         scale (Scale, optional): Numerical scale (long or short) for languages that distinguish between them.
-    
+        ordinals (bool): parse ordinal words to their number value.
+            ``"the twenty fifth"`` -> ``"the 25"``. Off by default, which leaves
+            an ordinal word untouched. Honoured for every supported language, and
+            an ordinal word is never read as a fraction regardless of this flag.
+
     Returns:
         str: The input text with written numbers replaced by their digit equivalents.
-    
+
     Raises:
         NotImplementedError: If the specified language is not supported.
     """
@@ -393,42 +566,50 @@ def numbers_to_digits(utterance: str, lang: str, scale: Optional[Scale] = None) 
         # English has its own converter, which reads compound ordinals
         # ("the twenty fifth" -> 25) and never mistakes a singular ordinal for a
         # fraction. The generic fallback did neither.
-        return numbers_to_digits_en(utterance, short_scale=scale == Scale.SHORT)
-    if lang.startswith("ast"):
-        return AST.numbers_to_digits(utterance)
-    if lang.startswith("oc"):
-        return OC.numbers_to_digits(utterance, scale=scale)
-    if lang.startswith("an"):
-        return AN.numbers_to_digits(utterance)
-    if lang.startswith("fy"):
-        return numbers_to_digits_fy(utterance)
-    if lang.startswith("gl"):
-        return numbers_to_digits_gl(utterance)
-    if lang.startswith("de"):
-        return numbers_to_digits_de(utterance)
-    if lang.startswith("pt"):
-        return PT_PT.numbers_to_digits(utterance, scale=scale)
-    if lang.startswith("mwl"):
-        return MWL.numbers_to_digits(utterance, scale=scale)
-    if lang.startswith("ro"):
-        return RO.numbers_to_digits(utterance, scale=scale)
-    if lang.startswith("bg"):
-        return numbers_to_digits_bg(utterance)
-    if lang.startswith("hr"):
-        return numbers_to_digits_hr(utterance)
-    if lang.startswith("ru"):
-        return numbers_to_digits_ru(utterance)
-    if lang.startswith("sk"):
-        return numbers_to_digits_sk(utterance)
-    if lang.startswith("id"):
-        return numbers_to_digits_id(utterance)
-    if lang.startswith("ms"):
-        return numbers_to_digits_ms(utterance)
-    if lang.startswith("tr"):
-        return numbers_to_digits_tr(utterance)
-    if lang.startswith("uk"):
-        return numbers_to_digits_uk(utterance)
-    return _numbers_to_digits_generic(utterance, lang)
+        return numbers_to_digits_en(utterance,
+                                    short_scale=scale == Scale.SHORT,
+                                    ordinals=ordinals)
+
+    def _convert(text: str) -> str:
+        """The language's own conversion, with ordinals threaded natively."""
+        if lang.startswith("ast"):
+            return AST.numbers_to_digits(text, ordinals=ordinals)
+        if lang.startswith("oc"):
+            return OC.numbers_to_digits(text, scale=scale, ordinals=ordinals)
+        if lang.startswith("an"):
+            return AN.numbers_to_digits(text, ordinals=ordinals)
+        if lang.startswith("fy"):
+            return numbers_to_digits_fy(text, ordinals=ordinals)
+        if lang.startswith("gl"):
+            return GL.numbers_to_digits(text, scale=scale, ordinals=ordinals)
+        if lang.startswith("de"):
+            return numbers_to_digits_de(text, ordinals=ordinals)
+        if lang.startswith("pt"):
+            return PT_PT.numbers_to_digits(text, scale=scale, ordinals=ordinals)
+        if lang.startswith("mwl"):
+            return MWL.numbers_to_digits(text, scale=scale, ordinals=ordinals)
+        if lang.startswith("ro"):
+            return RO.numbers_to_digits(text, scale=scale, ordinals=ordinals)
+        if lang.startswith("bg"):
+            return numbers_to_digits_bg(text, ordinals=ordinals)
+        if lang.startswith("hr"):
+            return numbers_to_digits_hr(text, ordinals=ordinals)
+        if lang.startswith("ru"):
+            return numbers_to_digits_ru(text, ordinals=ordinals)
+        if lang.startswith("sk"):
+            return numbers_to_digits_sk(text, ordinals=ordinals)
+        if lang.startswith("id"):
+            return numbers_to_digits_id(text, ordinals=ordinals)
+        if lang.startswith("ms"):
+            return numbers_to_digits_ms(text, ordinals=ordinals)
+        if lang.startswith("tr"):
+            return numbers_to_digits_tr(text, ordinals=ordinals)
+        if lang.startswith("uk"):
+            return numbers_to_digits_uk(text, ordinals=ordinals)
+        return _numbers_to_digits_generic(text, lang, ordinals=ordinals)
+
+    return _numbers_to_digits_flags(_convert, utterance, lang,
+                                    ordinals=ordinals)
 
 
 # Connectives for the a+bi complex form, per language, English as the default.

--- a/ovos_number_parser/__init__.py
+++ b/ovos_number_parser/__init__.py
@@ -288,6 +288,12 @@ SUPPORTED_LANGUAGES = (
     "sl", "sv", "tr", "uk",
 )
 
+#: Powers of ten that are spelled with a dedicated multiplier word in most
+#: languages ("hundred", "thousand", "million", ...). A word whose *whole* value
+#: is one of these is a scale word: "two hundred" is a count times a scale,
+#: while "duzentos" (200) is a lexicalised numeral and not a multiplier.
+_SCALE_WORD_VALUES = frozenset(10 ** n for n in range(2, 40))
+
 #: a number in converted output, used to compare two conversions
 _CONVERTED_NUMBER_RE = re.compile(r"-?\d+(?:\.\d+)?")
 
@@ -306,6 +312,18 @@ def _safe_extract(token: str, lang: str):
         return extract_number(token, lang)
     except Exception:  # language modules raise a variety of errors
         return False
+
+
+def _is_scale_word(token: str, lang: str) -> bool:
+    """True if the word is a multiplier scale word ("thousand", "milhão")."""
+    val = _safe_extract(_bare_word(token), lang)
+    if val is False or val is None or isinstance(val, bool):
+        return False
+    try:
+        fval = float(val)
+    except (TypeError, ValueError):
+        return False
+    return fval.is_integer() and int(fval) in _SCALE_WORD_VALUES
 
 
 def _is_fraction_word(token: str, lang: str) -> bool:
@@ -426,7 +444,8 @@ def _ordinal_words_to_digits(text: str, lang: str) -> str:
 
 
 def _numbers_to_digits_flags(convert, utterance: str, lang: str, *,
-                             ordinals: bool, fractions: bool) -> str:
+                             ordinals: bool, fractions: bool,
+                             scale_words: bool) -> str:
     """Apply the conversion flags on top of any language's own converter.
 
     With every flag at its default nothing is ever held back and ``convert`` sees
@@ -437,6 +456,11 @@ def _numbers_to_digits_flags(convert, utterance: str, lang: str, *,
         return convert(utterance)
 
     protected = set()
+    if not scale_words:
+        # the neighbouring count is *meant* to change here ("66 million"),
+        # so these need no locality check
+        protected |= {i for i, t in enumerate(tokens)
+                      if _is_scale_word(t, lang)}
 
     candidates = []
     if not fractions:
@@ -557,7 +581,8 @@ def _numbers_to_digits_generic(utterance: str, lang: str,
 def numbers_to_digits(utterance: str, lang: str, scale: Optional[Scale] = None,
                       *,
                       ordinals: bool = False,
-                      fractions: bool = True) -> str:
+                      fractions: bool = True,
+                      scale_words: bool = True) -> str:
     """
     Convert written numbers in a text string to their digit representations for the specified language and numerical scale.
 
@@ -574,6 +599,10 @@ def numbers_to_digits(utterance: str, lang: str, scale: Optional[Scale] = None,
             words ("half past nine" -> "half past 9"), while a fraction that
             belongs to a quantity is always converted ("two and a half hours" ->
             "2.5 hours").
+        scale_words (bool): expand multiplier scale words ("hundred", "million").
+            On by default. Turning it off converts only the count and keeps the
+            scale word ("sixty six million years ago" -> "66 million years ago").
+            Honoured for every supported language.
 
     Returns:
         str: The input text with written numbers replaced by their digit equivalents.
@@ -589,7 +618,8 @@ def numbers_to_digits(utterance: str, lang: str, scale: Optional[Scale] = None,
         return numbers_to_digits_en(utterance,
                                     short_scale=scale == Scale.SHORT,
                                     ordinals=ordinals,
-                                    fractions=fractions)
+                                    fractions=fractions,
+                                    scale_words=scale_words)
 
     def _convert(text: str) -> str:
         """The language's own conversion, with ordinals threaded natively."""
@@ -630,7 +660,8 @@ def numbers_to_digits(utterance: str, lang: str, scale: Optional[Scale] = None,
         return _numbers_to_digits_generic(text, lang, ordinals=ordinals)
 
     return _numbers_to_digits_flags(_convert, utterance, lang,
-                                    ordinals=ordinals, fractions=fractions)
+                                    ordinals=ordinals, fractions=fractions,
+                                    scale_words=scale_words)
 
 
 # Connectives for the a+bi complex form, per language, English as the default.

--- a/ovos_number_parser/__init__.py
+++ b/ovos_number_parser/__init__.py
@@ -389,6 +389,11 @@ def numbers_to_digits(utterance: str, lang: str, scale: Optional[Scale] = None) 
         NotImplementedError: If the specified language is not supported.
     """
     scale = _resolve_scale(lang, scale)
+    if lang.startswith("en"):
+        # English has its own converter, which reads compound ordinals
+        # ("the twenty fifth" -> 25) and never mistakes a singular ordinal for a
+        # fraction. The generic fallback did neither.
+        return numbers_to_digits_en(utterance, short_scale=scale == Scale.SHORT)
     if lang.startswith("ast"):
         return AST.numbers_to_digits(utterance)
     if lang.startswith("oc"):

--- a/ovos_number_parser/__init__.py
+++ b/ovos_number_parser/__init__.py
@@ -308,6 +308,17 @@ def _safe_extract(token: str, lang: str):
         return False
 
 
+def _is_fraction_word(token: str, lang: str) -> bool:
+    """True if the word names a fraction ("half", "meio", "половина")."""
+    word = _bare_word(token)
+    if not word:
+        return False
+    try:
+        return bool(is_fractional(word, lang))
+    except Exception:  # language modules raise a variety of errors
+        return False
+
+
 def _reads_ordinal_as_fraction(token: str, lang: str) -> bool:
     """True if an ordinal word would be misread as its reciprocal.
 
@@ -415,7 +426,7 @@ def _ordinal_words_to_digits(text: str, lang: str) -> str:
 
 
 def _numbers_to_digits_flags(convert, utterance: str, lang: str, *,
-                             ordinals: bool) -> str:
+                             ordinals: bool, fractions: bool) -> str:
     """Apply the conversion flags on top of any language's own converter.
 
     With every flag at its default nothing is ever held back and ``convert`` sees
@@ -428,6 +439,9 @@ def _numbers_to_digits_flags(convert, utterance: str, lang: str, *,
     protected = set()
 
     candidates = []
+    if not fractions:
+        candidates += [i for i, t in enumerate(tokens)
+                       if i not in protected and _is_fraction_word(t, lang)]
     if not ordinals:
         candidates += [i for i, t in enumerate(tokens)
                        if i not in protected and i not in candidates
@@ -542,7 +556,8 @@ def _numbers_to_digits_generic(utterance: str, lang: str,
 
 def numbers_to_digits(utterance: str, lang: str, scale: Optional[Scale] = None,
                       *,
-                      ordinals: bool = False) -> str:
+                      ordinals: bool = False,
+                      fractions: bool = True) -> str:
     """
     Convert written numbers in a text string to their digit representations for the specified language and numerical scale.
 
@@ -554,6 +569,11 @@ def numbers_to_digits(utterance: str, lang: str, scale: Optional[Scale] = None,
             ``"the twenty fifth"`` -> ``"the 25"``. Off by default, which leaves
             an ordinal word untouched. Honoured for every supported language, and
             an ordinal word is never read as a fraction regardless of this flag.
+        fractions (bool): convert a *bare* fraction word - one that is not part
+            of a numeric span. On by default. Turning it off keeps such words as
+            words ("half past nine" -> "half past 9"), while a fraction that
+            belongs to a quantity is always converted ("two and a half hours" ->
+            "2.5 hours").
 
     Returns:
         str: The input text with written numbers replaced by their digit equivalents.
@@ -568,7 +588,8 @@ def numbers_to_digits(utterance: str, lang: str, scale: Optional[Scale] = None,
         # fraction. The generic fallback did neither.
         return numbers_to_digits_en(utterance,
                                     short_scale=scale == Scale.SHORT,
-                                    ordinals=ordinals)
+                                    ordinals=ordinals,
+                                    fractions=fractions)
 
     def _convert(text: str) -> str:
         """The language's own conversion, with ordinals threaded natively."""
@@ -609,7 +630,7 @@ def numbers_to_digits(utterance: str, lang: str, scale: Optional[Scale] = None,
         return _numbers_to_digits_generic(text, lang, ordinals=ordinals)
 
     return _numbers_to_digits_flags(_convert, utterance, lang,
-                                    ordinals=ordinals)
+                                    ordinals=ordinals, fractions=fractions)
 
 
 # Connectives for the a+bi complex form, per language, English as the default.

--- a/ovos_number_parser/numbers_en.py
+++ b/ovos_number_parser/numbers_en.py
@@ -629,6 +629,45 @@ def pronounce_number_en(number, places=2, short_scale=True, scientific=False,
     return result
 
 
+#: A hyphen or underscore between two letters spells the space that joins a
+#: compound numeral, so "ninety-nine", "ninety_nine" and "ninety nine" read
+#: alike. Only letter-letter joins are rewritten: a leading "-" is a minus sign
+#: and a digit on either side is a range ("10-15"), both of which survive.
+_COMPOUND_JOIN_RE_EN = re.compile(r"(?<=[^\W\d_])[-_](?=[^\W\d_])", re.UNICODE)
+
+#: A comma between two number words is spoken punctuation inside one numeral
+#: ("two thousand, five hundred"), not a separator.
+_SPOKEN_COMMA_RE_EN = re.compile(r"\b(\w+),(\s+)(?=\w)", re.UNICODE)
+
+
+def _numeral_separators_en(text):
+    """Normalise the separators that spell a single English numeral.
+
+    Rewrites "-"/"_" written between letters to a space so the tokenizer does not
+    cut a compound in half ("nineteen ninety-nine" was read as "19 90 - 9"), and
+    drops a comma standing between two number words. Commas in ordinary prose are
+    left alone: only a comma with a number word on each side is removed.
+    """
+    text = _COMPOUND_JOIN_RE_EN.sub(" ", text)
+
+    def _is_number_word(word):
+        word = word.lower()
+        return (word in _STRING_NUM_EN or word in _SUMS_EN
+                or word in _MULTIPLIES_SHORT_SCALE_EN
+                or word in _MULTIPLIES_LONG_SCALE_EN
+                or is_numeric(word))
+
+    def _drop(match):
+        before = match.group(1)
+        after = text[match.end():].split(maxsplit=1)[0] if text[match.end():].split() else ""
+        after = re.split(r"\W", after, maxsplit=1)[0]
+        if _is_number_word(before) and _is_number_word(after):
+            return f"{before}{match.group(2)}"
+        return match.group(0)
+
+    return _SPOKEN_COMMA_RE_EN.sub(_drop, text)
+
+
 def numbers_to_digits_en(text, short_scale=True, ordinals=False):
     """
     Convert words in a string into their equivalent numbers.
@@ -643,7 +682,7 @@ def numbers_to_digits_en(text, short_scale=True, ordinals=False):
         The original text, with numbers subbed in where appropriate.
 
     """
-    tokens = tokenize(text)
+    tokens = tokenize(_numeral_separators_en(text))
     numbers_to_replace = \
         _extract_numbers_with_text_en(tokens, short_scale, ordinals)
     numbers_to_replace.sort(key=lambda number: number.start_index)
@@ -1017,14 +1056,15 @@ def _extract_whole_number_with_text_en(tokens, short_scale, ordinals):
         # half cup
         if val is False and \
                 not (ordinals is None and word in string_num_ordinal):
-            val = is_fractional_en(word, short_scale=short_scale,
-                                   spoken=ordinals is not None)
-
+            val = _fraction_value_en(word, short_scale=short_scale,
+                                     spoken=ordinals is not None,
+                                     ordinals=ordinals)
             current_val = val
 
         # 2 fifths
         if ordinals is False:
-            next_val = is_fractional_en(next_word, short_scale=short_scale)
+            next_val = _fraction_value_en(next_word, short_scale=short_scale,
+                                          ordinals=ordinals)
             if next_val:
                 if not val:
                     val = 1
@@ -1196,6 +1236,32 @@ def extract_number_en(text, short_scale=True, ordinals=False):
     text = re.sub(r"(?<=[a-z]),", "", text)
     return _extract_number_with_text_en(tokenize(text),
                                         short_scale, ordinals).value
+
+
+def _is_ordinal_word_en(input_str, short_scale=True):
+    """True if the word is an ordinal name ("third", "fifth") in singular form.
+
+    The plural ("thirds", "fifths") is excluded: that is unambiguously a
+    fraction denominator, while the singular is the ordinal.
+    """
+    table = _SHORT_ORDINAL_EN if short_scale else _LONG_ORDINAL_EN
+    return input_str.lower() in {name for num, name in table.items() if num > 2}
+
+
+def _fraction_value_en(input_str, short_scale=True, spoken=True, ordinals=True):
+    """Fraction value of a word, refusing to reinterpret ordinals as reciprocals.
+
+    English reuses ordinal names as fraction denominators ("two fifths" = 2/5),
+    but a singular ordinal in running text is an ordinal, not a reciprocal.
+    Reading it as one fabricates numbers that were never spoken: "the twenty
+    fifth" became 20 * 1/5 = 4.0 and "the third week" became 0.333. When ordinal
+    parsing is explicitly off, such a word is left alone rather than converted to
+    something the speaker did not say. "half", "quarter" and plural denominators
+    are unaffected.
+    """
+    if ordinals is False and _is_ordinal_word_en(input_str, short_scale):
+        return False
+    return is_fractional_en(input_str, short_scale=short_scale, spoken=spoken)
 
 
 def is_fractional_en(input_str, short_scale=True, spoken=True):

--- a/ovos_number_parser/numbers_en.py
+++ b/ovos_number_parser/numbers_en.py
@@ -668,7 +668,8 @@ def _numeral_separators_en(text):
     return _SPOKEN_COMMA_RE_EN.sub(_drop, text)
 
 
-def numbers_to_digits_en(text, short_scale=True, ordinals=False):
+def numbers_to_digits_en(text, short_scale=True, ordinals=False,
+                         fractions=True):
     """
     Convert words in a string into their equivalent numbers.
     Args:
@@ -676,6 +677,11 @@ def numbers_to_digits_en(text, short_scale=True, ordinals=False):
         short_scale boolean: True if short scale numbers should be used.
         ordinals boolean: True if ordinals (e.g. first, second, third) should
                           be parsed to their number values (1, 2, 3...)
+        fractions boolean: True (default) converts a bare fraction word such as
+                          "half" or "quarter". False leaves a bare fraction word
+                          alone ("half past nine" -> "half past 9") while still
+                          converting a fraction that belongs to a numeric span
+                          ("two and a half hours" -> "2.5 hours").
 
     Returns:
         str
@@ -684,7 +690,8 @@ def numbers_to_digits_en(text, short_scale=True, ordinals=False):
     """
     tokens = tokenize(_numeral_separators_en(text))
     numbers_to_replace = \
-        _extract_numbers_with_text_en(tokens, short_scale, ordinals)
+        _extract_numbers_with_text_en(tokens, short_scale, ordinals,
+                                      bare_fractions=fractions)
     numbers_to_replace.sort(key=lambda number: number.start_index)
 
     results = []
@@ -704,7 +711,8 @@ def numbers_to_digits_en(text, short_scale=True, ordinals=False):
 
 
 def _extract_numbers_with_text_en(tokens, short_scale=True,
-                                  ordinals=False, fractional_numbers=True):
+                                  ordinals=False, fractional_numbers=True,
+                                  bare_fractions=True):
     """
     Extract all numbers from a list of Tokens, with the words that
     represent them.
@@ -728,7 +736,8 @@ def _extract_numbers_with_text_en(tokens, short_scale=True,
     while True:
         to_replace = \
             _extract_number_with_text_en(tokens, short_scale,
-                                         ordinals, fractional_numbers)
+                                         ordinals, fractional_numbers,
+                                         bare_fractions=bare_fractions)
 
         if not to_replace:
             break
@@ -746,7 +755,8 @@ def _extract_numbers_with_text_en(tokens, short_scale=True,
 
 
 def _extract_number_with_text_en(tokens, short_scale=True,
-                                 ordinals=False, fractional_numbers=True):
+                                 ordinals=False, fractional_numbers=True,
+                                 bare_fractions=True):
     """
     This function extracts a number from a list of Tokens.
 
@@ -762,7 +772,8 @@ def _extract_number_with_text_en(tokens, short_scale=True,
     """
     number, tokens = \
         _extract_number_with_text_en_helper(tokens, short_scale,
-                                            ordinals, fractional_numbers)
+                                            ordinals, fractional_numbers,
+                                            bare_fractions=bare_fractions)
     while tokens and tokens[0].word in _ARTICLES_EN:
         tokens.pop(0)
     return ReplaceableNumber(number, tokens)
@@ -770,7 +781,8 @@ def _extract_number_with_text_en(tokens, short_scale=True,
 
 def _extract_number_with_text_en_helper(tokens,
                                         short_scale=True, ordinals=False,
-                                        fractional_numbers=True):
+                                        fractional_numbers=True,
+                                        bare_fractions=True):
     """
     Helper for _extract_number_with_text_en.
 
@@ -799,7 +811,8 @@ def _extract_number_with_text_en_helper(tokens,
         if decimal:
             return decimal, decimal_text
 
-    return _extract_whole_number_with_text_en(tokens, short_scale, ordinals)
+    return _extract_whole_number_with_text_en(tokens, short_scale, ordinals,
+                                              bare_fractions=bare_fractions)
 
 
 def _extract_fraction_with_text_en(tokens, short_scale, ordinals):
@@ -914,7 +927,8 @@ def _extract_decimal_with_text_en(tokens, short_scale, ordinals):
     return None, None
 
 
-def _extract_whole_number_with_text_en(tokens, short_scale, ordinals):
+def _extract_whole_number_with_text_en(tokens, short_scale, ordinals,
+                                       bare_fractions=True):
     """
     Handle numbers not handled by the decimal or fraction functions. This is
     generally whole numbers. Note that phrases such as "one half" will be
@@ -965,6 +979,22 @@ def _extract_whole_number_with_text_en(tokens, short_scale, ordinals):
             continue
         if prev_word == "and" and idx > 1:
             prev_word = tokens[idx - 2].word.lower()
+
+        # A *bare* fraction word - one with no number attached to it - is only
+        # converted when the caller asked for it. "half past nine" keeps "half"
+        # so a clock-time grammar downstream still recognises it, while "three
+        # quarters" and "two and a half" keep converting: there the fraction
+        # belongs to a numeric span and prev_val is set.
+        if not bare_fractions and prev_val is None and \
+                not (ordinals and word in string_num_ordinal) and \
+                _fraction_value_en(word, short_scale=short_scale,
+                                   ordinals=ordinals):
+            if number_words and not all(t.word.lower() in
+                                        _ARTICLES_EN | _NEGATIVES_EN
+                                        for t in number_words):
+                break
+            number_words = []
+            continue
 
         if is_numeric(word[:-2]) and \
                 (word.endswith("st") or word.endswith("nd") or

--- a/ovos_number_parser/numbers_en.py
+++ b/ovos_number_parser/numbers_en.py
@@ -669,7 +669,7 @@ def _numeral_separators_en(text):
 
 
 def numbers_to_digits_en(text, short_scale=True, ordinals=False,
-                         fractions=True):
+                         fractions=True, scale_words=True):
     """
     Convert words in a string into their equivalent numbers.
     Args:
@@ -682,6 +682,11 @@ def numbers_to_digits_en(text, short_scale=True, ordinals=False,
                           alone ("half past nine" -> "half past 9") while still
                           converting a fraction that belongs to a numeric span
                           ("two and a half hours" -> "2.5 hours").
+        scale_words boolean: True (default) expands multiplier scale words, so
+                          "sixty six million" becomes 66000000. False leaves the
+                          scale word as a word and converts only the count
+                          ("sixty six million years ago" -> "66 million years
+                          ago").
 
     Returns:
         str
@@ -691,7 +696,8 @@ def numbers_to_digits_en(text, short_scale=True, ordinals=False,
     tokens = tokenize(_numeral_separators_en(text))
     numbers_to_replace = \
         _extract_numbers_with_text_en(tokens, short_scale, ordinals,
-                                      bare_fractions=fractions)
+                                      bare_fractions=fractions,
+                                      scale_words=scale_words)
     numbers_to_replace.sort(key=lambda number: number.start_index)
 
     results = []
@@ -712,7 +718,7 @@ def numbers_to_digits_en(text, short_scale=True, ordinals=False,
 
 def _extract_numbers_with_text_en(tokens, short_scale=True,
                                   ordinals=False, fractional_numbers=True,
-                                  bare_fractions=True):
+                                  bare_fractions=True, scale_words=True):
     """
     Extract all numbers from a list of Tokens, with the words that
     represent them.
@@ -737,7 +743,8 @@ def _extract_numbers_with_text_en(tokens, short_scale=True,
         to_replace = \
             _extract_number_with_text_en(tokens, short_scale,
                                          ordinals, fractional_numbers,
-                                         bare_fractions=bare_fractions)
+                                         bare_fractions=bare_fractions,
+                                         scale_words=scale_words)
 
         if not to_replace:
             break
@@ -756,7 +763,7 @@ def _extract_numbers_with_text_en(tokens, short_scale=True,
 
 def _extract_number_with_text_en(tokens, short_scale=True,
                                  ordinals=False, fractional_numbers=True,
-                                 bare_fractions=True):
+                                 bare_fractions=True, scale_words=True):
     """
     This function extracts a number from a list of Tokens.
 
@@ -773,7 +780,8 @@ def _extract_number_with_text_en(tokens, short_scale=True,
     number, tokens = \
         _extract_number_with_text_en_helper(tokens, short_scale,
                                             ordinals, fractional_numbers,
-                                            bare_fractions=bare_fractions)
+                                            bare_fractions=bare_fractions,
+                                            scale_words=scale_words)
     while tokens and tokens[0].word in _ARTICLES_EN:
         tokens.pop(0)
     return ReplaceableNumber(number, tokens)
@@ -782,7 +790,8 @@ def _extract_number_with_text_en(tokens, short_scale=True,
 def _extract_number_with_text_en_helper(tokens,
                                         short_scale=True, ordinals=False,
                                         fractional_numbers=True,
-                                        bare_fractions=True):
+                                        bare_fractions=True,
+                                        scale_words=True):
     """
     Helper for _extract_number_with_text_en.
 
@@ -801,21 +810,28 @@ def _extract_number_with_text_en_helper(tokens,
 
     """
     if fractional_numbers:
+        # Inside a fraction or decimal construction the fraction word is by
+        # definition part of a numeric span, so ``bare_fractions`` (which only
+        # governs *bare* fraction words) does not apply to the recursion.
         fraction, fraction_text = \
-            _extract_fraction_with_text_en(tokens, short_scale, ordinals)
+            _extract_fraction_with_text_en(tokens, short_scale, ordinals,
+                                           scale_words=scale_words)
         if fraction:
             return fraction, fraction_text
 
         decimal, decimal_text = \
-            _extract_decimal_with_text_en(tokens, short_scale, ordinals)
+            _extract_decimal_with_text_en(tokens, short_scale, ordinals,
+                                          scale_words=scale_words)
         if decimal:
             return decimal, decimal_text
 
     return _extract_whole_number_with_text_en(tokens, short_scale, ordinals,
-                                              bare_fractions=bare_fractions)
+                                              bare_fractions=bare_fractions,
+                                              scale_words=scale_words)
 
 
-def _extract_fraction_with_text_en(tokens, short_scale, ordinals):
+def _extract_fraction_with_text_en(tokens, short_scale, ordinals,
+                                   scale_words=True):
     """
     Extract fraction numbers from a string.
 
@@ -839,10 +855,12 @@ def _extract_fraction_with_text_en(tokens, short_scale, ordinals):
         if len(partitions) == 3:
             numbers1 = \
                 _extract_numbers_with_text_en(partitions[0], short_scale,
-                                              ordinals, fractional_numbers=False)
+                                              ordinals, fractional_numbers=False,
+                                              scale_words=scale_words)
             numbers2 = \
                 _extract_numbers_with_text_en(partitions[2], short_scale,
-                                              ordinals, fractional_numbers=True)
+                                              ordinals, fractional_numbers=True,
+                                              scale_words=scale_words)
 
             if not numbers1 or not numbers2:
                 return None, None
@@ -857,7 +875,8 @@ def _extract_fraction_with_text_en(tokens, short_scale, ordinals):
     return None, None
 
 
-def _extract_decimal_with_text_en(tokens, short_scale, ordinals):
+def _extract_decimal_with_text_en(tokens, short_scale, ordinals,
+                                  scale_words=True):
     """
     Extract decimal numbers from a string.
 
@@ -887,10 +906,12 @@ def _extract_decimal_with_text_en(tokens, short_scale, ordinals):
         if len(partitions) == 3:
             numbers1 = \
                 _extract_numbers_with_text_en(partitions[0], short_scale,
-                                              ordinals, fractional_numbers=False)
+                                              ordinals, fractional_numbers=False,
+                                              scale_words=scale_words)
             numbers2 = \
                 _extract_numbers_with_text_en(partitions[2], short_scale,
-                                              ordinals, fractional_numbers=False)
+                                              ordinals, fractional_numbers=False,
+                                              scale_words=scale_words)
 
             if not numbers1 or not numbers2:
                 return None, None
@@ -928,7 +949,8 @@ def _extract_decimal_with_text_en(tokens, short_scale, ordinals):
 
 
 def _extract_whole_number_with_text_en(tokens, short_scale, ordinals,
-                                       bare_fractions=True):
+                                       bare_fractions=True,
+                                       scale_words=True):
     """
     Handle numbers not handled by the decimal or fraction functions. This is
     generally whole numbers. Note that phrases such as "one half" will be
@@ -946,7 +968,8 @@ def _extract_whole_number_with_text_en(tokens, short_scale, ordinals,
 
     """
     multiplies, string_num_ordinal, string_num_scale = \
-        _initialize_number_data_en(short_scale, speech=ordinals is not None)
+        _initialize_number_data_en(short_scale, speech=ordinals is not None,
+                                   scale_words=scale_words)
 
     number_words = []  # type: [Token]
     val = False
@@ -1207,7 +1230,7 @@ def _extract_whole_number_with_text_en(tokens, short_scale, ordinals,
     return val, number_words
 
 
-def _initialize_number_data_en(short_scale, speech=True):
+def _initialize_number_data_en(short_scale, speech=True, scale_words=True):
     """
     Generate dictionaries of words to numbers, based on scale.
 
@@ -1216,17 +1239,27 @@ def _initialize_number_data_en(short_scale, speech=True):
     Args:
         short_scale (bool):
         speech (bool): consider extra words (_SPOKEN_EXTRA_NUM_EN) to be numbers
+        scale_words (bool): recognise multiplier scale words ("hundred",
+                            "million"). False keeps them out of the number
+                            vocabulary so they survive as plain words.
 
     Returns:
         (set(str), dict(str, number), dict(str, number))
         multiplies, string_num_ordinal, string_num_scale
 
     """
-    multiplies = _MULTIPLIES_SHORT_SCALE_EN if short_scale \
-        else _MULTIPLIES_LONG_SCALE_EN
-
     string_num_ordinal_en = _STRING_SHORT_ORDINAL_EN if short_scale \
         else _STRING_LONG_ORDINAL_EN
+
+    if not scale_words:
+        # The caller wants scale words kept as words ("66 million years ago"),
+        # so they are simply not part of the number vocabulary: an unknown word
+        # ends the numeric span and only the leading count is converted.
+        string_num_scale_en = dict(_SPOKEN_EXTRA_NUM_EN) if speech else {}
+        return set(), string_num_ordinal_en, string_num_scale_en
+
+    multiplies = _MULTIPLIES_SHORT_SCALE_EN if short_scale \
+        else _MULTIPLIES_LONG_SCALE_EN
 
     string_num_scale_en = _SHORT_SCALE_EN if short_scale else _LONG_SCALE_EN
     string_num_scale_en = invert_dict(string_num_scale_en)

--- a/ovos_number_parser/util.py
+++ b/ovos_number_parser/util.py
@@ -666,7 +666,8 @@ class RomanceNumberExtractor:
 
     def numbers_to_digits(self,
                           utterance: str,
-                          scale: Optional[Scale] = None
+                          scale: Optional[Scale] = None,
+                          ordinals: bool = False
                           ) -> str:
         """
         Converts written numbers in a text string to their digit equivalents, preserving all other text.
@@ -676,6 +677,10 @@ class RomanceNumberExtractor:
         Parameters:
             utterance (str): Input text possibly containing written numbers.
             scale (Scale, optional): Numerical scale (short or long) to interpret large numbers. Defaults to Scale.LONG.
+            ordinals (bool): also convert a standalone ordinal word to its
+                ordinal value ("o terceiro dia" -> "o 3 dia"). Off by default,
+                which leaves ordinal words untouched. An ordinal is never read
+                as a fraction: only its ordinal value is ever produced.
 
         Returns:
             str: The input text with written numbers replaced by their digit representations.
@@ -686,6 +691,9 @@ class RomanceNumberExtractor:
         i = 0
 
         numbers_map = self.vocab.get_number_strings(scale)
+        # Ordinal words are not part of the cardinal vocabulary, so they only
+        # become numbers when the caller asks for them.
+        ordinals_map = self.vocab.get_ordinal_strings(scale) if ordinals else {}
 
         def next_word(idx):
             return words[idx + 1] if idx + 1 < len(words) else None
@@ -709,6 +717,14 @@ class RomanceNumberExtractor:
             return False
 
         while i < len(words):
+            # A standalone ordinal word converts to its ordinal value. It is
+            # handled before span logic so it can never be absorbed into a
+            # cardinal span or re-read as a fraction.
+            if ordinals_map and words[i] in ordinals_map \
+                    and not starts_span(i):
+                output.append(str(ordinals_map[words[i]]))
+                i += 1
+                continue
             # Look for the start of a number span
             if starts_span(i):
                 # Start a new span

--- a/tests/test_number_parser_en.py
+++ b/tests/test_number_parser_en.py
@@ -14,8 +14,10 @@ class TestNumberParserEN(unittest.TestCase):
         self.assertEqual(numbers_to_digits_en('three billions'), '3000000000.0')
         self.assertEqual(numbers_to_digits_en('two point five'), '2.5')
         self.assertEqual(numbers_to_digits_en('two point forty two'), '2.42')
+        # with ordinals off, "fifth" is left as a word: it must never be
+        # reinterpreted as the reciprocal 1/5 (this used to read "march 0.2")
         self.assertEqual(numbers_to_digits_en('march fifth two thousand twenty five', ordinals=False),
-                         'march 0.2 2025')
+                         'march fifth 2025')
         self.assertEqual(numbers_to_digits_en('march fifth', ordinals=True),
                          'march 5')
 

--- a/tests/test_numbers_to_digits_en_options.py
+++ b/tests/test_numbers_to_digits_en_options.py
@@ -1,0 +1,188 @@
+"""English number-to-digit conversion: routing, ordinals, and the caller knobs.
+
+The public dispatcher routes English to the English implementation, which knows
+about ordinals, hyphenated compounds and spoken fractions. This file pins that
+routing, the values it produces, and the three keyword flags a downstream
+date/time grammar needs: ``ordinals``, ``fractions`` and ``scale_words``. Every
+flag defaults to today's behaviour, so the "defaults" tests double as a guard
+against a future change quietly altering what existing callers see.
+"""
+import unittest
+
+from ovos_number_parser import numbers_to_digits
+from ovos_number_parser.numbers_en import numbers_to_digits_en
+
+
+class TestEnglishDispatchRoute(unittest.TestCase):
+    """English must reach numbers_to_digits_en, not the generic fallback."""
+
+    def test_ordinal_compound_is_not_arithmetic(self):
+        # the generic fallback read "the twenty fifth" as "the 20 0.2":
+        # the ordinal was silently turned into the reciprocal 1/5
+        self.assertEqual(numbers_to_digits("the twenty fifth", "en"),
+                         "the 20")
+        self.assertEqual(numbers_to_digits("the twenty fifth", "en",
+                                           ordinals=True),
+                         "the 25")
+
+    def test_plain_sentences_unchanged(self):
+        self.assertEqual(numbers_to_digits("two thousand and one", "en"), "2001")
+        self.assertEqual(numbers_to_digits("one hundred and one degrees", "en"),
+                         "101 degrees")
+        self.assertEqual(numbers_to_digits("it was five days ago", "en"),
+                         "it was 5 days ago")
+
+    def test_flags_accepted_for_other_languages(self):
+        # the flags are part of the public contract for every language;
+        # the cross-language behaviour itself lives in
+        # test_numbers_to_digits_flags_all_langs.py
+        for lang in ("es", "de", "pt", "ru", "nl", "fr", "it"):
+            with self.subTest(lang=lang):
+                out = numbers_to_digits("veinte", lang, ordinals=True,
+                                        fractions=False, scale_words=False)
+                self.assertIsInstance(out, str)
+
+
+class TestOrdinalWordsAreNeverReciprocals(unittest.TestCase):
+    """An ordinal word must never be fabricated into a fraction."""
+
+    def test_ordinal_left_alone_when_ordinals_off(self):
+        self.assertEqual(numbers_to_digits_en("the twenty fifth"), "the 20")
+        self.assertEqual(numbers_to_digits_en("the third week of june"),
+                         "the third week of june")
+        self.assertEqual(numbers_to_digits_en("march fifth"), "march fifth")
+
+    def test_ordinal_parsed_when_asked(self):
+        self.assertEqual(numbers_to_digits_en("the twenty fifth", ordinals=True),
+                         "the 25")
+        self.assertEqual(
+            numbers_to_digits_en("the third week of june", ordinals=True),
+            "the 3 week of june")
+
+    def test_plural_denominators_are_still_fractions(self):
+        # "fifths"/"thirds" are unambiguously denominators, unlike the singular
+        self.assertEqual(numbers_to_digits_en("two fifths"), "0.4")
+        self.assertEqual(numbers_to_digits_en("three quarters"), "0.75")
+
+
+class TestHyphenatedCompounds(unittest.TestCase):
+    """A hyphen inside a compound numeral spells a space, not a break."""
+
+    def test_hyphen_does_not_split_the_number(self):
+        self.assertEqual(numbers_to_digits("nineteen ninety-nine", "en"),
+                         "19 99")
+        self.assertEqual(numbers_to_digits("twenty-four hours", "en"),
+                         "24 hours")
+        self.assertEqual(numbers_to_digits("thirty-one days", "en"), "31 days")
+
+    def test_hyphenated_ordinal(self):
+        self.assertEqual(numbers_to_digits("the twenty-fifth", "en",
+                                           ordinals=True), "the 25")
+
+    def test_minus_sign_and_ranges_survive(self):
+        self.assertEqual(numbers_to_digits_en("-5"), "-5.0")
+        self.assertEqual(numbers_to_digits_en("10-15 people"), "10-15 people")
+
+
+class TestFractionsFlag(unittest.TestCase):
+    """``fractions=False`` keeps a bare fraction word as a word."""
+
+    def test_default_converts_bare_fractions(self):
+        self.assertEqual(numbers_to_digits("half past nine", "en"),
+                         "0.5 past 9")
+        self.assertEqual(numbers_to_digits("a quarter to five", "en"),
+                         "a 0.25 to 5")
+
+    def test_bare_fraction_kept_when_disabled(self):
+        self.assertEqual(numbers_to_digits("half past nine", "en",
+                                           fractions=False), "half past 9")
+        self.assertEqual(numbers_to_digits("a quarter to five", "en",
+                                           fractions=False), "a quarter to 5")
+
+    def test_fraction_inside_a_quantity_still_converts(self):
+        # here the fraction is part of the number, not a separate word
+        for flag in (True, False):
+            with self.subTest(fractions=flag):
+                self.assertEqual(
+                    numbers_to_digits("two and a half hours", "en",
+                                      fractions=flag), "2.5 hours")
+                self.assertEqual(
+                    numbers_to_digits("three quarters", "en", fractions=flag),
+                    "0.75")
+
+
+class TestScaleWordsFlag(unittest.TestCase):
+    """``scale_words=False`` converts the count and keeps the scale word."""
+
+    def test_default_expands_scale_words(self):
+        self.assertEqual(numbers_to_digits("66 million years ago", "en"),
+                         "66000000 years ago")
+        self.assertEqual(
+            numbers_to_digits("sixty six million years ago", "en"),
+            "66000000 years ago")
+        self.assertEqual(numbers_to_digits("two thousand and one", "en"), "2001")
+
+    def test_scale_word_kept_when_disabled(self):
+        self.assertEqual(
+            numbers_to_digits("66 million years ago", "en", scale_words=False),
+            "66 million years ago")
+        self.assertEqual(
+            numbers_to_digits("sixty six million years ago", "en",
+                              scale_words=False),
+            "66 million years ago")
+        self.assertEqual(
+            numbers_to_digits("three hundred years ago", "en",
+                              scale_words=False),
+            "3 hundred years ago")
+        # a compound spanning a scale word splits into its parts, by design
+        self.assertEqual(
+            numbers_to_digits("two thousand and one", "en", scale_words=False),
+            "2 thousand and 1")
+
+
+class TestFlagsCompose(unittest.TestCase):
+    """The realistic downstream call passes all three flags together."""
+
+    def setUp(self):
+        self.kwargs = dict(ordinals=True, fractions=False, scale_words=False)
+
+    def test_combined_call(self):
+        cases = {
+            "the twenty fifth of march": "the 25 of march",
+            "half past nine": "half past 9",
+            "a quarter to five": "a quarter to 5",
+            "sixty six million years ago": "66 million years ago",
+            "the third week of june": "the 3 week of june",
+            "wake me in twenty-four hours": "wake me in 24 hours",
+        }
+        for text, expected in cases.items():
+            with self.subTest(text=text):
+                self.assertEqual(
+                    numbers_to_digits(text, "en", **self.kwargs), expected)
+
+    def test_flags_are_independent(self):
+        # turning one flag off must not change what the others do
+        self.assertEqual(
+            numbers_to_digits("half past nine", "en", scale_words=False),
+            "0.5 past 9")
+        self.assertEqual(
+            numbers_to_digits("three hundred years ago", "en", fractions=False),
+            "300 years ago")
+
+
+class TestNotBugsGuard(unittest.TestCase):
+    """Correct behaviour that has been mistaken for a bug before. Leave it."""
+
+    def test_scale_expansion_is_correct_by_default(self):
+        # a number utility spells out the value it was given; the caller that
+        # wants the scale word kept asks for it with scale_words=False
+        self.assertEqual(numbers_to_digits("66 million years ago", "en"),
+                         "66000000 years ago")
+
+    def test_year_and_offset_forms(self):
+        self.assertEqual(numbers_to_digits("two thousand and one", "en"), "2001")
+        self.assertEqual(numbers_to_digits("five days ago", "en"), "5 days ago")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_numbers_to_digits_en_routing.py
+++ b/tests/test_numbers_to_digits_en_routing.py
@@ -1,0 +1,73 @@
+"""English `numbers_to_digits` routing and correctness.
+
+The public dispatcher must route English to the English implementation rather
+than the generic fallback. The generic fallback mis-read compound ordinals as
+arithmetic ("the twenty fifth" -> "the 20 0.2") and split hyphenated compounds
+("nineteen ninety-nine" -> "19 90 - 9"). These tests pin the routed behaviour
+and the two correctness fixes it depends on, using only the current public
+signature (no keyword flags).
+"""
+import unittest
+
+from ovos_number_parser import numbers_to_digits
+from ovos_number_parser.numbers_en import numbers_to_digits_en
+
+
+class TestEnglishDispatchRoute(unittest.TestCase):
+    """English must reach numbers_to_digits_en, not the generic fallback."""
+
+    def test_ordinal_compound_is_not_arithmetic(self):
+        # the generic fallback turned the ordinal into the reciprocal 1/5
+        self.assertEqual(numbers_to_digits("the twenty fifth", "en"), "the 20")
+
+    def test_plain_sentences_unchanged(self):
+        self.assertEqual(numbers_to_digits("two thousand and one", "en"), "2001")
+        self.assertEqual(numbers_to_digits("one hundred and one degrees", "en"),
+                         "101 degrees")
+        self.assertEqual(numbers_to_digits("it was five days ago", "en"),
+                         "it was 5 days ago")
+
+
+class TestOrdinalWordsAreNeverReciprocals(unittest.TestCase):
+    """An ordinal word must never be fabricated into a fraction."""
+
+    def test_ordinal_left_alone_when_ordinals_off(self):
+        self.assertEqual(numbers_to_digits_en("the twenty fifth"), "the 20")
+        self.assertEqual(numbers_to_digits_en("the third week of june"),
+                         "the third week of june")
+        self.assertEqual(numbers_to_digits_en("march fifth"), "march fifth")
+
+    def test_ordinal_parsed_when_asked(self):
+        self.assertEqual(numbers_to_digits_en("the twenty fifth", ordinals=True),
+                         "the 25")
+        self.assertEqual(
+            numbers_to_digits_en("the third week of june", ordinals=True),
+            "the 3 week of june")
+
+    def test_plural_denominators_are_still_fractions(self):
+        # "fifths"/"thirds" are unambiguously denominators, unlike the singular
+        self.assertEqual(numbers_to_digits_en("two fifths"), "0.4")
+        self.assertEqual(numbers_to_digits_en("three quarters"), "0.75")
+
+
+class TestHyphenatedCompounds(unittest.TestCase):
+    """A hyphen inside a compound numeral spells a space, not a break."""
+
+    def test_hyphen_does_not_split_the_number(self):
+        self.assertEqual(numbers_to_digits("nineteen ninety-nine", "en"),
+                         "19 99")
+        self.assertEqual(numbers_to_digits("twenty-four hours", "en"),
+                         "24 hours")
+        self.assertEqual(numbers_to_digits("thirty-one days", "en"), "31 days")
+
+    def test_hyphenated_ordinal(self):
+        self.assertEqual(numbers_to_digits_en("the twenty-fifth", ordinals=True),
+                         "the 25")
+
+    def test_minus_sign_and_ranges_survive(self):
+        self.assertEqual(numbers_to_digits_en("-5"), "-5.0")
+        self.assertEqual(numbers_to_digits_en("10-15 people"), "10-15 people")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_numbers_to_digits_flags_all_langs.py
+++ b/tests/test_numbers_to_digits_flags_all_langs.py
@@ -1,0 +1,310 @@
+"""`numbers_to_digits` conversion flags, for every supported language.
+
+`ordinals`, `fractions` and `scale_words` are part of the public contract, so
+they cannot be an English privilege. These tests iterate `SUPPORTED_LANGUAGES`
+rather than a hand-written list: adding a language to the package without
+deciding what the flags mean for it makes this file fail.
+
+The probe words are derived from the library itself (`pronounce_ordinal`,
+`pronounce_fraction`, `pronounce_number`), so no hand-translated vocabulary is
+hard-coded here and the tests keep working as vocabularies grow.
+
+Each language declares, per flag, one of three states:
+
+``HONOURED``
+    the flag changes the output in the documented direction.
+``NOTHING_TO_SUPPRESS``
+    the language never converted that kind of word in the first place, so the
+    output the flag asks for is what the caller already gets. The flag is
+    satisfied, with nothing left to do.
+``NO_VOCABULARY``
+    the language has no vocabulary of that kind at all (Kabyle counts only to
+    9999 and has no scale or fraction words), so the flag cannot apply.
+
+Two invariants hold for every language regardless of that state:
+defaults never change the output, and an ordinal word is never read as a
+fraction.
+"""
+import unittest
+
+from ovos_number_parser import (SUPPORTED_LANGUAGES, is_fractional, is_ordinal,
+                                numbers_to_digits, pronounce_fraction,
+                                pronounce_number, pronounce_ordinal)
+from ovos_number_parser import _is_fraction_word, _is_scale_word
+
+
+def _numbers_in(text):
+    """The numeric values present in converted output."""
+    values = []
+    for chunk in text.split():
+        try:
+            values.append(float(chunk))
+        except ValueError:
+            continue
+    return values
+
+HONOURED = "honoured"
+NOTHING_TO_SUPPRESS = "nothing to suppress"
+NO_VOCABULARY = "no vocabulary"
+
+#: lang -> (fractions state, scale_words state). `ordinals` is HONOURED for
+#: every supported language, so it needs no per-language entry.
+FLAG_SUPPORT = {
+    "an": (NOTHING_TO_SUPPRESS, HONOURED),
+    "ar": (HONOURED, HONOURED),
+    "ast": (NOTHING_TO_SUPPRESS, HONOURED),
+    "az": (HONOURED, HONOURED),
+    "bg": (HONOURED, HONOURED),
+    "ca": (HONOURED, HONOURED),
+    "cs": (HONOURED, HONOURED),
+    "da": (HONOURED, HONOURED),
+    "de": (HONOURED, NOTHING_TO_SUPPRESS),
+    "el": (HONOURED, HONOURED),
+    "en": (HONOURED, HONOURED),
+    "es": (HONOURED, HONOURED),
+    "et": (HONOURED, HONOURED),
+    "eu": (HONOURED, HONOURED),
+    "fa": (NOTHING_TO_SUPPRESS, HONOURED),
+    "fi": (HONOURED, HONOURED),
+    "fr": (HONOURED, HONOURED),
+    "fy": (HONOURED, HONOURED),
+    "gl": (NOTHING_TO_SUPPRESS, HONOURED),
+    "he": (HONOURED, HONOURED),
+    "hr": (HONOURED, HONOURED),
+    "hu": (HONOURED, HONOURED),
+    "id": (NOTHING_TO_SUPPRESS, NOTHING_TO_SUPPRESS),
+    "it": (HONOURED, HONOURED),
+    "kab": (NO_VOCABULARY, NO_VOCABULARY),
+    "ms": (NOTHING_TO_SUPPRESS, NOTHING_TO_SUPPRESS),
+    "mwl": (NOTHING_TO_SUPPRESS, HONOURED),
+    "nb": (HONOURED, HONOURED),
+    "nl": (HONOURED, HONOURED),
+    "nn": (HONOURED, HONOURED),
+    "oc": (NOTHING_TO_SUPPRESS, HONOURED),
+    "pl": (HONOURED, HONOURED),
+    "pt": (NOTHING_TO_SUPPRESS, HONOURED),
+    "ro": (NOTHING_TO_SUPPRESS, HONOURED),
+    "ru": (HONOURED, HONOURED),
+    "sk": (HONOURED, HONOURED),
+    "sl": (HONOURED, HONOURED),
+    "sv": (HONOURED, HONOURED),
+    "tr": (HONOURED, HONOURED),
+    "uk": (HONOURED, HONOURED),
+}
+
+
+def _ordinal_word(lang):
+    """A word meaning "third" in `lang`, taken from the library's own tables."""
+    try:
+        spoken = pronounce_ordinal(3, lang)
+    except Exception:
+        return None
+    for word in spoken.split():
+        try:
+            if is_ordinal(word, lang):
+                return word
+        except Exception:
+            continue
+    return None
+
+
+def _fraction_word(lang):
+    """A word meaning "half" in `lang`."""
+    try:
+        spoken = pronounce_fraction("1/2", lang)
+    except Exception:
+        return None
+    for word in spoken.split():
+        if _is_fraction_word(word, lang):
+            return word
+    return None
+
+
+def _scale_word(lang):
+    """A multiplier word meaning "million" in `lang`."""
+    try:
+        spoken = pronounce_number(1000000, lang)
+    except Exception:
+        return None
+    for word in spoken.split():
+        if _is_scale_word(word, lang):
+            return word
+    return None
+
+
+class TestFlagSupportIsDeclared(unittest.TestCase):
+    def test_every_supported_language_declares_its_flag_support(self):
+        self.assertEqual(sorted(FLAG_SUPPORT), sorted(SUPPORTED_LANGUAGES),
+                         "a language was added without declaring what the "
+                         "numbers_to_digits flags do for it")
+
+
+class TestDefaultsAreUnchanged(unittest.TestCase):
+    """The hard invariant: no default may alter a language's output."""
+
+    def test_explicit_defaults_match_the_plain_call(self):
+        for lang in SUPPORTED_LANGUAGES:
+            phrases = [pronounce_number(21, lang) + " xy",
+                       "xy " + pronounce_number(5, lang)]
+            word = _ordinal_word(lang)
+            if word:
+                phrases.append(f"xy {word} xy")
+            word = _fraction_word(lang)
+            if word:
+                phrases.append(f"{word} xy")
+            for phrase in phrases:
+                with self.subTest(lang=lang, phrase=phrase):
+                    self.assertEqual(
+                        numbers_to_digits(phrase, lang),
+                        numbers_to_digits(phrase, lang, ordinals=False,
+                                          fractions=True, scale_words=True))
+
+
+class TestOrdinalsAreNeverFractions(unittest.TestCase):
+    """No language may turn an ordinal word into a reciprocal."""
+
+    def test_bare_ordinal_never_becomes_a_fraction(self):
+        for lang in SUPPORTED_LANGUAGES:
+            word = _ordinal_word(lang)
+            if not word:
+                continue
+            with self.subTest(lang=lang, word=word):
+                out = numbers_to_digits(f"xy {word} xy", lang)
+                for chunk in out.split():
+                    try:
+                        val = float(chunk)
+                    except ValueError:
+                        continue
+                    self.assertTrue(
+                        float(val).is_integer(),
+                        f"{lang}: {word!r} was read as a fraction: {out!r}")
+
+
+class TestOrdinalsFlag(unittest.TestCase):
+    """`ordinals=True` reads ordinal words as their ordinal value everywhere."""
+
+    def test_ordinal_word_converts_for_every_language(self):
+        for lang in SUPPORTED_LANGUAGES:
+            word = _ordinal_word(lang)
+            if not word:
+                continue
+            with self.subTest(lang=lang, word=word):
+                out = numbers_to_digits(f"xy {word} xy", lang, ordinals=True)
+                self.assertIn("3", out, f"{lang}: {word!r} -> {out!r}")
+
+    def test_ordinal_word_is_left_alone_by_default(self):
+        # sv, uk and kab spell some ordinals exactly like the cardinal, so their
+        # modules read them as the plain number; that is the language, not a
+        # flag being ignored, and it is still never a fraction
+        always_numeric = {"sv", "uk", "kab"}
+        for lang in SUPPORTED_LANGUAGES:
+            if lang in always_numeric:
+                continue
+            word = _ordinal_word(lang)
+            if not word:
+                continue
+            with self.subTest(lang=lang, word=word):
+                self.assertIn(word, numbers_to_digits(f"xy {word} xy", lang))
+
+
+class TestFractionsFlag(unittest.TestCase):
+    def test_declared_behaviour_matches_reality(self):
+        for lang in SUPPORTED_LANGUAGES:
+            state = FLAG_SUPPORT[lang][0]
+            word = _fraction_word(lang)
+            if state == NO_VOCABULARY:
+                self.assertIsNone(word, f"{lang} declares no fraction words")
+                continue
+            self.assertIsNotNone(word, lang)
+            phrase = f"{word} xy"
+            default = numbers_to_digits(phrase, lang)
+            suppressed = numbers_to_digits(phrase, lang, fractions=False)
+            with self.subTest(lang=lang, word=word, state=state):
+                # whatever the state, the word must survive the flag
+                self.assertIn(word, suppressed,
+                              f"{lang}: {phrase!r} -> {suppressed!r}")
+                if state == HONOURED:
+                    self.assertNotEqual(default, suppressed, lang)
+                else:
+                    self.assertEqual(default, suppressed, lang)
+                    self.assertIn(word, default, lang)
+
+    def test_fraction_fused_into_a_quantity_still_converts(self):
+        # A fraction can only be held back while it is a word of its own. Where
+        # the language fuses it into the preceding number - one value out, not
+        # two - it is part of that number and the flag must leave it alone.
+        # Languages that simply read the pair as two numbers are not a quantity
+        # and are skipped: there the fraction really is bare.
+        for lang in SUPPORTED_LANGUAGES:
+            word = _fraction_word(lang)
+            if not word or FLAG_SUPPORT[lang][0] != HONOURED:
+                continue
+            phrase = f"{pronounce_number(2, lang)} {word}"
+            default = numbers_to_digits(phrase, lang)
+            if len(_numbers_in(default)) != 1:
+                continue  # read as two separate numbers: the fraction is bare
+            with self.subTest(lang=lang, phrase=phrase):
+                self.assertEqual(
+                    default, numbers_to_digits(phrase, lang, fractions=False),
+                    f"{lang}: a fraction fused into a quantity must still convert")
+
+
+class TestScaleWordsFlag(unittest.TestCase):
+    def test_declared_behaviour_matches_reality(self):
+        for lang in SUPPORTED_LANGUAGES:
+            state = FLAG_SUPPORT[lang][1]
+            word = _scale_word(lang)
+            if state == NO_VOCABULARY:
+                self.assertIsNone(word, f"{lang} declares no scale words")
+                continue
+            if word is None:
+                # the language spells its scale words in a way its own parser
+                # never converts; that is the NOTHING_TO_SUPPRESS case
+                self.assertEqual(state, NOTHING_TO_SUPPRESS, lang)
+                continue
+            count = pronounce_number(66, lang)
+            phrase = f"{count} {word} xy"
+            default = numbers_to_digits(phrase, lang)
+            kept = numbers_to_digits(phrase, lang, scale_words=False)
+            with self.subTest(lang=lang, word=word, state=state):
+                self.assertIn(word, kept, f"{lang}: {phrase!r} -> {kept!r}")
+                # the count itself must still be converted
+                self.assertTrue(any(ch.isdigit() for ch in kept),
+                                f"{lang}: {phrase!r} -> {kept!r}")
+                if state == HONOURED:
+                    self.assertNotEqual(default, kept, lang)
+                else:
+                    self.assertEqual(default, kept, lang)
+
+
+class TestFlagsComposeForEveryLanguage(unittest.TestCase):
+    def test_all_flags_together_never_raise_and_keep_words(self):
+        for lang in SUPPORTED_LANGUAGES:
+            # "xy" separates the probes so neighbouring numerals cannot fuse
+            # into one span and hide what is being asserted
+            parts = [pronounce_number(21, lang), "xy"]
+            frac = _fraction_word(lang)
+            scale = _scale_word(lang)
+            if frac:
+                parts += [frac, "xy"]
+            if scale:
+                parts += [pronounce_number(66, lang), scale]
+            phrase = " ".join(parts)
+            with self.subTest(lang=lang, phrase=phrase):
+                out = numbers_to_digits(phrase, lang, ordinals=True,
+                                        fractions=False, scale_words=False)
+                self.assertIsInstance(out, str)
+                # a word that names both a fraction and an ordinal (Persian
+                # "دوم" is "second" and the denominator alike) is claimed by
+                # ordinals=True, which the caller asked for
+                frac_is_ordinal = frac and _ordinal_word(lang) and \
+                    bool(is_ordinal(frac, lang))
+                if frac and not frac_is_ordinal \
+                        and FLAG_SUPPORT[lang][0] != NO_VOCABULARY:
+                    self.assertIn(frac, out, f"{lang}: {phrase!r} -> {out!r}")
+                if scale:
+                    self.assertIn(scale, out, f"{lang}: {phrase!r} -> {out!r}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_numbers_to_digits_fractions_all_langs.py
+++ b/tests/test_numbers_to_digits_fractions_all_langs.py
@@ -1,0 +1,123 @@
+"""The `fractions` flag of `numbers_to_digits`, for every supported language.
+
+`fractions` is part of the public contract, so it cannot be an English
+privilege. These tests iterate `SUPPORTED_LANGUAGES`; the probe word for "half"
+is taken from the library's own tables (`pronounce_fraction`), so no
+hand-translated vocabulary is hard-coded.
+
+Each language is one of two states, decided from the library itself rather than
+a hand-written table:
+
+* the language converts a bare fraction word, and ``fractions=False`` keeps it;
+* the language never converted that word, so ``fractions=False`` is already
+  what the caller gets.
+
+In both states the word must survive the flag, and the default must be unchanged.
+"""
+import unittest
+
+from ovos_number_parser import (SUPPORTED_LANGUAGES, numbers_to_digits,
+                                pronounce_fraction, pronounce_number)
+from ovos_number_parser import _is_fraction_word
+
+
+def _numbers_in(text):
+    values = []
+    for chunk in text.split():
+        try:
+            values.append(float(chunk))
+        except ValueError:
+            continue
+    return values
+
+
+def _fraction_word(lang):
+    """A word meaning "half" in `lang`, taken from the library's own tables."""
+    try:
+        spoken = pronounce_fraction("1/2", lang)
+    except Exception:
+        return None
+    for word in spoken.split():
+        if _is_fraction_word(word, lang):
+            return word
+    return None
+
+
+class TestDefaultsAreUnchanged(unittest.TestCase):
+    def test_explicit_default_matches_the_plain_call(self):
+        for lang in SUPPORTED_LANGUAGES:
+            word = _fraction_word(lang)
+            phrases = ["xy " + pronounce_number(5, lang)]
+            if word:
+                phrases.append(f"{word} xy")
+            for phrase in phrases:
+                with self.subTest(lang=lang, phrase=phrase):
+                    self.assertEqual(
+                        numbers_to_digits(phrase, lang),
+                        numbers_to_digits(phrase, lang, fractions=True))
+
+
+class TestFractionsFlag(unittest.TestCase):
+    def test_bare_fraction_word_survives_when_disabled(self):
+        for lang in SUPPORTED_LANGUAGES:
+            word = _fraction_word(lang)
+            if not word:
+                continue
+            phrase = f"{word} xy"
+            default = numbers_to_digits(phrase, lang)
+            suppressed = numbers_to_digits(phrase, lang, fractions=False)
+            with self.subTest(lang=lang, word=word):
+                # whatever the state, the word must survive the flag
+                self.assertIn(word, suppressed,
+                              f"{lang}: {phrase!r} -> {suppressed!r}")
+                if word in default:
+                    # the language never converted it: default already keeps it
+                    self.assertEqual(default, suppressed, lang)
+                else:
+                    # the language converts it: the flag must change the output
+                    self.assertNotEqual(default, suppressed, lang)
+
+    def test_fraction_fused_into_a_quantity_still_converts(self):
+        # A fraction can only be held back while it is a word of its own. Where
+        # the language fuses it into the preceding number - one value out, not
+        # two - it is part of that number and the flag must leave it alone.
+        for lang in SUPPORTED_LANGUAGES:
+            word = _fraction_word(lang)
+            if not word:
+                continue
+            phrase = f"{pronounce_number(2, lang)} {word}"
+            default = numbers_to_digits(phrase, lang)
+            if len(_numbers_in(default)) != 1:
+                continue  # read as two separate numbers: the fraction is bare
+            if word in default:
+                continue  # not converted at all: nothing to preserve
+            with self.subTest(lang=lang, phrase=phrase):
+                self.assertEqual(
+                    default, numbers_to_digits(phrase, lang, fractions=False),
+                    f"{lang}: a fraction fused into a quantity must still convert")
+
+
+class TestEnglishFractions(unittest.TestCase):
+    def test_bare_fraction_kept(self):
+        self.assertEqual(numbers_to_digits("half past nine", "en"),
+                         "0.5 past 9")
+        self.assertEqual(
+            numbers_to_digits("half past nine", "en", fractions=False),
+            "half past 9")
+        self.assertEqual(
+            numbers_to_digits("a quarter to five", "en", fractions=False),
+            "a quarter to 5")
+
+    def test_quantity_fraction_always_converts(self):
+        for flag in (True, False):
+            with self.subTest(fractions=flag):
+                self.assertEqual(
+                    numbers_to_digits("two and a half hours", "en",
+                                      fractions=flag), "2.5 hours")
+                self.assertEqual(
+                    numbers_to_digits("three quarters", "en", fractions=flag),
+                    "0.75")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_numbers_to_digits_ordinals_all_langs.py
+++ b/tests/test_numbers_to_digits_ordinals_all_langs.py
@@ -1,0 +1,111 @@
+"""The `ordinals` flag of `numbers_to_digits`, for every supported language.
+
+`ordinals` is part of the public contract, so it cannot be an English privilege.
+These tests iterate `SUPPORTED_LANGUAGES` rather than a hand-written list, and the
+probe word for "third" is taken from the library's own tables (`pronounce_ordinal`),
+so no hand-translated vocabulary is hard-coded.
+
+Two invariants hold for every language: the default never changes the output,
+and an ordinal word is never read as a fraction.
+"""
+import unittest
+
+from ovos_number_parser import (SUPPORTED_LANGUAGES, is_ordinal,
+                                numbers_to_digits, pronounce_number,
+                                pronounce_ordinal)
+
+
+def _ordinal_word(lang):
+    """A word meaning "third" in `lang`, taken from the library's own tables."""
+    try:
+        spoken = pronounce_ordinal(3, lang)
+    except Exception:
+        return None
+    for word in spoken.split():
+        try:
+            if is_ordinal(word, lang):
+                return word
+        except Exception:
+            continue
+    return None
+
+
+class TestDefaultsAreUnchanged(unittest.TestCase):
+    """The hard invariant: the ordinals default may not alter any output."""
+
+    def test_explicit_default_matches_the_plain_call(self):
+        for lang in SUPPORTED_LANGUAGES:
+            phrases = [pronounce_number(21, lang) + " xy",
+                       "xy " + pronounce_number(5, lang)]
+            word = _ordinal_word(lang)
+            if word:
+                phrases.append(f"xy {word} xy")
+            for phrase in phrases:
+                with self.subTest(lang=lang, phrase=phrase):
+                    self.assertEqual(
+                        numbers_to_digits(phrase, lang),
+                        numbers_to_digits(phrase, lang, ordinals=False))
+
+
+class TestOrdinalsAreNeverFractions(unittest.TestCase):
+    """No language may turn an ordinal word into a reciprocal."""
+
+    def test_bare_ordinal_never_becomes_a_fraction(self):
+        for lang in SUPPORTED_LANGUAGES:
+            word = _ordinal_word(lang)
+            if not word:
+                continue
+            with self.subTest(lang=lang, word=word):
+                out = numbers_to_digits(f"xy {word} xy", lang)
+                for chunk in out.split():
+                    try:
+                        val = float(chunk)
+                    except ValueError:
+                        continue
+                    self.assertTrue(
+                        float(val).is_integer(),
+                        f"{lang}: {word!r} was read as a fraction: {out!r}")
+
+
+class TestOrdinalsFlag(unittest.TestCase):
+    """`ordinals=True` reads ordinal words as their ordinal value everywhere."""
+
+    def test_ordinal_word_converts_for_every_language(self):
+        for lang in SUPPORTED_LANGUAGES:
+            word = _ordinal_word(lang)
+            if not word:
+                continue
+            with self.subTest(lang=lang, word=word):
+                out = numbers_to_digits(f"xy {word} xy", lang, ordinals=True)
+                self.assertIn("3", out, f"{lang}: {word!r} -> {out!r}")
+
+    def test_ordinal_word_is_left_alone_by_default(self):
+        # sv, uk and kab spell some ordinals exactly like the cardinal, so their
+        # modules read them as the plain number; that is the language, not a
+        # flag being ignored, and it is still never a fraction
+        always_numeric = {"sv", "uk", "kab"}
+        for lang in SUPPORTED_LANGUAGES:
+            if lang in always_numeric:
+                continue
+            word = _ordinal_word(lang)
+            if not word:
+                continue
+            with self.subTest(lang=lang, word=word):
+                self.assertIn(word, numbers_to_digits(f"xy {word} xy", lang))
+
+
+class TestEnglishOrdinalCompound(unittest.TestCase):
+    """The English compound-ordinal path is reachable through the flag."""
+
+    def test_compound_ordinal(self):
+        self.assertEqual(numbers_to_digits("the twenty fifth", "en"), "the 20")
+        self.assertEqual(
+            numbers_to_digits("the twenty fifth", "en", ordinals=True),
+            "the 25")
+        self.assertEqual(
+            numbers_to_digits("the twenty-fifth", "en", ordinals=True),
+            "the 25")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What this gives callers

`numbers_to_digits` gains a keyword-only `scale_words` flag (default `True`, so
existing callers are unchanged). When `False`, a multiplier scale word
("hundred", "thousand", "million", ...) is kept as a word and only the count is
converted:

```
scale_words=True   "sixty six million years ago" -> "66000000 years ago"
scale_words=False  "sixty six million years ago" -> "66 million years ago"
scale_words=False  "two thousand and one"        -> "2 thousand and 1"
```

The English backend drops scale words from its number vocabulary
(`_initialize_number_data_en`) so an unknown word ends the span; every other
language keeps its scale words as protected split points, so a number span can
never grow across one. `_is_scale_word` recognises a word whose *whole* value is
a power of ten (a multiplier), never a lexicalised numeral such as `"duzentos"`
(200).

## Language coverage

Honoured for every supported language. Languages whose parser never expands a
scale word (`de`, `id`, `ms`) already return what the flag asks for.

This completes the three-flag set. The new
`tests/test_numbers_to_digits_flags_all_langs.py` declares the per-language
support table for `fractions` and `scale_words` and checks it against reality
(it fails if a language is added without declaring its flag support);
`tests/test_numbers_to_digits_en_options.py` pins the English composition of all
three flags together.

**Defaults:** preserve current behaviour for every language.
Full suite green; adds the two test files above (27 tests total, iterating every
language plus English composition).

---
Part of splitting #283 into small, independently reviewable PRs.
**Review/merge order: 4 of 4.** Builds on #288 (the fractions flag).