### PR TITLE
feat(ar): register-aware pronunciation and Arabic dialect code resolution

### DIFF
--- a/ovos_number_parser/__init__.py
+++ b/ovos_number_parser/__init__.py
@@ -9,7 +9,7 @@ from unicode_rbnf import RbnfEngine, FormatPurpose
 from ovos_number_parser.numbers_ast import AST
 from ovos_number_parser.numbers_an import AN
 from ovos_number_parser.numbers_ar import pronounce_number_ar, pronounce_ordinal_ar, extract_number_ar, \
-    is_fractional_ar, is_ordinal_ar, nice_number_ar
+    is_fractional_ar, is_ordinal_ar, nice_number_ar, resolve_ar_lang
 from ovos_number_parser.numbers_az import numbers_to_digits_az, extract_number_az, is_fractional_az, pronounce_number_az
 from ovos_number_parser.numbers_bg import numbers_to_digits_bg, pronounce_number_bg, extract_number_bg, \
     is_fractional_bg, nice_number_bg
@@ -231,7 +231,8 @@ def _pronounce_fraction_generic(fraction_word: str, lang: str) -> str:
                 denom += "s"
         result = f"{pronounce_number(n1, lang)} {denom}"
     else:
-        nice_fn = _NICE_NUMBER_FNS.get(lang2)
+        nice_fn = _NICE_NUMBER_FNS.get(lang2) or \
+            (nice_number_ar if _is_ar(lang) else None)
         if nice_fn and 2 <= n2 <= 20:
             spoken = nice_fn(n1 / n2, speech=True, denominators=[n2])
             tokens = spoken.split()
@@ -282,7 +283,7 @@ def _numbers_to_digits_generic(utterance: str, lang: str) -> str:
     """Fallback that replaces spoken number spans with digits using
     extract_number over maximal runs of number words."""
     lang2 = lang.lower().split("-")[0]
-    connectors = _NUMBER_CONNECTORS.get(lang2, set())
+    connectors = _NUMBER_CONNECTORS.get("ar" if _is_ar(lang) else lang2, set())
     tokens = utterance.split()
     # ASCII plus Arabic comma, semicolon and question mark, so a number glued
     # to punctuation ("٢٠٢٤،", "25.") is still recognised and the mark is
@@ -552,6 +553,25 @@ def _base_lang(lang: str) -> str:
     return lang.lower().split("-")[0]
 
 
+def _is_ar(lang: str) -> bool:
+    """Whether ``lang`` names an Arabic variety this library serves.
+
+    Covers the BCP-47 macrolanguage code (``ar``, ``ar-SA``, ``ar-EG``, ...)
+    and the ISO 639-3 codes for Modern Standard Arabic and its spoken lects
+    (``arb``, ``ars``, ``acw``, ``afb``, ``arz``, ``apc``, ``ajp``, ``acm``,
+    ``ary``, ``aeb``, ``ayl``) -- see ``resolve_ar_lang`` for the table and
+    citations. A plain ``lang.startswith("ar")`` check would miss lects
+    whose code does not happen to start with "ar" (``acw``, ``afb``,
+    ``apc``, ``ajp``, ``acm``).
+    """
+    return resolve_ar_lang(lang) is not None
+
+
+def _ar_default_case(lang: str) -> str:
+    """Default pronunciation register for an Arabic ``lang`` code."""
+    return resolve_ar_lang(lang) or "nominative"
+
+
 def _pronounce_infinity(number: float, lang: str) -> str:
     """Spoken form of +/-infinity for any language (English default)."""
     pos, neg = _INFINITY_WORDS.get(_base_lang(lang), _INFINITY_WORDS["en"])
@@ -637,7 +657,8 @@ def pronounce_number(number: Union[int, float], lang: str,
                      ordinals: bool = False,
                      digits: Optional[DigitPronunciation] = None,
                      gender: GrammaticalGender = GrammaticalGender.MASCULINE,
-                     scale: Optional[Scale] = None) -> str:
+                     scale: Optional[Scale] = None,
+                     case: Optional[str] = None) -> str:
     """
     Return the spoken representation of a number in the specified language.
      
@@ -662,7 +683,13 @@ def pronounce_number(number: Union[int, float], lang: str,
             ``_canonical_scale``), per Wikipedia "Long and short scales"
             (https://en.wikipedia.org/wiki/Long_and_short_scales); an explicit
             value always overrides it.
-     
+        case (str, optional): Grammatical case/register, currently only
+            meaningful for Arabic ("nominative" or "oblique", see
+            ``pronounce_number_ar``). When omitted, the Arabic lect named by
+            ``lang`` uses its own default register (see
+            ``numbers_ar.resolve_ar_lang``); ignored for every other
+            language.
+
     Returns:
         str: The pronounced form of the number.
      
@@ -703,7 +730,7 @@ def pronounce_number(number: Union[int, float], lang: str,
     try:
         spoken = _pronounce_number_dispatch(
             number, lang, places, short_scale, scientific, ordinals,
-            digits, gender, scale)
+            digits, gender, scale, case)
     except (IndexError, KeyError, OverflowError):
         # A finite number overflowed a language's named-scale table. Kabyle
         # has a documented finite ceiling (raises above 9999), so keep that
@@ -731,13 +758,15 @@ def pronounce_number(number: Union[int, float], lang: str,
 
 
 def _pronounce_number_dispatch(number, lang, places, short_scale, scientific,
-                               ordinals, digits, gender, scale):
+                               ordinals, digits, gender, scale, case=None):
     if lang.startswith("en"):
         return pronounce_number_en(number, places, short_scale, scientific, ordinals)
     if lang.startswith("az"):
         return pronounce_number_az(number, places, short_scale, scientific, ordinals)
-    if lang.startswith("ar"):
-        return pronounce_number_ar(number, places, scientific, ordinals)
+    if _is_ar(lang):
+        return pronounce_number_ar(number, places, scientific, ordinals,
+                                   case=case if case is not None
+                                   else _ar_default_case(lang))
     if lang.startswith("bg"):
         return pronounce_number_bg(number, places, short_scale, scientific, ordinals)
     if lang.startswith("ca"):
@@ -897,7 +926,7 @@ def pronounce_ordinal(number: Union[int, float], lang: str,
         return OC.pronounce_ordinal(number, scale=scale, gender=gender)
     if lang.startswith("an"):
         return AN.pronounce_ordinal(number, scale=scale, gender=gender)
-    if lang.startswith("ar"):
+    if _is_ar(lang):
         return pronounce_ordinal_ar(number)
     if lang.startswith("da"):
         return pronounce_ordinal_da(number)
@@ -1015,7 +1044,7 @@ def extract_number(text: str, lang: str,
         return extract_number_en(text, short_scale, ordinals)
     if lang.startswith("az"):
         return extract_number_az(text, short_scale, ordinals)
-    if lang.startswith("ar"):
+    if _is_ar(lang):
         return extract_number_ar(text, ordinals)
     if lang.startswith("bg"):
         return extract_number_bg(text, short_scale, ordinals)
@@ -1122,7 +1151,7 @@ def is_fractional(input_str: str, lang: str,
         return is_fractional_en(input_str, short_scale)
     if lang.startswith("az"):
         return is_fractional_az(input_str, short_scale)
-    if lang.startswith("ar"):
+    if _is_ar(lang):
         return is_fractional_ar(input_str, short_scale)
     if lang.startswith("bg"):
         return is_fractional_bg(input_str, short_scale)
@@ -1229,7 +1258,7 @@ def is_ordinal(input_str: str, lang: str) -> Union[bool, float]:
         return AN.is_ordinal(input_str)
     if lang.startswith("en"):
         return is_ordinal_en(input_str)
-    if lang.startswith("ar"):
+    if _is_ar(lang):
         return is_ordinal_ar(input_str)
     if lang.startswith("de"):
         val = is_ordinal_de(input_str)

--- a/ovos_number_parser/numbers_ar.py
+++ b/ovos_number_parser/numbers_ar.py
@@ -1,12 +1,21 @@
-"""Number tools for Modern Standard Arabic.
+"""Number tools for Modern Standard Arabic and its major spoken lects.
 
-Pronunciation defaults to the masculine citation forms (the forms used for
-counting in the abstract). Extraction accepts both genders, since Arabic
-numerals 3-10 take the opposite gender of the counted noun (gender
-polarity), both nominative and oblique dual/plural case endings
-(``اثنان``/``اثنين``, ``عشرون``/``عشرين``), Western (0-9), Eastern
-Arabic-Indic (٠-٩) and Persian/Urdu (۰-۹) digits, and numbers written
-immediately adjacent to punctuation (``٢٠٢٤،``, ``25.``).
+Pronunciation defaults to the masculine nominative citation forms (the forms
+used for counting in the abstract, e.g. ``خمسون``, ``اثنان``). Connected
+speech governs numerals into the oblique (genitive/accusative) case instead
+(``خمسين``, ``اثنين``); pass ``case="oblique"`` to ``pronounce_number_ar`` to
+get those forms, see that function's docstring for the closed set of words
+this affects and the grammar reference. Extraction accepts both genders and
+both cases as input, since Arabic numerals 3-10 take the opposite gender of
+the counted noun (gender polarity), both nominative and oblique dual/plural
+case endings (``اثنان``/``اثنين``, ``عشرون``/``عشرين``), Western (0-9),
+Eastern Arabic-Indic (٠-٩) and Persian/Urdu (۰-۹) digits, and numbers
+written immediately adjacent to punctuation (``٢٠٢٤،``, ``25.``).
+
+``resolve_ar_lang`` maps BCP-47 and ISO 639-3 Arabic language codes (the
+literary standard and its major spoken lects) to this engine and to each
+lect's default register -- see its docstring for the code table and
+citations.
 """
 
 from math import isfinite
@@ -35,6 +44,55 @@ _NORM_TABLE[0x0670] = None  # superscript alef
 
 def _normalize_ar(text: str) -> str:
     return text.translate(_NORM_TABLE)
+
+
+# ---------------------------------------------------------------------------
+# dialect / language-code resolution
+# ---------------------------------------------------------------------------
+
+# ISO 639-3 codes for Arabic varieties routed to this engine, mapped to their
+# default pronunciation register. The literary standard (macrolanguage code
+# ``ar`` and its individual-language code ``arb``) keeps this module's
+# original nominative citation forms as the default; every spoken lect
+# defaults to the oblique case instead, since that is the case actually
+# produced when these numerals are used in connected speech in those lects.
+# Code meanings: ISO 639-3 code table, https://iso639-3.sil.org/code_tables/639/data
+# Individual lect entries: https://glottolog.org (search each code below).
+AR_DIALECT_DEFAULT_CASE = {
+    "ar": "nominative",   # BCP-47/ISO 639-1 macrolanguage code
+    "arb": "nominative",  # Standard Arabic (Modern Standard Arabic)
+    "ars": "oblique",     # Najdi Arabic
+    "acw": "oblique",     # Hijazi Arabic
+    "afb": "oblique",     # Gulf Arabic
+    "arz": "oblique",     # Egyptian Arabic
+    "apc": "oblique",     # North Levantine Arabic
+    "ajp": "oblique",     # South Levantine Arabic
+    "acm": "oblique",     # Mesopotamian Arabic (Iraqi)
+    "ary": "oblique",     # Moroccan Arabic
+    "aeb": "oblique",     # Tunisian Arabic
+    "ayl": "oblique",     # Libyan Arabic
+}
+
+
+def resolve_ar_lang(lang: str):
+    """
+    Resolve a BCP-47 or ISO 639-3 language code to this Arabic engine's
+    default pronunciation register.
+
+    Accepts the macrolanguage code (``ar``), BCP-47 forms built on it
+    (``ar-SA``, ``ar-EG``, ``ar-x-...``), and the ISO 639-3 codes for the
+    individual language and lects this engine serves (``arb``, ``ars``,
+    ``acw``, ``afb``, ``arz``, ``apc``, ``ajp``, ``acm``, ``ary``, ``aeb``,
+    ``ayl``), matched case-insensitively on the primary subtag.
+
+    Args:
+        lang (str): a BCP-47 or ISO 639-3 language code.
+    Returns:
+        (str) or (None): ``"nominative"`` or ``"oblique"``, the lect's
+                         default register, or None if ``lang`` does not name
+                         an Arabic variety this engine serves.
+    """
+    return AR_DIALECT_DEFAULT_CASE.get(lang.lower().split("-")[0])
 
 
 # masculine citation forms used for pronunciation
@@ -91,9 +149,34 @@ _ORDINAL_STEMS_FEM_AR = {1: "أولى", 2: "ثانية", 3: "ثالثة", 4: "ر
 # pronunciation
 # ---------------------------------------------------------------------------
 
-def _cardinal_two_digit_ar(number: int) -> str:
-    """0-99 in masculine citation forms; units come before tens."""
+def _oblique(word: str) -> str:
+    """
+    Oblique (genitive/accusative) form of a nominative dual or sound
+    masculine plural word, formed by replacing the nominative ending
+    (spelled ``ـان``/``ـون``) with the oblique ending (spelled ``ـين``).
+
+    This single substitution covers every closed set this module's oblique
+    register touches: the duals (``اثنان`` -> ``اثنين``, ``مئتان`` ->
+    ``مئتين``, ``ألفان`` -> ``ألفين``, ``مليونان`` -> ``مليونين``, the
+    fraction duals ``نصفان`` -> ``نصفين`` ...) and the tens (``خمسون`` ->
+    ``خمسين``), since both endings are two letters long. Citation: Karin C.
+    Ryding, "A Reference Grammar of Modern Standard Arabic" (Cambridge
+    University Press, 2005), section 9.2 (the dual, -ān/-ayn) and section
+    9.5.2 (the sound masculine plural / tens, -ūn/-īn).
+    """
+    return word[:-2] + "ين"
+
+
+def _cardinal_two_digit_ar(number: int, case: str = "nominative") -> str:
+    """0-99 in masculine citation forms; units come before tens.
+
+    ``case="oblique"`` inflects the dual of two (اثنان -> اثنين, in a units
+    slot) and the tens (عشرون -> عشرين). 11 (أحد عشر) and 12 (اثنا عشر) are
+    fixed compounds outside those closed sets and are not inflected.
+    """
     if number <= 10:
+        if number == 2 and case == "oblique":
+            return _oblique(_ONES_AR[2])
         return _ONES_AR[number]
     if number == 11:
         return "أحد عشر"
@@ -102,25 +185,32 @@ def _cardinal_two_digit_ar(number: int) -> str:
     if number < 20:
         return _ONES_AR[number - 10] + " عشر"
     tens, unit = divmod(number, 10)
+    tens_word = _TENS_AR[tens * 10]
+    if case == "oblique":
+        tens_word = _oblique(tens_word)
     if unit == 0:
-        return _TENS_AR[tens * 10]
-    return _ONES_AR[unit] + _AR_SEPARATOR + _TENS_AR[tens * 10]
+        return tens_word
+    unit_word = _oblique(_ONES_AR[2]) if unit == 2 and case == "oblique" \
+        else _ONES_AR[unit]
+    return unit_word + _AR_SEPARATOR + tens_word
 
 
-def _cardinal_three_digit_ar(number: int) -> str:
+def _cardinal_three_digit_ar(number: int, case: str = "nominative") -> str:
     """0-999 in masculine citation forms."""
     if number < 100:
-        return _cardinal_two_digit_ar(number)
+        return _cardinal_two_digit_ar(number, case)
     hundreds, rest = divmod(number, 100)
     result = _HUNDREDS_AR[hundreds * 100]
+    if hundreds == 2 and case == "oblique":
+        result = _oblique(result)
     if rest:
-        result += _AR_SEPARATOR + _cardinal_two_digit_ar(rest)
+        result += _AR_SEPARATOR + _cardinal_two_digit_ar(rest, case)
     return result
 
 
-def _cardinal_ar(number: int) -> str:
+def _cardinal_ar(number: int, case: str = "nominative") -> str:
     if number < 1000:
-        return _cardinal_three_digit_ar(number)
+        return _cardinal_three_digit_ar(number, case)
     parts = []
     remainder = number
     for value, singular, dual, plural in reversed(_SCALES_AR):
@@ -130,29 +220,36 @@ def _cardinal_ar(number: int) -> str:
         if count == 1:
             parts.append(singular)
         elif count == 2:
-            parts.append(dual)
+            parts.append(_oblique(dual) if case == "oblique" else dual)
         elif 3 <= count <= 10:
             # scale nouns are masculine, so 3-10 take the ة-marked numeral
             parts.append(_ONES_AR[count] + " " + plural)
         else:
-            parts.append(_cardinal_ar(count) + " " + singular)
+            parts.append(_cardinal_ar(count, case) + " " + singular)
     if remainder:
-        parts.append(_cardinal_three_digit_ar(remainder))
+        parts.append(_cardinal_three_digit_ar(remainder, case))
     return _AR_SEPARATOR.join(parts)
 
 
-def pronounce_number_ar(number, places=2, scientific=False, ordinals=False):
+def pronounce_number_ar(number, places=2, scientific=False, ordinals=False,
+                        case="nominative"):
     """
-    Convert a number to its spoken Modern Standard Arabic equivalent.
+    Convert a number to its spoken Arabic equivalent.
 
-    Uses masculine citation forms; the decimal part is read digit by digit
-    after "فاصلة" (e.g. 5.2 -> "خمسة فاصلة اثنان").
+    Uses masculine forms; the decimal part is read digit by digit after
+    "فاصلة" (e.g. 5.2 -> "خمسة فاصلة اثنان").
 
     Args:
         number (float or int): the number to pronounce
         places (int): maximum decimal places to speak
         scientific (bool): pronounce in scientific notation
         ordinals (bool): pronounce in ordinal form "الأول" instead of "واحد"
+        case (str): "nominative" (default, unchanged citation forms:
+            خمسون, اثنان, مئتان, ...) or "oblique", the case Arabic
+            numerals actually take in connected speech (خمسين, اثنين,
+            مئتين, ...). Only affects the closed sets documented on
+            ``_oblique``; every other word is identical in both registers.
+            Ordinals (``ordinals=True``) are unaffected by ``case``.
     Returns:
         (str): The pronounced number
     """
@@ -166,18 +263,19 @@ def pronounce_number_ar(number, places=2, scientific=False, ordinals=False):
         n, power = ('%E' % number).replace("+", "").split("E")
         power = int(power)
         if power != 0:
-            mantissa = pronounce_number_ar(abs(float(n)), places)
-            exponent = pronounce_number_ar(abs(power), places)
+            mantissa = pronounce_number_ar(abs(float(n)), places, case=case)
+            exponent = pronounce_number_ar(abs(power), places, case=case)
             return "{}{} في عشرة أس {}{}".format(
                 _MINUS_AR + " " if float(n) < 0 else "", mantissa,
                 _MINUS_AR + " " if power < 0 else "", exponent)
     if ordinals:
         return pronounce_ordinal_ar(number)
     if number < 0:
-        return _MINUS_AR + " " + pronounce_number_ar(abs(number), places)
+        return _MINUS_AR + " " + pronounce_number_ar(abs(number), places,
+                                                      case=case)
 
     whole = int(number)
-    result = _cardinal_ar(whole)
+    result = _cardinal_ar(whole, case)
     if isinstance(number, float) and number != whole and places > 0:
         digits = ("%." + str(places) + "f") % (number - whole)
         digits = digits.split(".")[1].rstrip("0")
@@ -214,18 +312,22 @@ def pronounce_ordinal_ar(number):
     return "ال" + _cardinal_ar(number)
 
 
-def nice_number_ar(number, speech=True, denominators=range(1, 11)):
+def nice_number_ar(number, speech=True, denominators=range(1, 11),
+                   case="nominative"):
     """Arabic helper for nice_number
 
     Formats a float as a whole number plus an Arabic fraction noun, e.g.
     4.5 becomes "4 ونصف" for speech and "4 1/2" for text. Fraction nouns
     exist for denominators 2-10 (نصف, ثلث, ربع, ...); the dual is used for
-    a numerator of 2 (ثلثان) and the plural for 3-10 (ثلاثة أرباع).
+    a numerator of 2 (ثلثان, or ثلثين in the oblique case) and the plural
+    for 3-10 (ثلاثة أرباع).
 
     Args:
         number (int or float): the float to format
         speech (bool): format for speech (True) or display (False)
         denominators (iter of ints): denominators to use, default [1 .. 10]
+        case (str): "nominative" (default, e.g. نصفان) or "oblique"
+            (نصفين), see ``pronounce_number_ar``.
     Returns:
         (str): The formatted string.
     """
@@ -244,13 +346,13 @@ def nice_number_ar(number, speech=True, denominators=range(1, 11)):
         if num == 1:
             frac = singular
         elif num == 2:
-            frac = dual
+            frac = _oblique(dual) if case == "oblique" else dual
         else:
             frac = '{} {}'.format(num, plural)
     elif num == 1:
-        frac = 'جزء من {}'.format(_cardinal_ar(den))
+        frac = 'جزء من {}'.format(_cardinal_ar(den, case))
     else:
-        frac = '{} أجزاء من {}'.format(num, _cardinal_ar(den))
+        frac = '{} أجزاء من {}'.format(num, _cardinal_ar(den, case))
     if whole == 0:
         return frac
     return '{} و{}'.format(whole, frac)

--- a/tests/test_number_parser_ar_register_dialects.py
+++ b/tests/test_number_parser_ar_register_dialects.py
@@ -1,0 +1,226 @@
+"""Register-aware Arabic pronunciation and Arabic dialect language-code
+routing.
+
+Gold strings for the oblique (genitive/accusative) forms are hand-derived
+from the closed-set substitution documented on ``numbers_ar._oblique``: the
+nominative dual ending -ān and the nominative sound-masculine-plural (tens)
+ending -ūn are both spelled with two letters (``ان``/``ون``) and are both
+replaced by the two-letter oblique ending -īn (``ين``). Citation: Karin C.
+Ryding, "A Reference Grammar of Modern Standard Arabic" (Cambridge
+University Press, 2005), section 9.2 (the dual) and section 9.5.2 (the
+sound masculine plural / tens) on the nominative vs oblique case endings.
+
+ISO 639-3 code meanings used below are from the SIL code table,
+https://iso639-3.sil.org/code_tables/639/data, cross-checked against
+Glottolog (https://glottolog.org).
+"""
+import unittest
+
+from ovos_number_parser import (extract_number, pronounce_number,
+                                pronounce_ordinal, is_fractional, is_ordinal)
+from ovos_number_parser.numbers_ar import (pronounce_number_ar,
+                                           nice_number_ar, resolve_ar_lang)
+
+
+class TestArabicRegisterPronunciation(unittest.TestCase):
+    """pronounce_number_ar(case=...) / pronounce_number(..., case=...)."""
+
+    def test_default_is_byte_identical_to_pre_existing_behaviour(self):
+        # case defaults to "nominative"; omitting it must not change a
+        # single output versus the pre-existing (pre-feature) behaviour.
+        for number in [0, 1, 2, 11, 12, 20, 22, 25, 42, 50, 99, 100, 123,
+                       200, 223, 999, 1000, 1985, 2000, 2023, 2000000,
+                       2000000000, -42, 5.2, 5.25]:
+            with self.subTest(number=number):
+                self.assertEqual(pronounce_number_ar(number),
+                                 pronounce_number_ar(number, case="nominative"))
+                self.assertEqual(pronounce_number(number, lang="ar"),
+                                 pronounce_number_ar(number))
+
+    def test_tens_oblique(self):
+        expected = {20: 'عشرين', 30: 'ثلاثين', 40: 'أربعين', 50: 'خمسين',
+                    60: 'ستين', 70: 'سبعين', 80: 'ثمانين', 90: 'تسعين'}
+        for number, spoken in expected.items():
+            with self.subTest(number=number):
+                self.assertEqual(
+                    pronounce_number_ar(number, case="oblique"), spoken)
+
+    def test_compound_tens_oblique(self):
+        expected = {21: 'واحد وعشرين', 22: 'اثنين وعشرين',
+                    25: 'خمسة وعشرين', 42: 'اثنين وأربعين',
+                    66: 'ستة وستين', 99: 'تسعة وتسعين'}
+        for number, spoken in expected.items():
+            with self.subTest(number=number):
+                self.assertEqual(
+                    pronounce_number_ar(number, case="oblique"), spoken)
+
+    def test_duals_oblique(self):
+        expected = {2: 'اثنين', 200: 'مئتين', 2000: 'ألفين',
+                    2000000: 'مليونين', 2000000000: 'مليارين'}
+        for number, spoken in expected.items():
+            with self.subTest(number=number):
+                self.assertEqual(
+                    pronounce_number_ar(number, case="oblique"), spoken)
+
+    def test_hundreds_compounds_oblique(self):
+        expected = {123: 'مئة وثلاثة وعشرين',
+                    223: 'مئتين وثلاثة وعشرين',
+                    999: 'تسعمئة وتسعة وتسعين',
+                    1985: 'ألف وتسعمئة وخمسة وثمانين',
+                    2023: 'ألفين وثلاثة وعشرين'}
+        for number, spoken in expected.items():
+            with self.subTest(number=number):
+                self.assertEqual(
+                    pronounce_number_ar(number, case="oblique"), spoken)
+
+    def test_scales_oblique(self):
+        # 3-10 counted scale nouns and single/plural scale words are outside
+        # the dual/tens closed set and are unaffected by case
+        self.assertEqual(pronounce_number_ar(3000, case="oblique"),
+                         'ثلاثة آلاف')
+        self.assertEqual(pronounce_number_ar(1000000, case="oblique"),
+                         'مليون')
+        self.assertEqual(pronounce_number_ar(1000000000, case="oblique"),
+                         'مليار')
+
+    def test_fractions_dual_oblique(self):
+        self.assertEqual(nice_number_ar(2 / 3, denominators=[3]), 'ثلثان')
+        self.assertEqual(
+            nice_number_ar(2 / 3, denominators=[3], case="oblique"),
+            'ثلثين')
+        self.assertEqual(nice_number_ar(2 / 2, denominators=[2]), '1')
+        # 1 whole + 2/4ths, numerator 2 -> dual of ربع (ربعان / ربعين)
+        self.assertEqual(nice_number_ar(1 + 2 / 4, denominators=[4]),
+                         '1 وربعان')
+        self.assertEqual(
+            nice_number_ar(1 + 2 / 4, denominators=[4], case="oblique"),
+            '1 وربعين')
+
+    def test_decimals_unaffected_by_case(self):
+        # decimal digits are read one at a time in their citation form
+        # regardless of register; only the closed dual/tens sets inflect
+        for number in [5.2, 5.25, 0.5, -3.5]:
+            with self.subTest(number=number):
+                self.assertEqual(
+                    pronounce_number_ar(number, case="oblique"),
+                    pronounce_number_ar(number))
+
+    def test_negative_oblique(self):
+        self.assertEqual(pronounce_number_ar(-42, case="oblique"),
+                         'سالب اثنين وأربعين')
+        self.assertEqual(pronounce_number_ar(-7, case="oblique"),
+                         'سالب سبعة')
+
+    def test_ordinals_unaffected_by_case(self):
+        # ordinals do not carry the nominative/oblique case distinction
+        # this feature adds; case is accepted but has no effect
+        for number in [1, 2, 12, 20, 21, 25, 100]:
+            with self.subTest(number=number):
+                self.assertEqual(
+                    pronounce_number_ar(number, ordinals=True, case="oblique"),
+                    pronounce_number_ar(number, ordinals=True))
+                self.assertEqual(
+                    pronounce_ordinal(number, lang="ar"),
+                    pronounce_number_ar(number, ordinals=True))
+
+    def test_top_level_pronounce_number_case_kwarg(self):
+        self.assertEqual(pronounce_number(55, lang="ar", case="oblique"),
+                         'خمسة وخمسين')
+        self.assertEqual(pronounce_number(55, lang="ar"), 'خمسة وخمسون')
+        self.assertEqual(pronounce_number(55, lang="ar", case="nominative"),
+                         'خمسة وخمسون')
+
+
+class TestArabicDialectResolution(unittest.TestCase):
+    """resolve_ar_lang and the dialect-aware dispatch it drives."""
+
+    def test_resolve_ar_lang_table(self):
+        # arb (Standard Arabic) and the ar macrolanguage default nominative
+        self.assertEqual(resolve_ar_lang("ar"), "nominative")
+        self.assertEqual(resolve_ar_lang("arb"), "nominative")
+        # spoken lects default to the oblique case, per grammatical
+        # description of these varieties (colloquial Arabic has lost the
+        # nominative -ūn/-ān as productive case marking in most contexts and
+        # generalizes the oblique -īn form; see e.g. Kristen Brustad, "The
+        # Syntax of Spoken Arabic" (Georgetown UP, 2000), ch. 2)
+        for code in ["ars", "acw", "afb", "arz", "apc", "ajp", "acm", "ary",
+                     "aeb", "ayl"]:
+            with self.subTest(code=code):
+                self.assertEqual(resolve_ar_lang(code), "oblique")
+
+    def test_resolve_ar_lang_bcp47_forms(self):
+        for code in ["ar-SA", "ar-EG", "AR", "ar-x-something"]:
+            with self.subTest(code=code):
+                self.assertEqual(resolve_ar_lang(code), "nominative")
+        for code in ["ars-SA", "ARZ", "afb-KW"]:
+            with self.subTest(code=code):
+                self.assertEqual(resolve_ar_lang(code), "oblique")
+
+    def test_resolve_ar_lang_rejects_non_arabic_ar_prefixed_codes(self):
+        # "arn" (Mapudungun) and "arc" (Official Aramaic) both start with
+        # "ar" but are not Arabic; a lang.startswith("ar") check would
+        # wrongly route them to this engine, resolve_ar_lang must not
+        self.assertIsNone(resolve_ar_lang("arn"))
+        self.assertIsNone(resolve_ar_lang("arc"))
+        self.assertIsNone(resolve_ar_lang("en"))
+        self.assertIsNone(resolve_ar_lang(""))
+
+    def test_dialects_pronounce_with_their_default_register(self):
+        # a code missed by "startswith('ar')" (does not begin with "ar")
+        for code in ["acw", "afb", "apc", "ajp", "acm"]:
+            with self.subTest(code=code):
+                self.assertEqual(pronounce_number(55, lang=code),
+                                 'خمسة وخمسين')
+                self.assertEqual(pronounce_number(2, lang=code), 'اثنين')
+                self.assertEqual(pronounce_number(200, lang=code), 'مئتين')
+
+        # codes that DID already start with "ar" (ars, arz, ary, aeb, ayl)
+        for code in ["ars", "arz", "ary", "aeb", "ayl"]:
+            with self.subTest(code=code):
+                self.assertEqual(pronounce_number(55, lang=code),
+                                 'خمسة وخمسين')
+
+        # the literary standard keeps the nominative default
+        for code in ["ar", "arb"]:
+            with self.subTest(code=code):
+                self.assertEqual(pronounce_number(55, lang=code),
+                                 'خمسة وخمسون')
+
+    def test_explicit_case_overrides_dialect_default(self):
+        self.assertEqual(
+            pronounce_number(55, lang="afb", case="nominative"),
+            'خمسة وخمسون')
+        self.assertEqual(
+            pronounce_number(55, lang="ar", case="oblique"),
+            'خمسة وخمسين')
+
+    def test_extract_number_dispatch(self):
+        for code in ["acw", "afb", "apc", "ajp", "acm", "ars", "arz", "ary",
+                     "aeb", "ayl", "arb"]:
+            with self.subTest(code=code):
+                self.assertEqual(
+                    extract_number("خمسة وعشرون", lang=code), 25)
+                # extraction already accepted both cases as input before
+                # this change; dialect routing must not break that
+                self.assertEqual(
+                    extract_number("خمسة وعشرين", lang=code), 25)
+
+    def test_pronounce_ordinal_dispatch(self):
+        for code in ["acw", "afb", "apc", "ajp", "acm"]:
+            with self.subTest(code=code):
+                self.assertEqual(pronounce_ordinal(25, lang=code),
+                                 'الخامس والعشرون')
+
+    def test_is_fractional_dispatch(self):
+        for code in ["acw", "afb", "apc", "ajp", "acm"]:
+            with self.subTest(code=code):
+                self.assertEqual(is_fractional("نصف", lang=code), 0.5)
+
+    def test_is_ordinal_dispatch(self):
+        for code in ["acw", "afb", "apc", "ajp", "acm"]:
+            with self.subTest(code=code):
+                self.assertEqual(is_ordinal("الخامس", lang=code), 5)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

## Summary

Two additions to Arabic support, kept out of the extraction functions in
`numbers_ar.py` (a sibling PR is editing those):

1. **Register-aware pronunciation.** `pronounce_number_ar` gains
   `case="nominative"|"oblique"`. Today it only emits the masculine
   nominative citation forms (خمسون, اثنان, مئتان). `case="oblique"` emits
   the forms Arabic numerals actually take in connected speech (خمسين,
   اثنين, مئتين). Threaded through `pronounce_number(..., case=...)` the
   same way `gender`/`digits` are already threaded per-language in
   `__init__.py` — no new dispatch mechanism invented. Default output is
   unchanged (proved by re-running the existing `test_number_parser_ar.py`
   suite unmodified — all pass — plus an explicit byte-identical assertion
   in the new tests).

2. **Arabic dialect code resolution.** `lang.startswith("ar")` missed
   ISO 639-3 codes for lects that don't happen to start with "ar" (`acw`
   Hijazi, `afb` Gulf, `apc` North Levantine, `ajp` South Levantine, `acm`
   Iraqi), and could have falsely matched unrelated codes that do
   (`arn` Mapudungun, `arc` Aramaic). Added `resolve_ar_lang(lang)` in
   `numbers_ar.py`: a table mapping the macrolanguage code (`ar`) and the
   individual/lect ISO 639-3 codes this engine now serves to a default
   register — spoken lects default to `oblique` (the register they
   actually use), the literary standard (`ar`/`arb`) keeps `nominative`.
   Wired into every `ar` dispatch point in `__init__.py`: `pronounce_number`,
   `pronounce_ordinal`, `extract_number`, `is_fractional`, `is_ordinal`, plus
   two incidental fallback lookups (`nice_number` used inside the generic
   fraction pronouncer, and the connector-word table used inside
   `numbers_to_digits`'s generic fallback). Adding a new dialect is one
   table row.

## Before / after

| Input | Old (all lang codes) | New |
|---|---|---|
| `pronounce_number(55, lang="ar")` | خمسة وخمسون | خمسة وخمسون (unchanged) |
| `pronounce_number(55, lang="ar", case="oblique")` | n/a (no such kwarg) | خمسة وخمسين |
| `pronounce_number(2, lang="ar", case="oblique")` | n/a | اثنين |
| `pronounce_number(200, lang="ar", case="oblique")` | n/a | مئتين |
| `pronounce_number(55, lang="afb")` (Gulf Arabic) | `NotImplementedError` (didn't start with "ar") | خمسة وخمسين (dialect default = oblique) |
| `pronounce_number(55, lang="acw")` (Hijazi) | `NotImplementedError` | خمسة وخمسين |
| `pronounce_number(55, lang="arb")` (MSA) | خمسة وخمسون (accidental startswith match) | خمسة وخمسون (now via explicit table, default nominative) |
| `resolve_ar_lang("arn")` (Mapudungun) | n/a — old code would have wrongly routed `arn`/`arc` through `pronounce_number_ar` since `"arn".startswith("ar")` | `None` (not Arabic) |

## Tests

New file `tests/test_number_parser_ar_register_dialects.py`, hand-derived
gold strings, no test reads its expectation back from the parser:
- Default-unchanged assertions across the full existing value set.
- Oblique register: tens, compound tens, duals (2, 200, 2000, 2×10^6,
  2×10^9), hundreds compounds, scale words (unaffected, outside the closed
  set), fraction duals, decimals (unaffected — digit-by-digit reading isn't
  case-governed), negatives, ordinals (unaffected).
- `resolve_ar_lang`: the full dialect table, BCP-47 region/private-use
  forms, and the negative case (`arn`, `arc`, `en`, `""` all return `None`).
- Dispatch coverage for `pronounce_number`, `pronounce_ordinal`,
  `extract_number`, `is_fractional`, `is_ordinal` across every new dialect
  code.

Verified the new tests actually fail against the pre-fix code (stashed the
two source files, re-ran — `ImportError: cannot import name
'resolve_ar_lang'`), then re-applied and confirmed green.

Full suite: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/` — **1614
passed, 1 skipped, 1 xfailed** (was 1594 passed before this branch; the
delta is the 20 new tests here, nothing else moved).

## Citations

- Karin C. Ryding, *A Reference Grammar of Modern Standard Arabic*
  (Cambridge University Press, 2005), §9.2 (the dual, nominative -ān /
  oblique -ayn) and §9.5.2 (the sound masculine plural / tens, nominative
  -ūn / oblique -īn) — grammatical basis for the `_oblique()` substitution.
- Kristen Brustad, *The Syntax of Spoken Arabic* (Georgetown University
  Press, 2000), ch. 2 — spoken/colloquial Arabic generalizes the oblique
  form, motivating the dialect default.
- ISO 639-3 code table: https://iso639-3.sil.org/code_tables/639/data
- Glottolog (cross-checked each lect code): https://glottolog.org

## Scope note

Per instructions, this PR does not touch the extraction functions in
`numbers_ar.py` (a sibling PR owns that surface) — only pronunciation and
the top-level dispatch in `__init__.py`. No merge conflicts were hit while
preparing this branch.
