### PR TITLE
fix(ar): spaced unit+hundred parses additively (خمس مية وثلاثين → 135 instead of 530)

### DIFF
--- a/ovos_number_parser/numbers_ar.py
+++ b/ovos_number_parser/numbers_ar.py
@@ -450,7 +450,7 @@ _FUSED_TEENS_LOOKUP = _norm_map({
 })
 _MINUS_LOOKUP = _norm_keys({"سالب", "ناقص"})
 _DECIMAL_LOOKUP = _norm_keys({"فاصلة", "فاصله"})
-_HUNDRED_MULT_LOOKUP = _norm_keys({"مئة", "مائة"})
+_HUNDRED_MULT_LOOKUP = _norm_keys({"مئة", "مائة", "مية", "ميه"})
 
 _ORDINAL_UNITS_LOOKUP = _norm_map(
     {stem: value for value, stem in _ORDINAL_STEMS_AR.items()})

--- a/tests/test_number_parser_ar.py
+++ b/tests/test_number_parser_ar.py
@@ -329,6 +329,32 @@ class TestArabicColloquialExtract(unittest.TestCase):
         # 100 + 50 = 150
         self.assertEqual(extract_number_ar("ميه وخمسين"), 150)
 
+    def test_spaced_unit_plus_colloquial_hundred_multiplies(self):
+        # "خمس مية وثلاثين" = 5 * 100 + 30 = 530 (spaced unit + مية/ميه must
+        # multiply exactly like the already-supported spaced unit + مئة/مائة,
+        # e.g. "ثلاث مئة" = 300 handled by _parse_number_span). Reproduced
+        # live from sherpa STT output in the Salesteq voice pipeline, where
+        # the spaced (non-fused) colloquial form is what the ASR emits.
+        self.assertEqual(extract_number_ar("خمس مية وثلاثين"), 530)
+        # with the definite article fronting the unit word
+        self.assertEqual(extract_number_ar("الخمس مية وثلاثين"), 530)
+        # bare spaced unit + مية: 3 * 100 = 300
+        self.assertEqual(extract_number_ar("ثلاث مية"), 300)
+        # spaced unit + ميه + tail unit: 7 * 100 + 5 = 705
+        self.assertEqual(extract_number_ar("سبع ميه وخمسة"), 705)
+
+    def test_spaced_unit_plus_hundred_in_sentence(self):
+        self.assertEqual(
+            numbers_to_digits(
+                "وش الفرق بينها وبين الخمس مية وثلاثين", lang="ar"),
+            "وش الفرق بينها وبين 530")
+
+    def test_non_regression_bare_hundred_and_fused_hundred(self):
+        # a bare مية (no preceding unit) still means 100 + tens, unaffected
+        self.assertEqual(extract_number_ar("مية وثلاثين"), 130)
+        # the already-fused form (PR #290) keeps working
+        self.assertEqual(extract_number_ar("الخمسمية وثلاثين"), 530)
+
     def test_fused_dialectal_teens(self):
         # dialectal fused teens (Gulf/Levantine): unit+عشر fused into one
         # word, cf. https://en.wikipedia.org/wiki/Arabic_numerals#Numbers_11-19


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

## Bug

sherpa STT emits the **spaced**
colloquial hundred form (unit word + مية/ميه as two separate tokens), and
`extract_number`/`numbers_to_digits` in `ar` mis-parsed it additively instead
of multiplicatively.

Repro (0.19.10a1):

```python
extract_number('خمس مية وثلاثين', lang='ar')   # -> 135 (5 + 130), should be 530 (5*100 + 30)
extract_number('الخمس مية وثلاثين', lang='ar')  # -> 135, should be 530 (definite article variant)
```

The **fused** form already worked correctly:

```python
extract_number('الخمسمية وثلاثين', lang='ar')  # -> 530, correct (fused-hundreds support from #290)
```

## Root cause

`_parse_number_span` in `ovos_number_parser/numbers_ar.py` has a rule that
makes a bare unit digit word (خمس/ثلاث/أربع/...) multiply with a following
standalone hundred word ("ثلاث مئة" = 300), but the lookup table backing that
rule, `_HUNDRED_MULT_LOOKUP`, only contained the classical spellings مئة and
مائة — not the colloquial مية/ميه that `#290` already added to the *fused*
hundred vocabulary (`_HUNDREDS_LOOKUP`, e.g. خمسمية). So "خمس مية" (spaced)
fell through to being parsed as two separate numbers (5, then "مية وثلاثين"
= 130), while "خمسمية" (fused, one token) hit the already-correct fused-word
path.

## Fix

One-line addition to the lookup:

```python
_HUNDRED_MULT_LOOKUP = _norm_keys({"مئة", "مائة", "مية", "ميه"})
```

Also verified: خمس آلاف / خمسة آلاف (thousands) already multiply correctly
via the generic scale-word path — no fix needed there.

## Testing

Added to `tests/test_number_parser_ar.py::TestArabicColloquialExtract`,
gold values computed by hand arithmetic (never read back from the parser):

- `خمس مية وثلاثين` → 530 (5*100 + 30)
- `الخمس مية وثلاثين` → 530 (definite article)
- `ثلاث مية` → 300
- `سبع ميه وخمسة` → 705 (7*100 + 5)
- `numbers_to_digits('وش الفرق بينها وبين الخمس مية وثلاثين', lang='ar')` →
  `'وش الفرق بينها وبين 530'`
- non-regression: `مية وثلاثين` → 130 (bare hundred unaffected),
  `الخمسمية وثلاثين` → 530 (fused form from #290 still works)

Verified RED before the fix (2 of the new tests failed with the old 135/135
outputs), GREEN after. Full suite: `PYTHONPATH=. PYTEST_DISABLE_PLUGIN_AUTOLOAD=1
python3 -m pytest tests/` — **1635 passed, 1 skipped, 1 xfailed** (unchanged
skip/xfail counts, no regressions).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Arabic number recognition now supports colloquial forms for “hundred,” including `مية` and `ميه`.
  * Improved handling of colloquial hundreds in phrases, sentences, and combinations with tens and units.

* **Bug Fixes**
  * Corrected parsing for standalone and combined colloquial Arabic hundred expressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->