### PR TITLE
fix: numbers_to_digits must not corrupt standalone digit runs (leading zeros lost)

### DIFF
--- a/ovos_number_parser/__init__.py
+++ b/ovos_number_parser/__init__.py
@@ -279,22 +279,20 @@ def _is_ordinal_generic(input_str: str, lang: str):
     return _ORDINAL_REVERSE_CACHE[lang2].get(input_str.lower().strip(), False)
 
 
-# digit characters that already denote a plain numeral, keyed by script.
-# Eastern-Arabic-Indic and Persian/Urdu are normalized to Western digits to
-# match existing pinned numbers_to_digits behaviour; the characters
-# themselves (including leading zeros) are never dropped.
 _WESTERN_DIGITS = "0123456789"
-_DIGIT_TRANSLATE = str.maketrans("٠١٢٣٤٥٦٧٨٩" + "۰۱۲۳۴۵۶۷۸۹", _WESTERN_DIGITS * 2)
-_RAW_DIGIT_CHARS = set(_WESTERN_DIGITS + "٠١٢٣٤٥٦٧٨٩" + "۰۱۲۳۴۵۶۷۸۹")
+_EASTERN_ARABIC_DIGITS = "٠١٢٣٤٥٦٧٨٩"
+_PERSIAN_DIGITS = "۰۱۲۳۴۵۶۷۸۹"
+# numbers_to_digits emits Western digits, so the two non-Western scripts are
+# translated character-for-character — never through int(), which would
+# destroy leading zeros.
+_TO_WESTERN_DIGITS = str.maketrans(_EASTERN_ARABIC_DIGITS + _PERSIAN_DIGITS,
+                                   _WESTERN_DIGITS * 2)
+_DIGIT_CHARS = frozenset(_WESTERN_DIGITS + _EASTERN_ARABIC_DIGITS + _PERSIAN_DIGITS)
 
 
-def _raw_digit_span(token: str) -> Optional[str]:
-    """If `token` is entirely digit characters (any supported script),
-    return it translated to Western digits with every character preserved
-    (leading zeros included). Otherwise return None."""
-    if not token or any(c not in _RAW_DIGIT_CHARS for c in token):
-        return None
-    return token.translate(_DIGIT_TRANSLATE)
+def _is_digit_run(token: str) -> bool:
+    """True if the token is one or more digit characters and nothing else."""
+    return bool(token) and all(c in _DIGIT_CHARS for c in token)
 
 
 def _numbers_to_digits_generic(utterance: str, lang: str) -> str:
@@ -381,25 +379,23 @@ def _numbers_to_digits_generic(utterance: str, lang: str) -> str:
                 j += 2
             else:
                 break
-        span = " ".join(_clean(t) for t in tokens[i:j + 1])
         stripped = tokens[j].rstrip(punct)
         trail = tokens[j][len(stripped):]
-        if j == i:
-            # a lone token that is already a digit run ("007", "٠٥٥٣١٧٥٨١٧")
-            # must not be round-tripped through extract_number/int: that
-            # destroys leading zeros in phone numbers, OTP codes and any
-            # zero-padded identifier. Script normalization (Eastern-Arabic
-            # -> Western) is preserved to match existing pinned behaviour,
-            # but every digit character survives.
-            raw = _raw_digit_span(_clean(tokens[i]))
-            if raw is not None:
-                out.append(f"{raw}{trail}")
-                i = j + 1
-                continue
-        val = extract_number(span, lang)
-        if isinstance(val, float) and val.is_integer():
-            val = int(val)
-        out.append(f"{val}{trail}")
+        single_token = i == j
+        if single_token and _is_digit_run(_clean(tokens[i])):
+            # Already digits ("007", "٠٥٥٣١٧٥٨١٧"): keep every character.
+            # Re-reading through extract_number would go via int() and strip
+            # leading zeros — corrupting phone numbers, OTP codes and other
+            # zero-padded identifiers. Digit runs are only re-read when they
+            # combine with neighbouring number words ("355 ألف" → 355000),
+            # which is the multi-token branch below.
+            out.append(_clean(tokens[i]).translate(_TO_WESTERN_DIGITS) + trail)
+        else:
+            span = " ".join(_clean(t) for t in tokens[i:j + 1])
+            val = extract_number(span, lang)
+            if isinstance(val, float) and val.is_integer():
+                val = int(val)
+            out.append(f"{val}{trail}")
         i = j + 1
     return " ".join(out)
 

--- a/ovos_number_parser/__init__.py
+++ b/ovos_number_parser/__init__.py
@@ -279,6 +279,24 @@ def _is_ordinal_generic(input_str: str, lang: str):
     return _ORDINAL_REVERSE_CACHE[lang2].get(input_str.lower().strip(), False)
 
 
+# digit characters that already denote a plain numeral, keyed by script.
+# Eastern-Arabic-Indic and Persian/Urdu are normalized to Western digits to
+# match existing pinned numbers_to_digits behaviour; the characters
+# themselves (including leading zeros) are never dropped.
+_WESTERN_DIGITS = "0123456789"
+_DIGIT_TRANSLATE = str.maketrans("٠١٢٣٤٥٦٧٨٩" + "۰۱۲۳۴۵۶۷۸۹", _WESTERN_DIGITS * 2)
+_RAW_DIGIT_CHARS = set(_WESTERN_DIGITS + "٠١٢٣٤٥٦٧٨٩" + "۰۱۲۳۴۵۶۷۸۹")
+
+
+def _raw_digit_span(token: str) -> Optional[str]:
+    """If `token` is entirely digit characters (any supported script),
+    return it translated to Western digits with every character preserved
+    (leading zeros included). Otherwise return None."""
+    if not token or any(c not in _RAW_DIGIT_CHARS for c in token):
+        return None
+    return token.translate(_DIGIT_TRANSLATE)
+
+
 def _numbers_to_digits_generic(utterance: str, lang: str) -> str:
     """Fallback that replaces spoken number spans with digits using
     extract_number over maximal runs of number words."""
@@ -364,9 +382,21 @@ def _numbers_to_digits_generic(utterance: str, lang: str) -> str:
             else:
                 break
         span = " ".join(_clean(t) for t in tokens[i:j + 1])
-        val = extract_number(span, lang)
         stripped = tokens[j].rstrip(punct)
         trail = tokens[j][len(stripped):]
+        if j == i:
+            # a lone token that is already a digit run ("007", "٠٥٥٣١٧٥٨١٧")
+            # must not be round-tripped through extract_number/int: that
+            # destroys leading zeros in phone numbers, OTP codes and any
+            # zero-padded identifier. Script normalization (Eastern-Arabic
+            # -> Western) is preserved to match existing pinned behaviour,
+            # but every digit character survives.
+            raw = _raw_digit_span(_clean(tokens[i]))
+            if raw is not None:
+                out.append(f"{raw}{trail}")
+                i = j + 1
+                continue
+        val = extract_number(span, lang)
         if isinstance(val, float) and val.is_integer():
             val = int(val)
         out.append(f"{val}{trail}")

--- a/ovos_number_parser/numbers_en.py
+++ b/ovos_number_parser/numbers_en.py
@@ -695,7 +695,15 @@ def numbers_to_digits_en(text, short_scale=True, ordinals=False):
         else:
             if numbers_to_replace and \
                     token.index == numbers_to_replace[0].start_index:
-                results.append(str(numbers_to_replace[0].value))
+                nr = numbers_to_replace[0]
+                if nr.start_index == nr.end_index and token.word.isdigit():
+                    # a lone token that is already a digit run ("007") must
+                    # not be round-tripped through int(): that destroys
+                    # leading zeros in phone numbers, OTP codes, and any
+                    # zero-padded identifier.
+                    results.append(token.word)
+                else:
+                    results.append(str(nr.value))
             if numbers_to_replace and \
                     token.index == numbers_to_replace[0].end_index:
                 numbers_to_replace.pop(0)

--- a/tests/test_number_parser_ar.py
+++ b/tests/test_number_parser_ar.py
@@ -201,6 +201,31 @@ class TestArabicNumbersToDigitsRobust(unittest.TestCase):
         self.assertEqual(
             numbers_to_digits("خمسة وعشرون كتاباً", lang="ar"), "25 كتاباً")
 
+    def test_standalone_digit_run_preserves_leading_zeros(self):
+        # live bug found in the Salesteq voice pipeline: numbers_to_digits
+        # re-parses a digit run that is ALREADY digits, round-trips it
+        # through an int, and destroys leading zeros. A phone number, OTP
+        # code, or any zero-padded identifier must survive byte-for-byte.
+        self.assertEqual(
+            numbers_to_digits("رقمي 0553175817", lang="ar"),
+            "رقمي 0553175817")
+        self.assertEqual(
+            numbers_to_digits("الرمز 007", lang="ar"), "الرمز 007")
+        self.assertEqual(
+            numbers_to_digits("الرمز 4729 والاحتياطي 007", lang="ar"),
+            "الرمز 4729 والاحتياطي 007")
+        # Eastern Arabic-Indic digits: script is converted to Western per
+        # existing pinned behaviour, but leading zeros must still survive
+        self.assertEqual(
+            numbers_to_digits("رقمي ٠٥٥٣١٧٥٨١٧", lang="ar"),
+            "رقمي 0553175817")
+
+    def test_mixed_digit_and_word_still_multiplies(self):
+        # this is why digits are re-read through extract_number at all:
+        # a digit run adjacent to a scale word must still multiply
+        self.assertEqual(
+            numbers_to_digits("355 ألف ريال", lang="ar"), "355000 ريال")
+
     def test_extract_dual_nouns(self):
         # the dual of common counting nouns carries the value 2 lexically
         for spoken in ["يومين", "يومان", "ساعتين", "ساعتان", "دقيقتين",

--- a/tests/test_number_parser_ar.py
+++ b/tests/test_number_parser_ar.py
@@ -202,7 +202,7 @@ class TestArabicNumbersToDigitsRobust(unittest.TestCase):
             numbers_to_digits("خمسة وعشرون كتاباً", lang="ar"), "25 كتاباً")
 
     def test_standalone_digit_run_preserves_leading_zeros(self):
-        # live bug found in the Salesteq voice pipeline: numbers_to_digits
+        # live bug found in a production Arabic voice pipeline: numbers_to_digits
         # re-parses a digit run that is ALREADY digits, round-trips it
         # through an int, and destroys leading zeros. A phone number, OTP
         # code, or any zero-padded identifier must survive byte-for-byte.
@@ -358,7 +358,7 @@ class TestArabicColloquialExtract(unittest.TestCase):
         # "خمس مية وثلاثين" = 5 * 100 + 30 = 530 (spaced unit + مية/ميه must
         # multiply exactly like the already-supported spaced unit + مئة/مائة,
         # e.g. "ثلاث مئة" = 300 handled by _parse_number_span). Reproduced
-        # live from sherpa STT output in the Salesteq voice pipeline, where
+        # live from production Arabic STT output, where
         # the spaced (non-fused) colloquial form is what the ASR emits.
         self.assertEqual(extract_number_ar("خمس مية وثلاثين"), 530)
         # with the definite article fronting the unit word

--- a/tests/test_number_parser_en.py
+++ b/tests/test_number_parser_en.py
@@ -21,6 +21,14 @@ class TestNumberParserEN(unittest.TestCase):
         self.assertEqual(numbers_to_digits_en('march fifth', ordinals=True),
                          'march 5')
 
+    def test_numbers_to_digits_en_preserves_leading_zeros(self):
+        # live bug: a standalone digit run that is already digits must pass
+        # through byte-for-byte, not get re-parsed and lose leading zeros
+        self.assertEqual(numbers_to_digits_en('code 007'), 'code 007')
+        self.assertEqual(
+            numbers_to_digits_en('otp 4729 backup 007'),
+            'otp 4729 backup 007')
+
     @unittest.expectedFailure
     def test_failures_numbers_to_digits_en(self):
         # TODO: fix me


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

## Live evidence

Found live in an Arabic voice pipeline doing phone-number capture. On `origin/dev`:

```python
>>> numbers_to_digits("رقمي 0553175817", lang="ar")
'رقمي 553175817'          # leading zero silently destroyed
>>> numbers_to_digits("الرمز 007", lang="ar")
'الرمز 7'
>>> numbers_to_digits("code 007", lang="en")   # same shared code path affects en
'code 7'
```

Downstream STT post-processors currently have to carry a workaround (re-protecting digit runs before calling in); that can be dropped once this releases.

## Root cause

`numbers_to_digits` treats a standalone digit token as just another number span: it feeds it through `extract_number` and re-stringifies the resulting `int`/`float`, which drops leading zeros. This affects the shared `_numbers_to_digits_generic` fallback (used by `ar` and other languages without a dedicated converter) and the English converter (`numbers_to_digits_en`), which has its own equivalent round-trip.

Digit runs still need to go through `extract_number` when they're adjacent to number words, because that's how mixed expressions multiply correctly (e.g. `"355 ألف ريال"` -> `"355000 ريال"` -- 355 x 1000). The bug is specifically the *standalone* digit-run case.

## Fix

- `ovos_number_parser/__init__.py` (`_numbers_to_digits_generic`): when a number span is a single token and that token is already a digit run (Western, Eastern-Arabic-Indic, or Persian/Urdu digits), emit it verbatim -- translated to Western digits to match already-pinned test behaviour, but with every digit character (including leading zeros) preserved -- instead of round-tripping it through `extract_number`/`int`. Multi-token spans (digits + number words) are untouched and still go through `extract_number`.
- `ovos_number_parser/numbers_en.py` (`numbers_to_digits_en`): when a substituted number span is a single already-all-digit token, emit the original token text instead of `str(value)`.

## What's verified

- New tests added in `tests/test_number_parser_ar.py` and `tests/test_number_parser_en.py`, real sentences: phone number (`"رقمي 0553175817"`), OTP-style (`"الرمز 4729 والاحتياطي 007"`), Eastern-Arabic-Indic digit run, English (`"code 007"`).
- Confirmed RED against unfixed `origin/dev` (leading zeros stripped), then GREEN after the fix.
- Confirmed the mixed digit+word multiplication path (`"355 ألف ريال"` -> `"355000 ريال"`) still passes -- added as a regression test.
- Full suite: **1638 passed, 1 skipped, 1 xfailed** (skip/xfail pre-existing, unrelated to this change).
- Existing pinned Eastern-Arabic/Persian digit-conversion tests (e.g. `"الرقم ٢٠٢٤"` -> `"الرقم 2024"`) still pass -- script normalization behaviour preserved, only the data-loss removed.

## Scope

`ar` (generic fallback path) and `en` (dedicated converter) are the two languages verified affected and fixed. Other languages route through dedicated converters (`pt`, `ro`, `de`, `ru`, `tr`, etc.) or the same shared generic fallback as `ar` and inherit the fix automatically; not individually probed here beyond confirming the full suite stays green.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved leading zeros when converting standalone numeric strings and codes.
  - Added support for detecting and translating Western, Eastern Arabic, and Persian digits into Western numerals.
  - Improved handling of mixed numeric and written-number expressions without changing existing scale-based conversions.

- **Tests**
  - Added coverage for leading-zero preservation across English, Arabic, and Persian digit formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->