### PR TITLE
fix(ar): digit runs with an attached clitic (و355) join mixed number spans

### DIFF
--- a/ovos_number_parser/__init__.py
+++ b/ovos_number_parser/__init__.py
@@ -429,7 +429,36 @@ def numbers_to_digits(utterance: str, lang: str, scale: Optional[Scale] = None) 
         return numbers_to_digits_tr(utterance)
     if lang.startswith("uk"):
         return numbers_to_digits_uk(utterance)
+    if _is_ar(lang):
+        return _numbers_to_digits_ar(utterance, lang)
     return _numbers_to_digits_generic(utterance, lang)
+
+
+# a clitic (و "and", ف "so/then", ب "with/by", ل "to/for") glued directly onto
+# a digit run at the start of a word ("و355") stops the generic tokenizer's
+# per-whitespace-token number check from recognising the digits, so the run
+# never joins a following scale word into a mixed number span ("و355 ألف"
+# reads as the literal text "و355" plus the bare number 1000, instead of
+# 355000). Matches only at a token boundary so it never touches a clitic
+# occurring mid-word.
+_AR_LEADING_CLITIC_DIGIT_RE = re.compile(r'(?<!\S)([وفبل])([0-9٠-٩۰-۹])')
+
+
+def _numbers_to_digits_ar(utterance: str, lang: str) -> str:
+    """Arabic wrapper around the generic converter that lets a clitic
+    glued directly onto a digit run ("و355") join a mixed digit+word number
+    span ("و355 ألف" -> "و355000") instead of being left untouched while the
+    following scale word is misread as its own separate number.
+
+    A space is inserted between the clitic and the digits so the generic
+    tokenizer sees the digit run as an ordinary number token, the normal
+    conversion runs, and the space is removed again afterwards so the
+    clitic re-attaches to the produced digits exactly as it was written.
+    A bare digit run (no leading clitic) is unaffected.
+    """
+    spaced = _AR_LEADING_CLITIC_DIGIT_RE.sub(r'\1 \2', utterance)
+    converted = _numbers_to_digits_generic(spaced, lang)
+    return re.sub(r'(?<!\S)([وفبل]) (?=[0-9])', r'\1', converted)
 
 
 # Connectives for the a+bi complex form, per language, English as the default.

--- a/ovos_number_parser/__init__.py
+++ b/ovos_number_parser/__init__.py
@@ -9,6 +9,7 @@ from unicode_rbnf import RbnfEngine, FormatPurpose
 from ovos_number_parser.numbers_ast import AST
 from ovos_number_parser.numbers_an import AN
 from ovos_number_parser.numbers_ar import pronounce_number_ar, pronounce_ordinal_ar, extract_number_ar, \
+    split_clitic_from_digits_ar, reattach_clitic_to_digits_ar, \
     is_fractional_ar, is_ordinal_ar, nice_number_ar, resolve_ar_lang
 from ovos_number_parser.numbers_az import numbers_to_digits_az, extract_number_az, is_fractional_az, pronounce_number_az
 from ovos_number_parser.numbers_bg import numbers_to_digits_bg, pronounce_number_bg, extract_number_bg, \
@@ -430,35 +431,13 @@ def numbers_to_digits(utterance: str, lang: str, scale: Optional[Scale] = None) 
     if lang.startswith("uk"):
         return numbers_to_digits_uk(utterance)
     if _is_ar(lang):
-        return _numbers_to_digits_ar(utterance, lang)
+        # Arabic clitics can be glued onto digit runs ("و355 ألف"); split
+        # them off so the digits parse, convert, then re-attach. The Arabic
+        # knowledge lives in numbers_ar; this is just the composition.
+        spaced = split_clitic_from_digits_ar(utterance)
+        return reattach_clitic_to_digits_ar(
+            _numbers_to_digits_generic(spaced, lang))
     return _numbers_to_digits_generic(utterance, lang)
-
-
-# a clitic (و "and", ف "so/then", ب "with/by", ل "to/for") glued directly onto
-# a digit run at the start of a word ("و355") stops the generic tokenizer's
-# per-whitespace-token number check from recognising the digits, so the run
-# never joins a following scale word into a mixed number span ("و355 ألف"
-# reads as the literal text "و355" plus the bare number 1000, instead of
-# 355000). Matches only at a token boundary so it never touches a clitic
-# occurring mid-word.
-_AR_LEADING_CLITIC_DIGIT_RE = re.compile(r'(?<!\S)([وفبل])([0-9٠-٩۰-۹])')
-
-
-def _numbers_to_digits_ar(utterance: str, lang: str) -> str:
-    """Arabic wrapper around the generic converter that lets a clitic
-    glued directly onto a digit run ("و355") join a mixed digit+word number
-    span ("و355 ألف" -> "و355000") instead of being left untouched while the
-    following scale word is misread as its own separate number.
-
-    A space is inserted between the clitic and the digits so the generic
-    tokenizer sees the digit run as an ordinary number token, the normal
-    conversion runs, and the space is removed again afterwards so the
-    clitic re-attaches to the produced digits exactly as it was written.
-    A bare digit run (no leading clitic) is unaffected.
-    """
-    spaced = _AR_LEADING_CLITIC_DIGIT_RE.sub(r'\1 \2', utterance)
-    converted = _numbers_to_digits_generic(spaced, lang)
-    return re.sub(r'(?<!\S)([وفبل]) (?=[0-9])', r'\1', converted)
 
 
 # Connectives for the a+bi complex form, per language, English as the default.

--- a/ovos_number_parser/__init__.py
+++ b/ovos_number_parser/__init__.py
@@ -9,7 +9,7 @@ from unicode_rbnf import RbnfEngine, FormatPurpose
 from ovos_number_parser.numbers_ast import AST
 from ovos_number_parser.numbers_an import AN
 from ovos_number_parser.numbers_ar import pronounce_number_ar, pronounce_ordinal_ar, extract_number_ar, \
-    split_clitic_from_digits_ar, reattach_clitic_to_digits_ar, \
+    numbers_to_digits_ar, \
     is_fractional_ar, is_ordinal_ar, nice_number_ar, resolve_ar_lang
 from ovos_number_parser.numbers_az import numbers_to_digits_az, extract_number_az, is_fractional_az, pronounce_number_az
 from ovos_number_parser.numbers_bg import numbers_to_digits_bg, pronounce_number_bg, extract_number_bg, \
@@ -431,12 +431,7 @@ def numbers_to_digits(utterance: str, lang: str, scale: Optional[Scale] = None) 
     if lang.startswith("uk"):
         return numbers_to_digits_uk(utterance)
     if _is_ar(lang):
-        # Arabic clitics can be glued onto digit runs ("و355 ألف"); split
-        # them off so the digits parse, convert, then re-attach. The Arabic
-        # knowledge lives in numbers_ar; this is just the composition.
-        spaced = split_clitic_from_digits_ar(utterance)
-        return reattach_clitic_to_digits_ar(
-            _numbers_to_digits_generic(spaced, lang))
+        return numbers_to_digits_ar(utterance, lang)
     return _numbers_to_digits_generic(utterance, lang)
 
 

--- a/ovos_number_parser/numbers_ar.py
+++ b/ovos_number_parser/numbers_ar.py
@@ -815,22 +815,24 @@ def is_ordinal_ar(input_str):
 # glued directly onto a digit run ("و355"). Tokenizers that check whole
 # whitespace tokens then fail to recognise the digits as a number, so the run
 # never joins a following scale word into a mixed span ("و355 ألف" should be
-# 355000 with the clitic re-attached: "و355000"). These two helpers let a
-# language-agnostic converter handle that: split before converting, re-attach
-# after. Both match only at a token boundary, so a clitic letter occurring
-# mid-word is never touched.
+# 355000 with the clitic re-attached: "و355000"). Both patterns match only at
+# a token boundary, so a clitic letter occurring mid-word is never touched.
 _CLITIC_BEFORE_DIGITS_RE = re.compile(r'(?<!\S)([وفبل])([0-9٠-٩۰-۹])')
 _CLITIC_SPACE_DIGITS_RE = re.compile(r'(?<!\S)([وفبل]) (?=[0-9٠-٩۰-۹])')
 
 
-def split_clitic_from_digits_ar(utterance: str) -> str:
-    """Insert a space between a leading clitic and a glued digit run
-    ("و355 ألف" -> "و 355 ألف") so the digits read as an ordinary number
-    token. Reverse with ``reattach_clitic_to_digits_ar``."""
-    return _CLITIC_BEFORE_DIGITS_RE.sub(r'\1 \2', utterance)
+def numbers_to_digits_ar(utterance: str, lang: str = "ar") -> str:
+    """Replace spoken Arabic number spans with digits.
 
-
-def reattach_clitic_to_digits_ar(utterance: str) -> str:
-    """Undo ``split_clitic_from_digits_ar`` after number conversion: glue the
-    clitic back onto the digits exactly as the caller wrote it."""
-    return _CLITIC_SPACE_DIGITS_RE.sub(r'\1', utterance)
+    Splits a clitic glued onto a digit run ("و355 ألف" -> "و 355 ألف") so
+    the digits read as an ordinary number token, converts through the shared
+    span converter, then glues the clitic back onto the produced digits
+    ("و355000"). Text without glued clitics passes through the converter
+    unchanged.
+    """
+    # deferred: the shared converter lives in the package root, which imports
+    # this module — importing it at module level would be circular
+    from ovos_number_parser import _numbers_to_digits_generic
+    spaced = _CLITIC_BEFORE_DIGITS_RE.sub(r'\1 \2', utterance)
+    converted = _numbers_to_digits_generic(spaced, lang)
+    return _CLITIC_SPACE_DIGITS_RE.sub(r'\1', converted)

--- a/ovos_number_parser/numbers_ar.py
+++ b/ovos_number_parser/numbers_ar.py
@@ -18,6 +18,7 @@ lect's default register -- see its docstring for the code table and
 citations.
 """
 
+import re
 from math import isfinite
 from ovos_number_parser.util import convert_to_mixed_fraction
 
@@ -808,3 +809,28 @@ def is_ordinal_ar(input_str):
     if value is not None and j == len(tokens):
         return value
     return False
+
+
+# A clitic (و "and", ف "so/then", ب "with/by", ل "to/for") can be written
+# glued directly onto a digit run ("و355"). Tokenizers that check whole
+# whitespace tokens then fail to recognise the digits as a number, so the run
+# never joins a following scale word into a mixed span ("و355 ألف" should be
+# 355000 with the clitic re-attached: "و355000"). These two helpers let a
+# language-agnostic converter handle that: split before converting, re-attach
+# after. Both match only at a token boundary, so a clitic letter occurring
+# mid-word is never touched.
+_CLITIC_BEFORE_DIGITS_RE = re.compile(r'(?<!\S)([وفبل])([0-9٠-٩۰-۹])')
+_CLITIC_SPACE_DIGITS_RE = re.compile(r'(?<!\S)([وفبل]) (?=[0-9٠-٩۰-۹])')
+
+
+def split_clitic_from_digits_ar(utterance: str) -> str:
+    """Insert a space between a leading clitic and a glued digit run
+    ("و355 ألف" -> "و 355 ألف") so the digits read as an ordinary number
+    token. Reverse with ``reattach_clitic_to_digits_ar``."""
+    return _CLITIC_BEFORE_DIGITS_RE.sub(r'\1 \2', utterance)
+
+
+def reattach_clitic_to_digits_ar(utterance: str) -> str:
+    """Undo ``split_clitic_from_digits_ar`` after number conversion: glue the
+    clitic back onto the digits exactly as the caller wrote it."""
+    return _CLITIC_SPACE_DIGITS_RE.sub(r'\1', utterance)

--- a/tests/test_number_parser_ar.py
+++ b/tests/test_number_parser_ar.py
@@ -382,6 +382,30 @@ class TestArabicColloquialExtract(unittest.TestCase):
         self.assertEqual(extract_number_ar("2 مليون"), 2000000)
         self.assertEqual(extract_number_ar("3 مليار"), 3000000000)
 
+    def test_clitic_attached_digit_joins_mixed_number_span(self):
+        # a clitic (و/ف/ب/ل) glued directly onto a digit run must not stop
+        # that digit run from starting a mixed digit+word number span: the
+        # digits still multiply with the following scale word, and the
+        # clitic re-attaches to the produced digits exactly as written.
+        # Found while verifying PR #296 ("355 ألف" = 355000, bare form
+        # below) -- pre-existing, not a #296 regression.
+        self.assertEqual(
+            numbers_to_digits("و355 ألف ريال", lang="ar"),
+            "و355000 ريال")
+        self.assertEqual(
+            numbers_to_digits("ف355 ألف ريال", lang="ar"),
+            "ف355000 ريال")
+        self.assertEqual(
+            numbers_to_digits("ب355 ألف ريال", lang="ar"),
+            "ب355000 ريال")
+        self.assertEqual(
+            numbers_to_digits("ل355 ألف ريال", lang="ar"),
+            "ل355000 ريال")
+        # bare form regression: unaffected, no clitic present
+        self.assertEqual(
+            numbers_to_digits("355 ألف ريال", lang="ar"),
+            "355000 ريال")
+
     def test_colloquial_forms_do_not_over_match(self):
         # words that merely resemble number words must not be extracted
         self.assertIn(extract_number_ar("اخي"), (False, None))


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

## Bug

Found while verifying PR #296 — pre-existing, not a regression from it.

```python
numbers_to_digits('و355 ألف', lang='ar')
# 'و355 1000'   (wrong)
# expected: 'و355000'
```

`numbers_to_digits('355 ألف', lang='ar')` (no clitic) already worked correctly ('355000'), per PR #296.

## Root cause

`_numbers_to_digits_generic` (the fallback converter Arabic uses) checks each whitespace-delimited token for a number with `extract_number`. A clitic (و "and", ف "so/then", ب "with/by", ل "to/for") glued directly onto a digit run ("و355") makes that whole token unrecognisable as a number, so the digit run never starts a mixed digit+word span and the following scale word (e.g. "ألف") gets read as a separate, un-multiplied number instead.

## Fix

Added `_numbers_to_digits_ar` in `ovos_number_parser/__init__.py`: before delegating to the generic converter, insert a space between a leading clitic (و/ف/ب/ل) and an immediately-following digit run (at a token boundary only), run the normal conversion, then remove the inserted space so the clitic re-attaches to the produced digits exactly as written. Wired into `numbers_to_digits()`'s Arabic dispatch via the existing `_is_ar()` check.

Bare digit runs (no clitic) are untouched, so the #296 behaviour is unaffected.

## Tests

New test `test_clitic_attached_digit_joins_mixed_number_span` in `tests/test_number_parser_ar.py`, red before the fix / green after:
- `'و355 ألف ريال'` → `'و355000 ريال'`
- `'ف355 ألف ريال'` → `'ف355000 ريال'`
- `'ب355 ألف ريال'` → `'ب355000 ريال'`
- `'ل355 ألف ريال'` → `'ل355000 ريال'`
- bare-form regression: `'355 ألف ريال'` → `'355000 ريال'`

Full suite: 1636 passed, 1 skipped, 1 xfailed, 31223 subtests passed.

Note: I looked for the leading-zero clitic guarantee mentioned alongside this bug (e.g. `'ورقمي 0553175817'` keeping its zeros) and found that dev does **not** currently preserve leading zeros there (`numbers_to_digits('ورقمي 0553175817', lang='ar')` → `'ورقمي 553175817'`, zero dropped) — that's a separate, pre-existing defect unrelated to the clitic-joining bug this PR fixes, so I did not add a test asserting a guarantee dev doesn't hold.

## Verification

- Verified against `origin/dev` (this branch is based on it, includes PR #296 already merged).
- Reproduced the bug before writing the test (RED), confirmed the fix turns it GREEN, ran full suite.
- Not merged — draft PR, human review requested.